### PR TITLE
specs: add 19-dx Developer Experience spec

### DIFF
--- a/.claude/rules/spec-guidelines.md
+++ b/.claude/rules/spec-guidelines.md
@@ -1,0 +1,9 @@
+# Spec Guidelines
+
+## Ideal State Only
+
+Specs describe the final, intended design — not the current implementation state.
+
+- No "Current State" / "Target Architecture" sections. Write as if the design is complete.
+- No `*(planned)*` annotations on features that haven't shipped yet.
+- Features not yet designed belong in a `## Future Considerations` section, not the spec body.

--- a/specs/00-overview.md
+++ b/specs/00-overview.md
@@ -33,7 +33,7 @@ The target package structure separates the memory contract into its own package.
 @noetic/memory  ←  @noetic/core  ←  @noetic/eval
 ```
 
-- **`@noetic/memory`** *(planned)* — The memory API contract and built-in implementations. Will contain: the `MemoryLayer` interface, all hook param/result types, `MemoryScope` (including narrowed scope), `StorageAdapter`, `ScopedStorage`, budget types, and all built-in layer factories. Custom layer authors will depend only on this package — not `@noetic/core`.
+- **`@noetic/memory`** *(planned)* — The memory API contract and built-in implementations. Will contain: the `MemoryLayer` interface, all hook param/result types, `MemoryScope`, `StorageAdapter`, `ScopedStorage`, budget types, and all built-in layer factories. Custom layer authors will depend only on this package — not `@noetic/core`.
 
 - **`@noetic/core`** *(target state)* — Step primitives and execution infrastructure only. Will depend on `@noetic/memory` for the layer contract. Will not contain layer implementations.
 

--- a/specs/00-overview.md
+++ b/specs/00-overview.md
@@ -18,17 +18,26 @@ The insight: six patterns (ReAct, Ralph Wiggum, Task Trees, A2A, Recursive LLMs,
 
 ## Packages
 
-The framework is split across three published packages with a strict dependency direction:
+### Current State
+
+The framework currently ships two packages:
+
+- **`@noetic/core`** — Everything: step primitives, execution infrastructure, memory layer contract, built-in layer implementations, error taxonomy, observability, and runtime. This is the package users install today.
+- **`@noetic/eval`** — Eval framework, CLI, scorers, and optimization loop. Depends on `@noetic/core`.
+
+### Target Architecture
+
+The target package structure separates the memory contract into its own package. This split is not yet implemented — it is the goal. See Gap Audit in `19-dx`.
 
 ```
 @noetic/memory  ←  @noetic/core  ←  @noetic/eval
 ```
 
-- **`@noetic/memory`** — The memory API contract and built-in implementations. Contains: the `MemoryLayer` interface, all hook param/result types, `MemoryScope` (including narrowed scope), `StorageAdapter`, `ScopedStorage`, budget types, and all built-in layer factories (`workingMemory`, `semanticRecall`, `observationalMemory`, `episodicMemory`, `durableTaskState`, `steering`). Custom layer authors depend only on this package — they do not need `@noetic/core`.
+- **`@noetic/memory`** *(planned)* — The memory API contract and built-in implementations. Will contain: the `MemoryLayer` interface, all hook param/result types, `MemoryScope` (including narrowed scope), `StorageAdapter`, `ScopedStorage`, budget types, and all built-in layer factories. Custom layer authors will depend only on this package — not `@noetic/core`.
 
-- **`@noetic/core`** — Step primitives and execution infrastructure. Depends on `@noetic/memory` for the layer contract. Contains: `Step<I,O>` and all variants, the `execute()` interpreter, `Runtime`, `Context`, `ItemLog`, error taxonomy, observability, the Projector (View assembly), and layer lifecycle orchestration. Does not contain layer implementations.
+- **`@noetic/core`** *(target state)* — Step primitives and execution infrastructure only. Will depend on `@noetic/memory` for the layer contract. Will not contain layer implementations.
 
-- **`@noetic/eval`** — Eval framework, CLI, scorers, and optimization loop. Depends on `@noetic/core`.
+- **`@noetic/eval`** — Unchanged.
 
 ## Architecture
 

--- a/specs/00-overview.md
+++ b/specs/00-overview.md
@@ -18,30 +18,19 @@ The insight: six patterns (ReAct, Ralph Wiggum, Task Trees, A2A, Recursive LLMs,
 
 ## Packages
 
-### Current State
-
-The framework currently ships two packages:
-
-- **`@noetic/core`** — Everything: step primitives, execution infrastructure, memory layer contract, built-in layer implementations, error taxonomy, observability, and runtime. This is the package users install today.
-- **`@noetic/eval`** — Eval framework, CLI, scorers, and optimization loop. Depends on `@noetic/core`.
-
-### Target Architecture
-
-The target package structure separates the memory contract into its own package. This split is not yet implemented — it is the goal. See Gap Audit in `19-dx`.
-
 ```
 @noetic/memory  ←  @noetic/core  ←  @noetic/eval
 ```
 
-- **`@noetic/memory`** *(planned)* — The memory API contract and built-in implementations. Will contain: the `MemoryLayer` interface, all hook param/result types, `MemoryScope`, `StorageAdapter`, `ScopedStorage`, budget types, and all built-in layer factories. Custom layer authors will depend only on this package — not `@noetic/core`.
+- **`@noetic/memory`** — The memory API contract and built-in implementations. Contains: the `MemoryLayer` interface, all hook param/result types, `MemoryScope`, `StorageAdapter`, `ScopedStorage`, budget types, and all built-in layer factories. Custom layer authors depend only on this package — not `@noetic/core`.
 
-- **`@noetic/core`** *(target state)* — Step primitives and execution infrastructure only. Will depend on `@noetic/memory` for the layer contract. Will not contain layer implementations.
+- **`@noetic/core`** — Step primitives and execution infrastructure only. Depends on `@noetic/memory` for the layer contract. Does not contain layer implementations.
 
-- **`@noetic/eval`** — Unchanged.
+- **`@noetic/eval`** — Eval framework, CLI, scorers, and optimization loop. Depends on `@noetic/core`.
 
 ## Architecture
 
-`@noetic/core` is structured around two layers (memory contract lives in `@noetic/memory`):
+`@noetic/core` is structured around two layers (the memory contract lives in `@noetic/memory`):
 
 1. **Step primitives** (`01-step-type`, `02-step-variants`, `03-control-flow`, `04-spawn`, `05-loop-and-until`, `06-channels`) — One discriminated union type with seven variants. Everything is a `Step<I, O>`.
 

--- a/specs/00-overview.md
+++ b/specs/00-overview.md
@@ -16,15 +16,31 @@ The insight: six patterns (ReAct, Ralph Wiggum, Task Trees, A2A, Recursive LLMs,
 - **LangGraph's Pregel engine** — supersteps, channels, message passing
 - **Slate's architecture** — episodic memory, orchestrator/worker separation, thread-as-actor model
 
+## Packages
+
+The framework is split across three published packages with a strict dependency direction:
+
+```
+@noetic/memory  ←  @noetic/core  ←  @noetic/eval
+```
+
+- **`@noetic/memory`** — The memory API contract and built-in implementations. Contains: the `MemoryLayer` interface, all hook param/result types, `MemoryScope` (including narrowed scope), `StorageAdapter`, `ScopedStorage`, budget types, and all built-in layer factories (`workingMemory`, `semanticRecall`, `observationalMemory`, `episodicMemory`, `durableTaskState`, `steering`). Custom layer authors depend only on this package — they do not need `@noetic/core`.
+
+- **`@noetic/core`** — Step primitives and execution infrastructure. Depends on `@noetic/memory` for the layer contract. Contains: `Step<I,O>` and all variants, the `execute()` interpreter, `Runtime`, `Context`, `ItemLog`, error taxonomy, observability, the Projector (View assembly), and layer lifecycle orchestration. Does not contain layer implementations.
+
+- **`@noetic/eval`** — Eval framework, CLI, scorers, and optimization loop. Depends on `@noetic/core`.
+
 ## Architecture
 
-`@noetic/core` is structured around three layers:
+`@noetic/core` is structured around two layers (memory contract lives in `@noetic/memory`):
 
 1. **Step primitives** (`01-step-type`, `02-step-variants`, `03-control-flow`, `04-spawn`, `05-loop-and-until`, `06-channels`) — One discriminated union type with seven variants. Everything is a `Step<I, O>`.
 
 2. **Execution infrastructure** (`07-context-and-event-log`, `08-runtime`, `09-error-model`, `10-observability`) — The engine that runs steps: context management, pluggable runtime backends, error taxonomy, and tracing. Items-native (OpenResponses) — the framework uses `Item` types aligned with the OpenResponses format throughout, eliminating impedance mismatch with `callModel`.
 
-3. **Memory system** (`11-memory-layer-system`, `12-builtin-memory-layers`) — Composable plugins that recall context before LLM calls and persist learnings after them. The View (what the LLM actually sees) is assembled from memory layer outputs + conversation history.
+`@noetic/memory` provides:
+
+3. **Memory contract and implementations** (`11-memory-layer-system`, `12-builtin-memory-layers`) — The `MemoryLayer` interface, lifecycle hook types, scope system, storage adapter contract, and built-in layer factories. The View (what the LLM actually sees) is assembled by the Projector in `@noetic/core` from the layer outputs + conversation history, but the layer contract itself is owned by `@noetic/memory`.
 
 **Patterns** (`13-patterns`) are 15-30 line compositions of primitives. They prove the primitives are sufficient; they are not framework magic.
 
@@ -51,6 +67,12 @@ The insight: six patterns (ReAct, Ralph Wiggum, Task Trees, A2A, Recursive LLMs,
 ## Dependency Graph
 
 ```
+── @noetic/memory ──────────────────────────────────────────────
+                11-memory-system
+                       |
+                12-builtin-layers
+
+── @noetic/core ────────────────────────────────────────────────
                     01-step-type
                    /    |    \
           02-variants 03-flow  05-loop
@@ -61,9 +83,10 @@ The insight: six patterns (ReAct, Ralph Wiggum, Task Trees, A2A, Recursive LLMs,
                     \      /                 |
                    08-runtime                |
                        |                     |
-                11-memory-system ────────────+
-                       |
-                12-builtin-layers
+                  [memory contract] ─────────+   (imported from @noetic/memory)
                        |
                   13-patterns (uses all primitives)
+
+── @noetic/eval ────────────────────────────────────────────────
+                17-eval-and-optimization
 ```

--- a/specs/04-spawn.md
+++ b/specs/04-spawn.md
@@ -124,6 +124,18 @@ Parent calls runtime.detachedSpawn(step, input, ctx)
 
 Tools receive a `ToolExecutionContext` as their second argument, which provides `{ ctx, runtime?, memory, assembledView, lastStepMeta, turnContext? }`. Note: `runtime` is `undefined` when the step is executed via bare `execute()` without a Runtime wrapper; tools that need runtime (for spawn, channels) should check for its presence. Tools that spawn sub-agents **must use `toolCtx.ctx`** (the parent context) rather than creating a new root context via `runtime.createContext()`. Creating a root context breaks depth tracking, `threadId`/`resourceId` inheritance, memory layer propagation, and observability tracing. Both `runtime.execute()` and `runtime.detachedSpawn()` create their own child contexts internally, so the tool should simply forward the parent context it receives via `toolCtx.ctx`.
 
+---
+
+## Parent Context Updates to Forked Children
+
+A forked child does not run in complete isolation from its parent. While the child has its own ItemLog and context convergence, the parent's layers may continue to produce state changes during the child's execution. The child can receive these updates and decide how to respond.
+
+This is opt-in per memory layer via the `onParentUpdate` hook (see `11-memory-layer-system`). The runtime fires `onParentUpdate` on the child's layer whenever the corresponding parent layer's state changes (after `store()` on the parent side) and the child is still running. The child layer receives both the current parent state and its own current state, and decides what — if anything — to do with the update.
+
+**The child is never forced to accept parent updates.** Returning `void` means the child ignores the update entirely. This preserves the child's autonomy while enabling reactive parent-child relationships where needed.
+
+---
+
 ### Integration with Loop Inbox
 
 Detached spawns pair naturally with the loop inbox channel (see `05-loop-and-until`). A common pattern:

--- a/specs/04-spawn.md
+++ b/specs/04-spawn.md
@@ -126,9 +126,11 @@ Tools receive a `ToolExecutionContext` as their second argument, which provides 
 
 ---
 
-## Parent Context Updates to Forked Children
+## Parent Context Updates to Spawned Children
 
-A forked child does not run in complete isolation from its parent. While the child has its own ItemLog and context convergence, the parent's layers may continue to produce state changes during the child's execution. The child can receive these updates and decide how to respond.
+`spawn` creates a child context — not `fork`. `fork` branches share the parent context entirely and do not trigger `onParentUpdate`. This section applies only to `spawn` boundaries.
+
+A spawned child does not run in complete isolation from its parent. While the child has its own ItemLog and context convergence, the parent's layers may continue to produce state changes during the child's execution. The child can receive these updates and decide how to respond.
 
 This is opt-in per memory layer via the `onParentUpdate` hook (see `11-memory-layer-system`). The runtime fires `onParentUpdate` on the child's layer whenever the corresponding parent layer's state changes (after `store()` on the parent side) and the child is still running. The child layer receives both the current parent state and its own current state, and decides what — if anything — to do with the update.
 

--- a/specs/07-context-and-event-log.md
+++ b/specs/07-context-and-event-log.md
@@ -157,6 +157,7 @@ interface LLMResponse {
 - **`span`** means every step is automatically traced without user instrumentation (see `10-observability`).
 - **`threadId` / `resourceId`** are used by the runtime to resolve memory layer scope keys. A `scope: 'thread'` memory layer isolates state per `threadId`; a `scope: 'resource'` layer shares state across threads for the same `resourceId` (see `11-memory-layer-system`).
 - **`itemLog`** is the raw record. The View (what the LLM sees) is a projection of it plus memory layer outputs.
+- **The `Context` interface is not the context the LLM sees.** The `Context` object is execution infrastructure — metadata, state, and runtime handles. What the LLM actually receives is the View: the result of all memory layers converging in slot order. Context is never a layer itself; it is the output of layer convergence, assembled fresh before each LLM call. See `11-memory-layer-system`.
 
 ## Circular Reference with Channels
 

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -126,6 +126,66 @@ setRuntime(new InMemoryRuntime());
 
 ---
 
+## Runtime Registration
+
+`setRuntime()` registers the global singleton runtime for the current process. There is exactly one active runtime per process at any time.
+
+```typescript
+function setRuntime(runtime: Runtime): void;
+function getRuntime(): Runtime; // throws NoeticConfigError if none set
+```
+
+### Singleton Semantics
+
+1. Calling `setRuntime()` after `execute()` has already been called is a `NoeticConfigError` with `code: RUNTIME_ALREADY_IN_USE`. Set the runtime before any execution begins.
+2. Calling `setRuntime()` a second time replaces the previous runtime. This is intentional for test isolation (see below) — it is not an error.
+3. Calling `execute()` without a prior `setRuntime()` throws `NoeticConfigError` with `code: NO_RUNTIME_SET` and a hint pointing to the setup docs.
+
+### Module Load Order
+
+`setRuntime()` MUST be called at the top of the application entry point, before any module that calls `execute()` is imported or evaluated. In ESM environments, dynamic imports may evaluate lazily — do not rely on import order to ensure the runtime is set before execution begins.
+
+Recommended pattern:
+
+```ts
+// entry.ts — first file evaluated
+import { setRuntime, InMemoryRuntime } from '@noetic/core';
+setRuntime(new InMemoryRuntime());
+
+// All other imports come after
+import { runAgent } from './agent';
+await runAgent();
+```
+
+### Test Isolation
+
+Each test file MUST call `setRuntime()` in a `beforeEach` block. Without this, runtime state leaks between tests and between test files when they share the same process.
+
+```ts
+import { setRuntime, InMemoryRuntime } from '@noetic/core';
+
+beforeEach(() => {
+  setRuntime(new InMemoryRuntime());
+});
+```
+
+### Serverless / Stateless Environments
+
+In serverless functions (AWS Lambda, Cloudflare Workers, etc.), the runtime is re-instantiated per cold start. Call `setRuntime()` at module scope so it runs once per instance, not once per invocation:
+
+```ts
+// Runs once per cold start
+setRuntime(new InMemoryRuntime({ callModel: createOpenRouterCallModel() }));
+
+export const handler = async (event) => {
+  return execute(agentStep, event, runtime.createContext());
+};
+```
+
+In-memory channel storage and non-durable runtimes do not persist across invocations. Use `DurableRuntime` if cross-invocation state is required.
+
+---
+
 ## `AgentConfig`
 
 The top-level configuration for an agent, integrating steps, tools, memory layers, and projection policy.

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -137,9 +137,8 @@ function getRuntime(): Runtime; // throws NoeticConfigError if none set
 
 ### Singleton Semantics
 
-1. Calling `setRuntime()` after `execute()` has already been called is a `NoeticConfigError` with `code: RUNTIME_ALREADY_IN_USE`. Set the runtime before any execution begins.
-2. Calling `setRuntime()` a second time replaces the previous runtime. This is intentional for test isolation (see below) — it is not an error.
-3. Calling `execute()` without a prior `setRuntime()` throws `NoeticConfigError` with `code: NO_RUNTIME_SET` and a hint pointing to the setup docs.
+1. Calling `setRuntime()` when a runtime is already registered is a `NoeticConfigError` with `code: RUNTIME_ALREADY_REGISTERED`. The runtime cannot be replaced or reconfigured after it is set.
+2. Calling `execute()` without a prior `setRuntime()` throws `NoeticConfigError` with `code: NO_RUNTIME_SET` and a hint pointing to the setup docs.
 
 ### Module Load Order
 
@@ -159,15 +158,17 @@ await runAgent();
 
 ### Test Isolation
 
-Each test file MUST call `setRuntime()` in a `beforeEach` block. Without this, runtime state leaks between tests and between test files when they share the same process.
+Bun runs each test file in a fresh module environment. Call `setRuntime()` at module scope (top of the test file) — it will execute once per file and will not conflict across files.
 
 ```ts
 import { setRuntime, InMemoryRuntime } from '@noetic/core';
 
-beforeEach(() => {
-  setRuntime(new InMemoryRuntime());
-});
+setRuntime(new InMemoryRuntime());
+
+// tests follow...
 ```
+
+Do not call `setRuntime()` inside `beforeEach` — the runtime is immutable once registered, and calling it a second time within the same module is an error.
 
 ### Serverless / Stateless Environments
 

--- a/specs/09-error-model.md
+++ b/specs/09-error-model.md
@@ -1,7 +1,7 @@
 # Error Model
 
 > **Depends On:** `01-step-type` (stepId concept)
-> **Exports:** `NoeticError`
+> **Exports:** `NoeticError`, `NoeticConfigError`, `isNoeticError`, `isNoeticConfigError`
 
 ---
 
@@ -76,6 +76,43 @@ Cancellation walks the execution tree depth-first from the cancelled context:
 #### Cancellation is Idempotent
 
 Calling `runtime.cancel()` on an already-cancelled context is a no-op.
+
+---
+
+## `NoeticConfigError`
+
+`NoeticConfigError` is a separate class from `NoeticError`. The two are never interchangeable:
+
+- **`NoeticError`** — thrown during execution (LLM failures, fork failures, spawn errors, budget exceeded, cancellation). Always has a `kind` discriminant. Caught by callers of `execute()`.
+- **`NoeticConfigError`** — thrown during construction and setup (invalid step config, missing env vars, invalid memory layer config, runtime misconfiguration). Always has `code`, `hint`, and optional `docsUrl`. Caught before execution begins.
+
+```typescript
+class NoeticConfigError extends Error {
+  readonly code: string;       // SCREAMING_SNAKE_CASE, e.g. 'MISSING_API_KEY'
+  readonly hint: string;       // complete sentence: what the user should do next
+  readonly docsUrl?: string;   // link to the relevant docs page
+}
+
+function isNoeticConfigError(e: unknown): e is NoeticConfigError;
+```
+
+### Rules
+
+1. `code` MUST be `SCREAMING_SNAKE_CASE` and uniquely identify the error condition across the entire framework.
+2. `hint` MUST be a complete sentence. It MUST NOT say "an error occurred" or restate the message.
+3. `docsUrl` SHOULD be provided for any error a new user is likely to hit during setup.
+4. Error messages MUST NOT expose internal stack details, file paths, or implementation class names.
+5. Every `code` value MUST appear in `docs/errors.mdx` with an explanation and resolution steps.
+6. Construction-time functions (builders, factories, memory layer factories) that can throw `NoeticConfigError` MUST document the applicable `code` values in a `@throws` TSDoc tag.
+
+### Example
+
+```
+NoeticConfigError: Missing required environment variable.
+  code: MISSING_API_KEY
+  hint: Set OPENROUTER_API_KEY in your environment or pass a callModel adapter explicitly.
+  docsUrl: https://noetic.dev/docs/errors#MISSING_API_KEY
+```
 
 ### Budget Exceeded
 

--- a/specs/11-memory-layer-system.md
+++ b/specs/11-memory-layer-system.md
@@ -6,7 +6,9 @@
 
 ## Package Boundary
 
-This spec is owned by `@noetic/memory`. The split is:
+**Current state:** Everything in this spec currently lives in `@noetic/core`. The `@noetic/memory` package does not yet exist.
+
+**Target state:** This spec is owned by `@noetic/memory`. The planned split is:
 
 | Lives in `@noetic/memory` | Lives in `@noetic/core` |
 |---|---|
@@ -16,9 +18,9 @@ This spec is owned by `@noetic/memory`. The split is:
 | `ExecutionContext` (memory-facing read-only view) | `Context` (full execution object) |
 | `ProjectionPolicy` | Projector implementation |
 
-**Dependency direction:** `@noetic/memory` has no runtime dependency on `@noetic/core`. It may import `Item`, `ItemLog`, and `Span` types from `@noetic/core` as type-only imports. `@noetic/core` depends on `@noetic/memory` for the layer contract.
+**Dependency direction:** `@noetic/memory` will have no runtime dependency on `@noetic/core`. It may import `Item`, `ItemLog`, and `Span` types as type-only imports. `@noetic/core` will depend on `@noetic/memory` for the layer contract.
 
-**Custom layer authors** import only from `@noetic/memory`. They never need `@noetic/core` to implement a layer.
+**Custom layer authors** will import only from `@noetic/memory`. They will not need `@noetic/core` to implement a layer.
 
 ---
 
@@ -406,6 +408,20 @@ A layer may declare a **narrowed scope** — interest in a specific subset of a 
 **Why narrowed scope exists.** A step may be a specialist — it cares about one domain (e.g., user preferences, active task list) and should not receive or process the full weight of parent context changes. Narrowing the scope limits unnecessary recomputation and enforces separation of concern between layers.
 
 **Narrowed scope does not grant broader access.** A `narrowed` layer cannot read keys outside its `select` patterns, even if they exist in the `from` scope. Attempts to access unselected keys return `null` from `ScopedStorage`.
+
+### Narrowed Scope Contract
+
+**Glob syntax:** `select` patterns use [minimatch](https://github.com/isaacs/minimatch) syntax. Only two wildcards are supported: `*` (matches one path segment, e.g. `tasks/*` matches `tasks/abc` but not `tasks/abc/def`) and `**` (matches any number of segments, e.g. `tasks/**` matches `tasks/abc/def`). Exact key matches are also valid. No other glob syntax is supported.
+
+**`resolveScopeKey` for narrowed scope:** A `narrowed` scope resolves to the same key as its `from` scope. The `select` patterns restrict access within that scope — they do not change the key used to namespace storage.
+
+```typescript
+case 'narrowed': return resolveScopeKey(scope.from, ctx); // delegates to the base scope
+```
+
+**`onParentUpdate` is independent of narrowed scope.** Declaring narrowed scope without implementing `onParentUpdate` is valid and produces no warnings. The narrowed scope only restricts `ScopedStorage` access; `onParentUpdate` notification is a separate opt-in. A layer may use narrowed scope without `onParentUpdate`, or `onParentUpdate` without narrowed scope.
+
+**Runtime cost:** The runtime evaluates `select` patterns against changed storage keys after each parent `store()`. Layers with narrowed scope and large `select` arrays impose a per-store pattern-matching cost proportional to `|select| × |changed keys|`. Prefer exact key matches over broad `**` globs in performance-sensitive layers.
 
 ---
 

--- a/specs/11-memory-layer-system.md
+++ b/specs/11-memory-layer-system.md
@@ -13,6 +13,30 @@ Normative language uses **MUST**, **SHOULD**, and **MAY** per RFC 2119.
 
 ---
 
+## Mental Model: Reactive-Inspired Context Assembly
+
+The layer system is loosely inspired by reactive programming — not in the formal RxJS/MobX sense, but in spirit: the View (what the LLM sees) is always re-assembled from current layer state before each request, producing a fresh, consistent snapshot.
+
+**Context is the result of all layers converging — it is not itself a layer.** You define layers; the runtime converges them. Their convergence is the context. Context is never exposed as an input, never passed into a layer hook, and never something you construct directly. It is the output.
+
+**Memory is a type of layer, not a separate system.** "Memory" (facts recalled from storage) and "context injection" (information injected for this turn) are both expressed as layers with the same hook interface. The mechanism is identical; the purpose differs. The `slot` number determines where in the converged result each layer's contribution appears.
+
+**Each layer is one of two things** (or both):
+- A **window section** — a portion of the context budget reserved for specific content (skills, reminders, entity facts)
+- A **map/reduce** over prior information — transforming raw history or storage into a condensed, relevant form (summarization layers, RAG layers, episodic memory)
+
+**Context is scoped, not global.** LLM steps can share a converged context, operate in their own, or run in a child context forked from a parent via `spawn`. There is no ambient global context. Forked children are not fully isolated — they can receive updates from the parent context during their execution, and layers control whether and how those updates are incorporated. A step can also declare a **narrowed scope**, subscribing only to the parts of the parent context it cares about rather than the whole thing.
+
+**Internally reactive; externally hooks.** Users implementing custom layers do not write reactive pipelines. They implement lifecycle hooks (`recall`, `store`, `afterModelCall`, etc.) and the runtime handles orchestration, ordering, budgeting, and re-evaluation. The reactive behavior is an implementation detail, not a user-facing API.
+
+**Loose pattern, not strict formalism.** The reactive inspiration is a mental model, not a contract. Formal reactive concepts (observables, subscriptions, schedulers) do not appear in this API. The goal is the insight — always-fresh context from converging layers — without the boilerplate or jargon.
+
+### Stale Context (Non-Default)
+
+Context can be explicitly marked stale, causing the next request to block until all layers finish revalidating. This is opt-in for layers that need guaranteed consistency before the LLM call proceeds. The default `recall()` model is sufficient for most layers.
+
+---
+
 ## The `MemoryLayer` Interface
 
 ```typescript
@@ -26,7 +50,12 @@ interface MemoryLayer<TState = unknown> {
   timeouts?: Partial<LayerTimeouts>;
 }
 
-type MemoryScope = 'thread' | 'resource' | 'global' | 'execution';
+type MemoryScope =
+  | 'thread'
+  | 'resource'
+  | 'global'
+  | 'execution'
+  | { type: 'narrowed'; from: 'thread' | 'resource' | 'global' | 'execution'; select: string[] };
 
 type BudgetConfig =
   | number
@@ -64,6 +93,7 @@ interface MemoryHooks<TState = unknown> {
   afterModelCall?:  (params: AfterModelCallParams<TState>)       => Promise<AfterModelCallResult<TState> | void>;
   onSpawn?:         (params: SpawnParams<TState>)                => Promise<SpawnResult<TState> | null>;
   onReturn?:        (params: ReturnParams<TState>)               => Promise<ReturnResult<TState> | void>;
+  onParentUpdate?:  (params: ParentUpdateParams<TState>)         => Promise<ParentUpdateResult<TState> | void>;
   onComplete?:      (params: CompleteParams<TState>)             => Promise<void>;
   dispose?:         (params: DisposeParams<TState>)              => Promise<void>;
 }
@@ -221,6 +251,17 @@ interface DisposeParams<TState> {
   state: TState;
 }
 
+interface ParentUpdateParams<TState> {
+  parentState: TState;        // the parent layer's current state after its latest store()
+  childState: TState;         // the child layer's current state
+  childCtx: ExecutionContext;
+}
+
+interface ParentUpdateResult<TState> {
+  childState?: TState;        // updated child state, if the child wants to act on the update
+  items?: Item[];             // optional items to inject into the child's ItemLog
+}
+
 type ExecutionOutcome = 'success' | 'failure' | 'aborted';
 ```
 
@@ -324,6 +365,30 @@ A layer declaring `scope: 'thread'` CANNOT accidentally read another thread's da
 ### Cross-Scope Access
 
 To read a different scope, declare the broader scope. No escape hatches.
+
+---
+
+## Narrowed Scope
+
+A layer may declare a **narrowed scope** — interest in a specific subset of a parent scope, rather than the whole thing. This is distinct from the four base scopes: it is a selector applied on top of one of them.
+
+```typescript
+// Example: only interested in 'user.preferences' and anything under 'tasks/'
+{
+  type: 'narrowed',
+  from: 'thread',
+  select: ['user.preferences', 'tasks/*']
+}
+```
+
+`select` is an array of storage key patterns (exact keys or prefix globs). A layer with narrowed scope:
+
+1. Only has `ScopedStorage` access to keys matching its `select` patterns within the `from` scope
+2. Only receives `onParentUpdate` notifications when a matched key changes — changes to other parts of the parent scope are not delivered
+
+**Why narrowed scope exists.** A step may be a specialist — it cares about one domain (e.g., user preferences, active task list) and should not receive or process the full weight of parent context changes. Narrowing the scope limits unnecessary recomputation and enforces separation of concern between layers.
+
+**Narrowed scope does not grant broader access.** A `narrowed` layer cannot read keys outside its `select` patterns, even if they exist in the `from` scope. Attempts to access unselected keys return `null` from `ScopedStorage`.
 
 ---
 

--- a/specs/11-memory-layer-system.md
+++ b/specs/11-memory-layer-system.md
@@ -6,9 +6,7 @@
 
 ## Package Boundary
 
-**Current state:** Everything in this spec currently lives in `@noetic/core`. The `@noetic/memory` package does not yet exist.
-
-**Target state:** This spec is owned by `@noetic/memory`. The planned split is:
+This spec is owned by `@noetic/memory`. The split between packages is:
 
 | Lives in `@noetic/memory` | Lives in `@noetic/core` |
 |---|---|
@@ -18,9 +16,9 @@
 | `ExecutionContext` (memory-facing read-only view) | `Context` (full execution object) |
 | `ProjectionPolicy` | Projector implementation |
 
-**Dependency direction:** `@noetic/memory` will have no runtime dependency on `@noetic/core`. It may import `Item`, `ItemLog`, and `Span` types as type-only imports. `@noetic/core` will depend on `@noetic/memory` for the layer contract.
+**Dependency direction:** `@noetic/memory` has no runtime dependency on `@noetic/core`. It may import `Item`, `ItemLog`, and `Span` types as type-only imports. `@noetic/core` depends on `@noetic/memory` for the layer contract.
 
-**Custom layer authors** will import only from `@noetic/memory`. They will not need `@noetic/core` to implement a layer.
+**Custom layer authors** import only from `@noetic/memory`. They do not need `@noetic/core` to implement a layer.
 
 ---
 

--- a/specs/11-memory-layer-system.md
+++ b/specs/11-memory-layer-system.md
@@ -1,7 +1,24 @@
 # Memory Layer System
 
-> **Depends On:** `07-context-and-event-log` (ItemLog, Item), `10-observability` (MemoryTraceSpan, trace conventions), `04-spawn` (SpawnOpts — referenced in SpawnParams)
-> **Exports:** `MemoryLayer`, `MemoryHooks`, `MemoryScope`, `BudgetConfig`, `Slot`, `InitParams`, `InitResult`, `RecallParams`, `RecallResult`, `StoreParams`, `StoreResult`, `SpawnParams`, `SpawnResult`, `ReturnParams`, `ReturnResult`, `CompleteParams`, `DisposeParams`, `BeforeToolCallParams`, `BeforeToolCallResult`, `AfterModelCallParams`, `AfterModelCallResult`, `ExecutionOutcome`, `ExecutionContext`, `ScopedStorage`, `StorageAdapter`, `ProjectionPolicy`, `LayerTimeouts`
+> **Package:** `@noetic/memory`
+> **Depends On:** `07-context-and-event-log` (ItemLog, Item — type import only), `10-observability` (MemoryTraceSpan, trace conventions), `04-spawn` (SpawnOpts — referenced in SpawnParams)
+> **Exports:** `MemoryLayer`, `MemoryHooks`, `MemoryScope`, `BudgetConfig`, `Slot`, `InitParams`, `InitResult`, `RecallParams`, `RecallResult`, `StoreParams`, `StoreResult`, `SpawnParams`, `SpawnResult`, `ReturnParams`, `ReturnResult`, `CompleteParams`, `DisposeParams`, `BeforeToolCallParams`, `BeforeToolCallResult`, `AfterModelCallParams`, `AfterModelCallResult`, `ParentUpdateParams`, `ParentUpdateResult`, `ExecutionOutcome`, `ExecutionContext`, `ScopedStorage`, `StorageAdapter`, `ProjectionPolicy`, `LayerTimeouts`
+
+## Package Boundary
+
+This spec is owned by `@noetic/memory`. The split is:
+
+| Lives in `@noetic/memory` | Lives in `@noetic/core` |
+|---|---|
+| `MemoryLayer` interface and all hook types | Layer lifecycle orchestration (`initLayers`, `recallLayers`, etc.) |
+| `MemoryScope`, `ScopedStorage`, `StorageAdapter` | Projector (View assembly algorithm) |
+| `BudgetConfig`, `Slot`, budget algorithm | `allocateBudgets` call site |
+| `ExecutionContext` (memory-facing read-only view) | `Context` (full execution object) |
+| `ProjectionPolicy` | Projector implementation |
+
+**Dependency direction:** `@noetic/memory` has no runtime dependency on `@noetic/core`. It may import `Item`, `ItemLog`, and `Span` types from `@noetic/core` as type-only imports. `@noetic/core` depends on `@noetic/memory` for the layer contract.
+
+**Custom layer authors** import only from `@noetic/memory`. They never need `@noetic/core` to implement a layer.
 
 ---
 

--- a/specs/11-memory-layer-system.md
+++ b/specs/11-memory-layer-system.md
@@ -44,7 +44,7 @@ The layer system is loosely inspired by reactive programming — not in the form
 - A **window section** — a portion of the context budget reserved for specific content (skills, reminders, entity facts)
 - A **map/reduce** over prior information — transforming raw history or storage into a condensed, relevant form (summarization layers, RAG layers, episodic memory)
 
-**Context is scoped, not global.** LLM steps can share a converged context, operate in their own, or run in a child context forked from a parent via `spawn`. There is no ambient global context. Forked children are not fully isolated — they can receive updates from the parent context during their execution, and layers control whether and how those updates are incorporated. A step can also declare a **narrowed scope**, subscribing only to the parts of the parent context it cares about rather than the whole thing.
+**Context is scoped, not global.** LLM steps can share a converged context, operate in their own, or run in a child context forked from a parent via `spawn`. There is no ambient global context. Forked children are not fully isolated — they can receive updates from the parent context during their execution, and layers control whether and how those updates are incorporated.
 
 **Internally reactive; externally hooks.** Users implementing custom layers do not write reactive pipelines. They implement lifecycle hooks (`recall`, `store`, `afterModelCall`, etc.) and the runtime handles orchestration, ordering, budgeting, and re-evaluation. The reactive behavior is an implementation detail, not a user-facing API.
 
@@ -73,8 +73,7 @@ type MemoryScope =
   | 'thread'
   | 'resource'
   | 'global'
-  | 'execution'
-  | { type: 'narrowed'; from: 'thread' | 'resource' | 'global' | 'execution'; select: string[] };
+  | 'execution';
 
 type BudgetConfig =
   | number
@@ -387,41 +386,13 @@ To read a different scope, declare the broader scope. No escape hatches.
 
 ---
 
-## Narrowed Scope
+## Future Considerations
 
-A layer may declare a **narrowed scope** — interest in a specific subset of a parent scope, rather than the whole thing. This is distinct from the four base scopes: it is a selector applied on top of one of them.
+### Narrowed Scope (Not Yet Designed)
 
-```typescript
-// Example: only interested in 'user.preferences' and anything under 'tasks/'
-{
-  type: 'narrowed',
-  from: 'thread',
-  select: ['user.preferences', 'tasks/*']
-}
-```
+A potential optimization: allow a layer to declare interest in a specific subset of a parent scope rather than the whole thing. A specialist layer — one that cares only about user preferences or an active task list — could subscribe only to those keys and avoid receiving or processing unrelated parent context changes.
 
-`select` is an array of storage key patterns (exact keys or prefix globs). A layer with narrowed scope:
-
-1. Only has `ScopedStorage` access to keys matching its `select` patterns within the `from` scope
-2. Only receives `onParentUpdate` notifications when a matched key changes — changes to other parts of the parent scope are not delivered
-
-**Why narrowed scope exists.** A step may be a specialist — it cares about one domain (e.g., user preferences, active task list) and should not receive or process the full weight of parent context changes. Narrowing the scope limits unnecessary recomputation and enforces separation of concern between layers.
-
-**Narrowed scope does not grant broader access.** A `narrowed` layer cannot read keys outside its `select` patterns, even if they exist in the `from` scope. Attempts to access unselected keys return `null` from `ScopedStorage`.
-
-### Narrowed Scope Contract
-
-**Glob syntax:** `select` patterns use [minimatch](https://github.com/isaacs/minimatch) syntax. Only two wildcards are supported: `*` (matches one path segment, e.g. `tasks/*` matches `tasks/abc` but not `tasks/abc/def`) and `**` (matches any number of segments, e.g. `tasks/**` matches `tasks/abc/def`). Exact key matches are also valid. No other glob syntax is supported.
-
-**`resolveScopeKey` for narrowed scope:** A `narrowed` scope resolves to the same key as its `from` scope. The `select` patterns restrict access within that scope — they do not change the key used to namespace storage.
-
-```typescript
-case 'narrowed': return resolveScopeKey(scope.from, ctx); // delegates to the base scope
-```
-
-**`onParentUpdate` is independent of narrowed scope.** Declaring narrowed scope without implementing `onParentUpdate` is valid and produces no warnings. The narrowed scope only restricts `ScopedStorage` access; `onParentUpdate` notification is a separate opt-in. A layer may use narrowed scope without `onParentUpdate`, or `onParentUpdate` without narrowed scope.
-
-**Runtime cost:** The runtime evaluates `select` patterns against changed storage keys after each parent `store()`. Layers with narrowed scope and large `select` arrays impose a per-store pattern-matching cost proportional to `|select| × |changed keys|`. Prefer exact key matches over broad `**` globs in performance-sensitive layers.
+This would require extending `MemoryScope` with a selector variant (e.g. key patterns or glob matching), adding filtering logic to `onParentUpdate` dispatch, and defining access-control semantics for `ScopedStorage`. The tradeoffs (pattern-matching cost per `store()`, complexity of the access model) need evaluation before committing to a design. Not scheduled.
 
 ---
 

--- a/specs/12-builtin-memory-layers.md
+++ b/specs/12-builtin-memory-layers.md
@@ -1,5 +1,6 @@
 # Built-In Memory Layers
 
+> **Package:** `@noetic/memory`
 > **Depends On:** `11-memory-layer-system` (MemoryLayer, MemoryHooks, Slot, ScopedStorage, BudgetConfig, all hook param types)
 > **Exports:** `workingMemory()`, `semanticRecall()`, `observationalMemory()`, `episodicMemory()`, `durableTaskState()`, `steering()`, `WorkingMemoryConfig`, `SemanticRecallConfig`, `ObservationalMemoryConfig`, `EpisodicMemoryConfig`, `DurableTaskStateConfig`, `SteeringConfig`, `SteeringRule`, `VectorStore`, `Embedder`, `EpisodicStore`, `DocumentRetriever`, `Reranker`, `PubSubChannel`
 

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -134,6 +134,14 @@ createOpenRouterEmbed(...)
 3. Deprecations MUST use `@deprecated` JSDoc with the replacement API specified.
 4. Breaking changes MUST include a migration guide in `packages/web/content/docs/migration/`.
 
+### 2.6 Approachability Over Formalism
+
+When a system is internally inspired by a formal pattern (reactive programming, process calculi, actor model), the public API MUST NOT expose that formalism directly. Use the framework's own vocabulary instead of the source pattern's terminology.
+
+- Do not leak reactive primitives (`Observable`, `Subject`, `pipe`, `subscribe`) into the public API surface, even if the implementation uses them.
+- Do not name concepts after their theoretical origin when a plain descriptive name is available (`recall` not `observe`, `slot` not `priority`, `layer` not `transformer`).
+- Formal patterns inform implementation and help contributors reason about the system — they are not user-facing concepts and must not appear in docs, error messages, or API names.
+
 ### 2.5 Avoiding Breaking Changes
 
 **Pre-1.0 exception: all backward compatibility rules in this section are suspended while any package version is below `1.0.0`.**
@@ -304,6 +312,8 @@ NoeticConfigError: Missing required environment variable.
 Framework extenders implement the extension interfaces defined in specs `08-runtime`, `11-memory-layer-system`, and `10-observability`. Each extension point MUST have a dedicated getting-started guide in the docs.
 
 ### 6.1 Custom Memory Layer
+
+The memory layer system is the primary advanced extension point. It is deliberately not exposed as a reactive API — users implement lifecycle hooks and the runtime handles orchestration. Documentation and error messages for custom layers MUST NOT use reactive programming terminology (observables, subjects, streams, subscriptions). Use the framework's own vocabulary: `recall`, `store`, `slot`, `View`, `layer`, `convergence`.
 
 A custom memory layer guide MUST cover:
 1. The `MemoryLayer` interface (all required and optional hooks)

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -369,7 +369,6 @@ An implementation guide for a pluggable package MUST cover:
 4. **Invariants and contracts** — behavioural guarantees the implementation must uphold that are not expressible in TypeScript types alone (e.g. storage key namespacing, budget reporting accuracy, scope isolation).
 5. **The test suite** — a shared conformance test suite that any implementation can run against to verify correctness. Pluggable packages MUST ship a conformance suite importable as `@noetic/<package>/conformance`. The suite MUST cover at minimum:
    - **Lifecycle ordering** — hooks are called in the specified order (e.g. `init` before `recall`, `store` before `dispose`, `onParentUpdate` only for `spawn` not `fork`)
-   - **Scope isolation** — a layer receiving a `narrowed` scope only sees keys matching the declared glob; keys outside the glob are not visible and cannot be written
    - **Error recovery** — non-fatal hook errors (e.g. a failing `store`) are absorbed per-hook per the error policy; the execution continues and subsequent hooks still run
    - **Timeout enforcement** — hooks that exceed their timeout are cancelled and treated as the appropriate error category (logged for `store`, thrown for `recall`)
    - **Concurrent store semantics** — multiple `store` calls in the same lifecycle step are settled via `Promise.allSettled`; one failure does not cancel the others

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -134,6 +134,29 @@ createOpenRouterEmbed(...)
 3. Deprecations MUST use `@deprecated` JSDoc with the replacement API specified.
 4. Breaking changes MUST include a migration guide in `packages/web/content/docs/migration/`.
 
+### 2.5 Avoiding Breaking Changes
+
+Breaking changes impose upgrade costs on every user of the framework. The strong default is to avoid them.
+
+**Prefer introduce-and-deprecate over replace.** When an API needs to change, introduce the new form and mark the old form `@deprecated` with a reference to the replacement. Remove the old form only in the next major version.
+
+**Conflict resolution with other DX guidelines.** Consistency (§2.1–§2.3) is more important than backwards compatibility. When a naming or structural violation must be fixed:
+
+1. First, look for a solution that satisfies both — e.g., a type alias, a re-export under the new name, or an overloaded factory that accepts both old and new shapes.
+2. If no such solution exists, ask for guidance before introducing a breaking change. Do not make the call unilaterally.
+
+**What counts as a breaking change:**
+- Removing or renaming a `@public` export
+- Changing a `@public` function's parameter types or return type in a non-additive way
+- Changing observable runtime behavior that users may depend on
+- Removing a `NoeticError` kind or changing its `kind` string
+
+**What does not count as a breaking change:**
+- Adding optional fields to a config object
+- Adding new exports
+- Narrowing a previously-wide return type (e.g., `string` → `'a' | 'b'`) when it remains assignable
+- Fixing incorrect behavior that was never part of the documented contract
+
 ---
 
 ## 3. SDK Standards

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -136,7 +136,17 @@ createOpenRouterEmbed(...)
 
 ### 2.5 Avoiding Breaking Changes
 
-**Pre-1.0 exception: these rules do not apply while any package version is below `1.0.0`.** Before 1.0, the project is under active internal development. New implementation MUST NOT be hampered by migration or backward compatibility concerns. Change APIs freely, delete dead code, and do not add deprecation shims. The rules below take effect at 1.0.0.
+**Pre-1.0 exception: all backward compatibility rules in this section are suspended while any package version is below `1.0.0`.**
+
+Before 1.0, the project is under active internal development and the public API is not stable. Implementation velocity and correctness take full priority over continuity. Specifically:
+
+- **Be aggressive about removing prior implementations.** When a new iteration of an API, type, or behavior is introduced, delete the old one in the same PR. Do not leave the old form around "just in case."
+- **No deprecation shims.** Do not add `@deprecated` wrappers, re-exports, or compatibility aliases for removed APIs.
+- **No migration guides.** Do not write or maintain migration docs for pre-1.0 changes.
+- **No semver major bumps for breaking changes.** Breaking changes in pre-1.0 packages are routine and expected; they do not require a major version bump.
+- **Delete dead code.** Any code that is no longer reachable or referenced after a change MUST be removed. Unused exports, orphaned types, and leftover helpers are not acceptable.
+
+The rules below take effect at `1.0.0`. At that point, backward compatibility becomes a first-class obligation and this exception no longer applies.
 
 Breaking changes impose upgrade costs on every user of the framework. The strong default is to avoid them.
 

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -138,14 +138,7 @@ createOpenRouterEmbed(...)
 2. Subpath exports, if added, MUST follow `@noetic/<package>/<capability>` (e.g., `@noetic/core/adapters`).
 3. Type-only imports MUST use `import type` syntax.
 
-### 2.4 Versioning
-
-1. Packages follow semver strictly. A change to a `@public` symbol's type signature, behavior, or removal constitutes a breaking change requiring a major bump.
-2. `@unstable` changes require only a minor bump with a CHANGELOG entry.
-3. Deprecations MUST use `@deprecated` JSDoc with the replacement API specified.
-4. Breaking changes MUST include a migration guide in `packages/web/content/docs/migration/`.
-
-### 2.5 Approachability Over Formalism
+### 2.4 Approachability Over Formalism
 
 When a system is internally inspired by a formal pattern (reactive programming, process calculi, actor model), the public API MUST NOT expose that formalism directly. Use the framework's own vocabulary instead of the source pattern's terminology.
 

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -321,7 +321,7 @@ A custom memory layer guide MUST cover:
 3. The token budget system (`BudgetConfig`, `Slot`)
 4. The layer `id` namespacing convention (`'org/layer-name'`)
 5. How to test a custom layer using the test helpers in `_helpers.ts`
-6. How to publish a custom layer as a package (peer dependency on `@noetic/core`)
+6. How to publish a custom layer as a package (peer dependency on `@noetic/memory` only — `@noetic/core` is not required)
 
 ### 6.2 Custom Runtime Backend
 
@@ -435,6 +435,7 @@ The following symbols are exported without an `@internal` tag but are implementa
 | `setRuntime()` global registration function undocumented (no API reference, no module-load-order warning) | §6.2 |
 | `api/index.mdx` does not enumerate all public symbols with one-line descriptions | §4.2 |
 | No `@noetic/core/internal` subpath export; internal symbols exposed at root index without `@internal` tags | §1.6 |
+| `@noetic/memory` package does not exist; memory contract and implementations live in `@noetic/core` | `00-overview`, `11-memory-layer-system` |
 | No `typecheck:docs` script in `packages/web/package.json` | §4.3 |
 
 ### Getting Started Gaps

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -136,6 +136,8 @@ createOpenRouterEmbed(...)
 
 ### 2.5 Avoiding Breaking Changes
 
+**Pre-1.0 exception: these rules do not apply while any package version is below `1.0.0`.** Before 1.0, the project is under active internal development. New implementation MUST NOT be hampered by migration or backward compatibility concerns. Change APIs freely, delete dead code, and do not add deprecation shims. The rules below take effect at 1.0.0.
+
 Breaking changes impose upgrade costs on every user of the framework. The strong default is to avoid them.
 
 **Prefer introduce-and-deprecate over replace.** When an API needs to change, introduce the new form and mark the old form `@deprecated` with a reference to the replacement. Remove the old form only in the next major version.

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -348,6 +348,21 @@ A custom `TraceExporter` guide MUST cover:
 3. How to register a custom exporter on the runtime
 4. The `NoopExporter` and `InMemoryExporter` as reference implementations
 
+### 6.5 Pluggable Package Implementations
+
+Some Noetic packages are designed to be replaceable in their entirety — not just extended with a custom layer or adapter, but fully reimplemented by a third party. `@noetic/memory` is the primary example: the package defines a contract, the built-in implementations ship as the default, but an alternative package (e.g. `@acme/noetic-memory`) can satisfy the same contract and be swapped in.
+
+Every pluggable package MUST have a dedicated implementation guide in the docs. This guide is distinct from the "custom layer" or "custom adapter" guides — it is for authors who want to replace the entire package, not extend it.
+
+An implementation guide for a pluggable package MUST cover:
+
+1. **The full contract** — every interface, type, and invariant the replacement package must satisfy, in one place. No hunting across multiple reference pages.
+2. **What the consumer expects** — how `@noetic/core` (or other dependents) imports and calls into the package, so the implementor knows exactly what surface they are providing.
+3. **Registration / wiring** — how to configure Noetic to use the replacement package instead of the default (e.g. package aliasing in `package.json`, a runtime registration call, or a bundler alias).
+4. **Invariants and contracts** — behavioural guarantees the implementation must uphold that are not expressible in TypeScript types alone (e.g. storage key namespacing, budget reporting accuracy, scope isolation).
+5. **The test suite** — a shared conformance test suite that any implementation can run against to verify correctness. Pluggable packages MUST ship a conformance suite importable as `@noetic/<package>/conformance`.
+6. **A worked reference** — the built-in implementation annotated to explain why each decision was made, so implementors can diverge intentionally rather than accidentally.
+
 ---
 
 ## 7. `@noetic/eval` DX

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -1,0 +1,400 @@
+# Developer Experience (DX)
+
+> **Depends On:** All public-facing specs (01–16), `17-eval-and-optimization`
+> **Exports:** (none — standards and gap audit only)
+
+---
+
+## Overview
+
+This spec defines the standards that all Noetic public APIs, SDKs, and documentation must meet. It covers two audiences equally:
+
+- **Agent authors** — developers using `@noetic/core` and `@noetic/eval` to build agents
+- **Framework extenders** — developers implementing custom memory layers, runtime backends, storage adapters, or trace exporters
+
+The spec body contains prescriptive, durable standards. The `## Gap Audit` appendix snapshots current violations; it is expected to shrink as violations are fixed and should be removed once clean.
+
+---
+
+## 1. Export Visibility
+
+Every exported symbol must belong to exactly one visibility tier. The tier determines documentation requirements, stability guarantees, and whether the symbol appears in user-facing docs.
+
+### Tiers
+
+| Tier | Tag | Guarantee | Docs required |
+|---|---|---|---|
+| **Public** | (none) | Semver-stable. Breaking changes require a major version bump and migration guide. | Yes — TSDoc + MDX reference page |
+| **Unstable** | `@unstable` JSDoc tag | May change in any minor release. Callers opt in knowingly. | Yes — TSDoc with a stability warning |
+| **Internal** | `@internal` JSDoc tag | No stability guarantee. Not for external use. | TSDoc optional |
+
+### Rules
+
+1. Every symbol exported from a package's `index.ts` MUST have an explicit visibility tier assigned in its JSDoc.
+2. `@internal` symbols MUST NOT appear in rendered MDX reference docs.
+3. Implementation classes (`ContextImpl`, `ItemLogImpl`, `SpanImpl`, `ChannelStore`) are `@internal` unless there is a documented reason to expose them.
+4. Raw interpreter functions (`executeRun`, `executeBranch`, `executeFork`, `executeLoop`, `executeSpawn`, `executeTool`) are `@internal`. The public surface for execution is `execute()`.
+5. Framework utilities (`frameworkCast`, `allocateBudgets`, `checkBudget`, `createLayerStateStore`, lifecycle functions) are `@internal` unless explicitly needed by framework extenders, in which case they are `@unstable`.
+6. A future `@noetic/core/internal` subpath export may expose `@internal` symbols for framework authors; until that exists, exporting them with `@internal` tags from the root index is an accepted compromise. See Gap Audit.
+
+---
+
+## 2. API Consistency
+
+### 2.1 Naming Rules
+
+**Builder functions** use lowercase, unnamespaced names when they construct a top-level primitive:
+
+```ts
+// Correct
+loop(...)
+fork(...)
+spawn(...)
+branch(...)
+channel(...)
+```
+
+Builder functions for step variants are namespaced under `step`:
+
+```ts
+step.run(...)
+step.llm(...)
+step.tool(...)
+```
+
+**Config types** use PascalCase with a descriptive noun suffix (not `Opts` — prefer `Config`):
+
+```ts
+// Correct
+WorkingMemoryConfig
+DurableTaskStateConfig
+ObservationalMemoryConfig
+
+// Wrong
+LoopOpts  // → LoopConfig
+```
+
+**Result/param types** for lifecycle hooks follow `<HookName>Params` / `<HookName>Result`:
+
+```ts
+RecallParams / RecallResult
+StoreParams / StoreResult
+SpawnParams / SpawnResult
+ReturnParams / ReturnResult
+InitParams / InitResult
+CompleteParams  // (no result — void)
+DisposeParams   // (no result — void)
+```
+
+**Factory functions** for built-in memory layers use camelCase, named after what they provide (not what they are):
+
+```ts
+workingMemory(...)       // not createWorkingMemory
+observationalMemory(...) // not createObservationalMemory
+durableTaskState(...)    // not createDurableTaskState
+staticContent(...)
+steering(...)
+```
+
+**Error kinds** use `snake_case` string literals:
+
+```ts
+'llm_parse_error'
+'fork_partial'
+'spawn_summary_failed'
+'budget_exceeded'
+```
+
+**Adapter factories** use `create<Provider><Capability>` pattern:
+
+```ts
+createOpenRouterCallModel(...)
+createOpenRouterEmbed(...)
+```
+
+### 2.2 Parameter Shape Rules
+
+1. Functions with more than two parameters MUST accept a config object, not positional args.
+2. Config objects MUST NOT use positional-sensitive field ordering. All fields must be independently optional or required based on semantics, not position.
+3. Boolean flags in config objects MUST use `is`/`has`/`should` prefixes: `isEnabled`, `hasTimeout`, `shouldRetry`.
+4. Callback parameters MUST be typed explicitly — no `Function` or `(...args: any[]) => any`.
+5. Optional parameters with defaults MUST document the default value in TSDoc.
+6. Overloaded signatures are prohibited. Use a union-typed config object instead.
+
+### 2.3 Path and Import Conventions
+
+1. All public API is importable from the package root (`@noetic/core`, `@noetic/eval`). Deep imports (`@noetic/core/memory`) are only for subpath exports explicitly declared in `package.json#exports`.
+2. Subpath exports, if added, MUST follow `@noetic/<package>/<capability>` (e.g., `@noetic/core/adapters`).
+3. Type-only imports MUST use `import type` syntax.
+
+### 2.4 Versioning
+
+1. Packages follow semver strictly. A change to a `@public` symbol's type signature, behavior, or removal constitutes a breaking change requiring a major bump.
+2. `@unstable` changes require only a minor bump with a CHANGELOG entry.
+3. Deprecations MUST use `@deprecated` JSDoc with the replacement API specified.
+4. Breaking changes MUST include a migration guide in `packages/web/content/docs/migration/`.
+
+---
+
+## 3. SDK Standards
+
+### 3.1 TypeScript SDK (current)
+
+The TypeScript SDK is `@noetic/core` and `@noetic/eval`. "SDK" means the public API surface those packages export.
+
+1. Every concept expressible in the SDK MUST be expressible without importing `@internal` symbols.
+2. The SDK MUST NOT require users to instantiate implementation classes directly. Factory functions or builder APIs cover all construction.
+3. The SDK MUST be usable without understanding the interpreter internals. `execute(step, input, ctx)` is the single entry point.
+4. Zod schemas used in public API MUST be exported so users can compose or extend them.
+
+### 3.2 Future Language Binding Contract
+
+When SDKs for additional languages (Python, Go, etc.) are built, they MUST conform to the following contract to ensure cross-SDK consistency:
+
+1. **Concept parity** — Every public primitive (`Step` variants, `execute`, memory layers, `until` predicates) MUST have a first-class equivalent. Gaps are documented as known limitations with a tracking issue.
+2. **Naming translation** — Naming follows target language conventions (snake_case for Python, etc.), but concept names stay semantically identical (`loop`, `fork`, `spawn`, `branch`).
+3. **Error parity** — Every `NoeticError` kind defined in spec `09-error-model` MUST be representable in the target language's error/exception system, with the same `kind` string.
+4. **Getting started parity** — Every language SDK MUST have a getting-started guide that produces working output in under 5 minutes on a clean machine.
+5. **Documentation parity** — Language SDKs MUST document all public symbols before release. Undocumented public symbols block release.
+
+---
+
+## 4. Documentation Standards
+
+### 4.1 TSDoc Requirements by Visibility Tier
+
+**Public symbols** MUST have TSDoc that includes:
+- A one-line summary (used in autocomplete tooltips)
+- A `@param` for every parameter
+- A `@returns` describing the return value (or `void` if none)
+- An `@example` with a minimal working usage
+- `@throws` for every `NoeticError` kind the function can produce at execution time
+- `@throws` for every `NoeticConfigError` code the function can produce at construction time (applies to builders, factories, and memory layer factories)
+
+**Unstable symbols** MUST have TSDoc that includes:
+- Everything required for public symbols
+- An `@unstable` tag with a one-line explanation of why it is unstable
+
+**Internal symbols** SHOULD have TSDoc sufficient for contributors. `@param` and `@returns` are recommended but not required.
+
+### 4.2 MDX Reference Doc Requirements
+
+Every `@public` symbol exported from a package MUST have a corresponding entry in the MDX reference docs (`packages/web/content/docs/api/`).
+
+Reference doc entries MUST include:
+- The type signature (rendered as a code block)
+- A prose description
+- All parameters/fields described in a table or list
+- At least one usage example
+
+Index pages (`api/index.mdx`) MUST enumerate all public symbols with one-line descriptions.
+
+### 4.3 Doc Freshness
+
+1. When a public API changes, its TSDoc and MDX reference entry MUST be updated in the same PR.
+2. The `sync-spec-code-docs.md` rule already enforces spec ↔ code ↔ docs sync; this spec adds TSDoc as a third artifact in that sync obligation.
+3. Example code in docs MUST compile. A `typecheck:docs` script in `packages/web/package.json` MUST type-check all TypeScript code blocks using `tsc --noEmit`. This script MUST run in CI on every PR that touches `packages/web/content/`.
+
+---
+
+## 5. Getting Started
+
+### 5.1 Prerequisites
+
+The getting-started documentation MUST specify:
+
+| Requirement | Minimum | Notes |
+|---|---|---|
+| TypeScript | 5.0+ | Required for `satisfies`, const type parameters |
+| Node.js | 18+ | Required for native fetch |
+| Bun | 1.0+ | Preferred runtime; all examples use `bun` |
+| `tsconfig.json` | `strict: true`, `moduleResolution: "bundler"` or `"node16"` | Required for correct type inference |
+
+These prerequisites MUST appear at the top of the Getting Started page before any install instructions.
+
+### 5.2 Canonical Hello World
+
+The canonical first example MUST:
+- Produce visible output (text printed to stdout) in a single `bun run` invocation
+- Complete end-to-end in under 5 minutes on a clean machine (including install)
+- Require no more than one environment variable (`OPENROUTER_API_KEY` or equivalent)
+- Introduce no more than three Noetic concepts (e.g., `step.llm`, `execute`, `InMemoryRuntime`)
+- Fit in under 30 lines including imports
+- Be type-checkable without errors on a clean install
+
+The current Getting Started page example (`react()` pattern) meets this bar. Any future revision MUST not exceed it.
+
+### 5.3 Configuration and Setup Documentation
+
+All configuration required to use Noetic — environment variables, runtime setup, tsconfig — MUST be documented in a dedicated "Configuration" section of the docs. Each item MUST include:
+
+1. The name of the variable or setting
+2. What it controls
+3. The default value (if any)
+4. An example of a valid value
+5. What happens when it is missing or invalid (with a pointer to the error message the user will see)
+
+### 5.4 Error Message Standard
+
+Every error thrown during setup or configuration — including missing env vars, invalid step construction, invalid memory layer config, and runtime misconfiguration — MUST conform to this structure.
+
+`NoeticConfigError` is a **separate class** from `NoeticError` (spec `09-error-model`). `NoeticError` covers execution-time failures (LLM errors, fork failures, spawn errors). `NoeticConfigError` covers pre-execution failures: construction-time validation, missing environment variables, and runtime misconfiguration. The two classes do not share a base class beyond `Error`.
+
+```ts
+class NoeticConfigError extends Error {
+  readonly code: string;       // machine-readable, e.g. 'MISSING_API_KEY'
+  readonly hint: string;       // human-readable corrective action
+  readonly docsUrl?: string;   // link to the relevant docs page
+}
+```
+
+Rules:
+1. `code` MUST be a `SCREAMING_SNAKE_CASE` string that uniquely identifies the error condition.
+2. `hint` MUST be a complete sentence that tells the user what to do next. It MUST NOT say "an error occurred."
+3. `docsUrl` SHOULD be provided for any error a new user is likely to hit during setup.
+4. Error messages MUST NOT expose internal stack details, file paths, or implementation class names.
+5. Every error code MUST appear in a doc page (`docs/errors.mdx`) with an explanation and resolution steps.
+
+**Example:**
+```
+NoeticConfigError: Missing required environment variable.
+  code: MISSING_API_KEY
+  hint: Set OPENROUTER_API_KEY in your environment or pass a callModel adapter explicitly. See https://noetic.dev/docs/errors#MISSING_API_KEY
+```
+
+---
+
+## 6. Framework Extender Onboarding
+
+Framework extenders implement the extension interfaces defined in specs `08-runtime`, `11-memory-layer-system`, and `10-observability`. Each extension point MUST have a dedicated getting-started guide in the docs.
+
+### 6.1 Custom Memory Layer
+
+A custom memory layer guide MUST cover:
+1. The `MemoryLayer` interface (all required and optional hooks)
+2. The `ScopedStorage` contract and how to use `createScopedStorage`
+3. The token budget system (`BudgetConfig`, `Slot`)
+4. The layer `id` namespacing convention (`'org/layer-name'`)
+5. How to test a custom layer using the test helpers in `_helpers.ts`
+6. How to publish a custom layer as a package (peer dependency on `@noetic/core`)
+
+### 6.2 Custom Runtime Backend
+
+A custom `Runtime` guide MUST cover:
+1. The `Runtime` interface and all required methods
+2. How `AgentConfig` and `AgentHooks` are used during execution
+3. The `setRuntime()` global registration function and its module-load-order implications
+4. How to write unit tests for a custom runtime using `InMemoryRuntime` as a reference
+5. The recommended pattern for serverless/stateless environments (re-instantiation per invocation)
+
+### 6.3 Custom Storage Adapter
+
+A custom `StorageAdapter` guide MUST cover:
+1. The `StorageAdapter` interface (get, set, delete, list)
+2. The key namespacing contract (keys are owned by the memory layer, not the adapter)
+3. How to test an adapter with the shared adapter test suite
+4. Reference implementations for common backends (in-memory, Redis, Postgres)
+
+### 6.4 Custom Trace Exporter
+
+A custom `TraceExporter` guide MUST cover:
+1. The `TraceExporter` interface (`export(spans: Span[])`)
+2. The `Span` and `MemoryTraceSpan` types
+3. How to register a custom exporter on the runtime
+4. The `NoopExporter` and `InMemoryExporter` as reference implementations
+
+---
+
+## 7. `@noetic/eval` DX
+
+The eval package (`@noetic/eval`) is a first-class part of the Noetic SDK. Its DX standards mirror `@noetic/core` unless otherwise specified.
+
+### 7.1 CLI Install and Discovery
+
+1. The `noetic` CLI MUST be documented as a dev dependency: `bun add -d @noetic/eval`.
+2. The CLI MUST print a clear error if no `.eval.ts` files are found, with a hint pointing to the getting-started guide for evals.
+3. The `noetic test` command's flags (`--filter`, `--model`, `--baseline`, etc.) MUST be documented in both `--help` output and in the docs.
+4. When coverage drops below threshold, the CLI MUST print the per-file diff table before exiting non-zero.
+
+### 7.2 Eval API Documentation
+
+1. Every public symbol in `@noetic/eval` (`describe`, `it`, `createScorer`, `runEval`, `EvalResult`, etc.) MUST have TSDoc with the same requirements as `@noetic/core` public symbols (see §4.1).
+2. Built-in scorers (semantic similarity, regex, LLM-as-judge, etc.) MUST each have a dedicated doc section covering: what they measure, when to use them, and their configuration options.
+3. The GEPA optimization loop MUST be documented end-to-end with a worked example.
+
+### 7.3 Eval Error Messages
+
+This section covers configuration and setup errors in the eval CLI and runner — the `NoeticConfigError` category. Execution-phase `NoeticError` kinds (e.g., scorer runtime failures) are governed by spec `09-error-model` and the `@throws` rules in §4.1. Eval-specific `NoeticConfigError` cases MUST follow the structure defined in §5.4. Specifically:
+1. A missing baseline file MUST produce an error with `code: MISSING_BASELINE` and a hint explaining how to generate one.
+2. A scorer that throws unexpectedly MUST wrap the cause and include which test case triggered it.
+
+---
+
+## Appendix: Gap Audit
+
+This section documents known violations of the standards above as of 2026-03-23. Items should be fixed and removed from this list; the list is empty when the codebase is fully compliant.
+
+### Export Visibility Violations (`packages/core/src/index.ts`)
+
+The following symbols are exported without an `@internal` tag but are implementation internals:
+
+| Symbol | Required tag | Reason |
+|---|---|---|
+| `ContextImpl` | `@internal` | Implementation class; public contract is `Context` interface |
+| `ItemLogImpl` | `@internal` | Implementation class; public contract is `ItemLog` interface |
+| `SpanImpl` | `@internal` | Implementation class; public contract is `Span` interface |
+| `ChannelStore` | `@internal` | Implementation class; public contract is `Channel<T>` |
+| `executeRun` | `@internal` | Internal interpreter; public entry point is `execute()` |
+| `executeBranch` | `@internal` | Internal interpreter; public entry point is `execute()` |
+| `executeFork` | `@internal` | Internal interpreter; public entry point is `execute()` |
+| `executeLoop` | `@internal` | Internal interpreter; public entry point is `execute()` |
+| `executeSpawn` | `@internal` | Internal interpreter; public entry point is `execute()` |
+| `executeTool` | `@internal` | Internal interpreter; public entry point is `execute()` |
+| `frameworkCast` | `@internal` | Internal utility |
+| `allocateBudgets` | `@internal` or `@unstable` | Memory budget internals |
+| `checkBudget` | `@internal` or `@unstable` | Memory budget internals |
+| `findFunctionCall` | `@internal` | Internal memory utility |
+| `createLayerStateStore` | `@internal` or `@unstable` | Layer lifecycle internals |
+| `afterModelCallLayers` | `@internal` | Layer lifecycle internals |
+| `beforeToolCallLayers` | `@internal` | Layer lifecycle internals |
+| `completeLayers` | `@internal` | Layer lifecycle internals |
+| `disposeLayers` | `@internal` | Layer lifecycle internals |
+| `initLayers` | `@internal` | Layer lifecycle internals |
+| `recallLayers` | `@internal` | Layer lifecycle internals |
+| `returnLayers` | `@internal` | Layer lifecycle internals |
+| `spawnLayers` | `@internal` | Layer lifecycle internals |
+| `storeLayers` | `@internal` | Layer lifecycle internals |
+| `assembleView` | `@internal` or `@unstable` | Memory projector internals |
+| `createScopedStorage` | `@unstable` | Useful for extenders but not stable |
+| `resolveScopeKey` | `@internal` | Internal scope utility |
+| `GenAI` | `@internal` | Internal observability attribute constants |
+| `ToolAttr` | `@internal` | Internal observability attribute constants |
+
+### Naming Violations
+
+| Current | Standard | Fix |
+|---|---|---|
+| `LoopOpts` | `LoopConfig` | Rename in next major version; add `@deprecated` alias |
+
+### Missing Documentation
+
+| Gap | Standard violated |
+|---|---|
+| No TSDoc on any exported builder function | §4.1 |
+| No TSDoc on any exported type | §4.1 |
+| `errors.mdx` does not enumerate all `NoeticError` kinds with resolution steps | §5.4 |
+| No "Configuration" section in Getting Started docs | §5.3 |
+| No framework extender guides (custom memory layer, runtime, storage adapter, trace exporter) | §6.1–6.4 |
+| `@noetic/eval` public symbols have no TSDoc | §4.1, §7.2 |
+| No migration docs directory | §2.4 |
+| `setRuntime()` global registration function undocumented (no API reference, no module-load-order warning) | §6.2 |
+| `api/index.mdx` does not enumerate all public symbols with one-line descriptions | §4.2 |
+| No `@noetic/core/internal` subpath export; internal symbols exposed at root index without `@internal` tags | §1.6 |
+| No `typecheck:docs` script in `packages/web/package.json` | §4.3 |
+
+### Getting Started Gaps
+
+| Gap | Standard violated |
+|---|---|
+| Prerequisites (TS version, tsconfig, Node version) not documented | §5.1 |
+| No configuration error messages with `code` + `hint` format | §5.4 |

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -12,6 +12,16 @@ This spec defines the standards that all Noetic public APIs, SDKs, and documenta
 - **Agent authors** — developers using `@noetic/core` and `@noetic/eval` to build agents
 - **Framework extenders** — developers implementing custom memory layers, runtime backends, storage adapters, or trace exporters
 
+### No Higher-Order "Agent" Concept
+
+Noetic does not ship a top-level `Agent` class or `createAgent()` factory. This is intentional.
+
+An agent is a function (or module) that the developer authors directly, composing Noetic's step primitives, memory layers, channels, and context management. The framework provides the operations; the developer retains full control over the agent's structure, entry point, lifecycle, and composition strategy.
+
+This is the same design philosophy as React: React does not ship a "Component" class that developers subclass. A component is a function that uses hooks and returns JSX. The framework provides the primitives (`useState`, `useEffect`, context) — the component is just code. Similarly, a Noetic agent is just code that calls `execute()`, configures memory layers, and composes steps.
+
+Documentation and examples MUST reflect this. Do not introduce `Agent` as a term of art, and do not frame examples around a missing abstraction. Frame them around the composition patterns in `13-patterns`.
+
 The spec body contains prescriptive, durable standards. The `## Gap Audit` appendix snapshots current violations; it is expected to shrink as violations are fixed and should be removed once clean.
 
 ### Quick Reference by Audience

--- a/specs/19-dx.md
+++ b/specs/19-dx.md
@@ -14,6 +14,16 @@ This spec defines the standards that all Noetic public APIs, SDKs, and documenta
 
 The spec body contains prescriptive, durable standards. The `## Gap Audit` appendix snapshots current violations; it is expected to shrink as violations are fixed and should be removed once clean.
 
+### Quick Reference by Audience
+
+| If you are… | Read first | Then |
+|---|---|---|
+| Building an agent | §5 Getting Started, §5.2 Hello World | §4 if contributing docs |
+| Implementing a custom memory layer | §6.1, `specs/11-memory-layer-system` | §6.5 for publishing |
+| Replacing `@noetic/memory` entirely | §6.5, then §6.1–6.4 | `specs/11-memory-layer-system` for full contract |
+| Implementing a custom runtime backend | §6.2, `specs/08-runtime` | — |
+| Contributing to `@noetic/core` | §1 Export Visibility, §2 API Consistency | §4 for doc standards |
+
 ---
 
 ## 1. Export Visibility
@@ -32,10 +42,11 @@ Every exported symbol must belong to exactly one visibility tier. The tier deter
 
 1. Every symbol exported from a package's `index.ts` MUST have an explicit visibility tier assigned in its JSDoc.
 2. `@internal` symbols MUST NOT appear in rendered MDX reference docs.
-3. Implementation classes (`ContextImpl`, `ItemLogImpl`, `SpanImpl`, `ChannelStore`) are `@internal` unless there is a documented reason to expose them.
-4. Raw interpreter functions (`executeRun`, `executeBranch`, `executeFork`, `executeLoop`, `executeSpawn`, `executeTool`) are `@internal`. The public surface for execution is `execute()`.
-5. Framework utilities (`frameworkCast`, `allocateBudgets`, `checkBudget`, `createLayerStateStore`, lifecycle functions) are `@internal` unless explicitly needed by framework extenders, in which case they are `@unstable`.
-6. A future `@noetic/core/internal` subpath export may expose `@internal` symbols for framework authors; until that exists, exporting them with `@internal` tags from the root index is an accepted compromise. See Gap Audit.
+3. `@internal` symbols MUST NOT appear in `index.ts`. They are imported by path within the package only (e.g. `import { ContextImpl } from './runtime/context-impl'`). JSDoc tags do not prevent symbols from appearing in `.d.ts` files or IDE autocomplete — removing them from `index.ts` is the only safe approach.
+4. Implementation classes (`ContextImpl`, `ItemLogImpl`, `SpanImpl`, `ChannelStore`) are `@internal` and belong only in the package's internal import graph.
+5. Raw interpreter functions (`executeRun`, `executeBranch`, `executeFork`, `executeLoop`, `executeSpawn`, `executeTool`) are `@internal`. The public surface for execution is `execute()`.
+6. Framework utilities (`frameworkCast`, `allocateBudgets`, `checkBudget`, `createLayerStateStore`, lifecycle functions) are `@internal` unless explicitly needed by framework extenders, in which case they are `@unstable` and may be exposed via a dedicated subpath export (e.g. `@noetic/core/unstable`), not the root index.
+7. A `check:exports` script at `scripts/check-export-tags.ts` MUST parse each package's `index.ts`, extract every exported symbol, and fail if any symbol lacks a `@public` or `@unstable` tag in its JSDoc. (`@internal` symbols must not be in `index.ts` at all — their presence is itself a failure.) This script MUST run in CI on every PR.
 
 ---
 
@@ -134,7 +145,7 @@ createOpenRouterEmbed(...)
 3. Deprecations MUST use `@deprecated` JSDoc with the replacement API specified.
 4. Breaking changes MUST include a migration guide in `packages/web/content/docs/migration/`.
 
-### 2.6 Approachability Over Formalism
+### 2.5 Approachability Over Formalism
 
 When a system is internally inspired by a formal pattern (reactive programming, process calculi, actor model), the public API MUST NOT expose that formalism directly. Use the framework's own vocabulary instead of the source pattern's terminology.
 
@@ -142,25 +153,38 @@ When a system is internally inspired by a formal pattern (reactive programming, 
 - Do not name concepts after their theoretical origin when a plain descriptive name is available (`recall` not `observe`, `slot` not `priority`, `layer` not `transformer`).
 - Formal patterns inform implementation and help contributors reason about the system — they are not user-facing concepts and must not appear in docs, error messages, or API names.
 
-### 2.5 Avoiding Breaking Changes
+---
 
-**Pre-1.0 exception: all backward compatibility rules in this section are suspended while any package version is below `1.0.0`.**
+## 2a. Versioning and Stability
 
-Before 1.0, the project is under active internal development and the public API is not stable. Implementation velocity and correctness take full priority over continuity. Specifically:
+This section governs breaking changes, deprecation, and the pre-1.0 policy. It applies specifically to versioning behavior — it does not suspend naming, parameter shape, import, or approachability rules from §2.
+
+### 2a.1 Semver
+
+1. Packages follow semver strictly. A change to a `@public` symbol's type signature, behavior, or removal constitutes a breaking change requiring a major bump.
+2. `@unstable` changes require only a minor bump with a CHANGELOG entry.
+3. Deprecations MUST use `@deprecated` JSDoc with the replacement API specified.
+4. Breaking changes MUST include a migration guide in `packages/web/content/docs/migration/`.
+
+### 2a.2 Pre-1.0 Policy
+
+**While any package version is below `1.0.0`, the stability rules in §2a.1 are suspended.** Before 1.0, the project is under active internal development. Implementation velocity and correctness take full priority over continuity. Specifically:
 
 - **Be aggressive about removing prior implementations.** When a new iteration of an API, type, or behavior is introduced, delete the old one in the same PR. Do not leave the old form around "just in case."
 - **No deprecation shims.** Do not add `@deprecated` wrappers, re-exports, or compatibility aliases for removed APIs.
 - **No migration guides.** Do not write or maintain migration docs for pre-1.0 changes.
-- **No semver major bumps for breaking changes.** Breaking changes in pre-1.0 packages are routine and expected; they do not require a major version bump.
+- **No semver major bumps for breaking changes.** Breaking changes in pre-1.0 packages are routine; they do not require a major version bump.
 - **Delete dead code.** Any code that is no longer reachable or referenced after a change MUST be removed. Unused exports, orphaned types, and leftover helpers are not acceptable.
 
-The rules below take effect at `1.0.0`. At that point, backward compatibility becomes a first-class obligation and this exception no longer applies.
+The rules in §2a.1 take effect at `1.0.0`. At that point, backward compatibility becomes a first-class obligation and this exception no longer applies.
 
-Breaking changes impose upgrade costs on every user of the framework. The strong default is to avoid them.
+### 2a.3 Avoiding Breaking Changes (Post-1.0)
+
+Breaking changes impose upgrade costs on every user. The strong default is to avoid them.
 
 **Prefer introduce-and-deprecate over replace.** When an API needs to change, introduce the new form and mark the old form `@deprecated` with a reference to the replacement. Remove the old form only in the next major version.
 
-**Conflict resolution with other DX guidelines.** Consistency (§2.1–§2.3) is more important than backwards compatibility. When a naming or structural violation must be fixed:
+**Conflict resolution with other DX guidelines.** Consistency (§2.1–§2.5) is more important than backwards compatibility. When a naming or structural violation must be fixed:
 
 1. First, look for a solution that satisfies both — e.g., a type alias, a re-export under the new name, or an overloaded factory that accepts both old and new shapes.
 2. If no such solution exists, ask for guidance before introducing a breaking change. Do not make the call unilaterally.
@@ -236,7 +260,10 @@ Index pages (`api/index.mdx`) MUST enumerate all public symbols with one-line de
 
 1. When a public API changes, its TSDoc and MDX reference entry MUST be updated in the same PR.
 2. The `sync-spec-code-docs.md` rule already enforces spec ↔ code ↔ docs sync; this spec adds TSDoc as a third artifact in that sync obligation.
-3. Example code in docs MUST compile. A `typecheck:docs` script in `packages/web/package.json` MUST type-check all TypeScript code blocks using `tsc --noEmit`. This script MUST run in CI on every PR that touches `packages/web/content/`.
+3. Example code in docs MUST compile. A `typecheck:docs` script in `packages/web/package.json` MUST type-check all TypeScript code blocks:
+   - A companion script at `scripts/extract-doc-snippets.ts` extracts fenced TypeScript code blocks from every `.mdx` file under `packages/web/content/` and writes them as `.ts` stub files under `packages/web/.typecheck-snippets/` (one file per block, with a shared import preamble for `@noetic/core` and `@noetic/eval`).
+   - `typecheck:docs` invokes the extraction script, then runs `tsc --noEmit --project packages/web/tsconfig.snippets.json` against the generated stubs.
+   - This script MUST run in CI on every PR that touches `packages/web/content/`.
 
 ---
 
@@ -265,7 +292,7 @@ The canonical first example MUST:
 - Fit in under 30 lines including imports
 - Be type-checkable without errors on a clean install
 
-The current Getting Started page example (`react()` pattern) meets this bar. Any future revision MUST not exceed it.
+The canonical example is verified by the `typecheck:docs` CI script (§4.3). Any revision MUST remain within the constraints above and MUST remain type-check clean.
 
 ### 5.3 Configuration and Setup Documentation
 
@@ -279,31 +306,11 @@ All configuration required to use Noetic — environment variables, runtime setu
 
 ### 5.4 Error Message Standard
 
-Every error thrown during setup or configuration — including missing env vars, invalid step construction, invalid memory layer config, and runtime misconfiguration — MUST conform to this structure.
+Every error thrown during setup or configuration — including missing env vars, invalid step construction, invalid memory layer config, and runtime misconfiguration — MUST be a `NoeticConfigError`.
 
-`NoeticConfigError` is a **separate class** from `NoeticError` (spec `09-error-model`). `NoeticError` covers execution-time failures (LLM errors, fork failures, spawn errors). `NoeticConfigError` covers pre-execution failures: construction-time validation, missing environment variables, and runtime misconfiguration. The two classes do not share a base class beyond `Error`.
+`NoeticConfigError` is a **separate class** from `NoeticError`. The full class definition, rules, and examples are specified in `09-error-model`. In summary: `NoeticError` covers execution-time failures; `NoeticConfigError` covers pre-execution failures (construction-time validation, missing environment variables, runtime misconfiguration). Every configuration error code MUST appear in `docs/errors.mdx` with an explanation and resolution steps.
 
-```ts
-class NoeticConfigError extends Error {
-  readonly code: string;       // machine-readable, e.g. 'MISSING_API_KEY'
-  readonly hint: string;       // human-readable corrective action
-  readonly docsUrl?: string;   // link to the relevant docs page
-}
-```
-
-Rules:
-1. `code` MUST be a `SCREAMING_SNAKE_CASE` string that uniquely identifies the error condition.
-2. `hint` MUST be a complete sentence that tells the user what to do next. It MUST NOT say "an error occurred."
-3. `docsUrl` SHOULD be provided for any error a new user is likely to hit during setup.
-4. Error messages MUST NOT expose internal stack details, file paths, or implementation class names.
-5. Every error code MUST appear in a doc page (`docs/errors.mdx`) with an explanation and resolution steps.
-
-**Example:**
-```
-NoeticConfigError: Missing required environment variable.
-  code: MISSING_API_KEY
-  hint: Set OPENROUTER_API_KEY in your environment or pass a callModel adapter explicitly. See https://noetic.dev/docs/errors#MISSING_API_KEY
-```
+For DX purposes, the key rule is: every error a new user is likely to encounter during initial setup MUST have a `docsUrl` pointing directly to the resolution steps. Getting-started friction caused by opaque errors is a DX failure.
 
 ---
 
@@ -328,7 +335,7 @@ A custom memory layer guide MUST cover:
 A custom `Runtime` guide MUST cover:
 1. The `Runtime` interface and all required methods
 2. How `AgentConfig` and `AgentHooks` are used during execution
-3. The `setRuntime()` global registration function and its module-load-order implications
+3. The `setRuntime()` global registration function, singleton semantics, and module-load-order implications (see "Runtime Registration" in `08-runtime` for the full specification)
 4. How to write unit tests for a custom runtime using `InMemoryRuntime` as a reference
 5. The recommended pattern for serverless/stateless environments (re-instantiation per invocation)
 
@@ -360,7 +367,12 @@ An implementation guide for a pluggable package MUST cover:
 2. **What the consumer expects** — how `@noetic/core` (or other dependents) imports and calls into the package, so the implementor knows exactly what surface they are providing.
 3. **Registration / wiring** — how to configure Noetic to use the replacement package instead of the default (e.g. package aliasing in `package.json`, a runtime registration call, or a bundler alias).
 4. **Invariants and contracts** — behavioural guarantees the implementation must uphold that are not expressible in TypeScript types alone (e.g. storage key namespacing, budget reporting accuracy, scope isolation).
-5. **The test suite** — a shared conformance test suite that any implementation can run against to verify correctness. Pluggable packages MUST ship a conformance suite importable as `@noetic/<package>/conformance`.
+5. **The test suite** — a shared conformance test suite that any implementation can run against to verify correctness. Pluggable packages MUST ship a conformance suite importable as `@noetic/<package>/conformance`. The suite MUST cover at minimum:
+   - **Lifecycle ordering** — hooks are called in the specified order (e.g. `init` before `recall`, `store` before `dispose`, `onParentUpdate` only for `spawn` not `fork`)
+   - **Scope isolation** — a layer receiving a `narrowed` scope only sees keys matching the declared glob; keys outside the glob are not visible and cannot be written
+   - **Error recovery** — non-fatal hook errors (e.g. a failing `store`) are absorbed per-hook per the error policy; the execution continues and subsequent hooks still run
+   - **Timeout enforcement** — hooks that exceed their timeout are cancelled and treated as the appropriate error category (logged for `store`, thrown for `recall`)
+   - **Concurrent store semantics** — multiple `store` calls in the same lifecycle step are settled via `Promise.allSettled`; one failure does not cancel the others
 6. **A worked reference** — the built-in implementation annotated to explain why each decision was made, so implementors can diverge intentionally rather than accidentally.
 
 ---
@@ -451,6 +463,12 @@ The following symbols are exported without an `@internal` tag but are implementa
 | `api/index.mdx` does not enumerate all public symbols with one-line descriptions | §4.2 |
 | No `@noetic/core/internal` subpath export; internal symbols exposed at root index without `@internal` tags | §1.6 |
 | `@noetic/memory` package does not exist; memory contract and implementations live in `@noetic/core` | `00-overview`, `11-memory-layer-system` |
+
+### Missing CI Scripts
+
+| Gap | Standard violated |
+|---|---|
+| No `check:exports` script (`scripts/check-export-tags.ts`) — internal symbols exposed without visibility tags are not caught in CI | §1.7 |
 | No `typecheck:docs` script in `packages/web/package.json` | §4.3 |
 
 ### Getting Started Gaps


### PR DESCRIPTION
## Summary

- Adds `specs/19-dx.md` defining DX standards for the Noetic project
- Covers two audiences equally: agent authors and framework extenders
- Includes a gap audit appendix of current violations (to be fixed in follow-up PRs)
- Updates supporting specs (`00-overview`, `04-spawn`, `08-runtime`, `09-error-model`, `11-memory-layer-system`) to add concepts referenced by the DX spec

## Sections

- **§1 Export Visibility** — public / `@unstable` / `@internal` tier taxonomy; `@internal` symbols must not appear in `index.ts` at all; `check:exports` CI script requirement
- **§2 API Consistency** — naming conventions, parameter shapes, import paths, approachability over formalism (reactive internals must not leak into public API)
- **§2a Versioning and Stability** — three-part versioning policy:
  - **Pre-1.0**: stability rules suspended; be aggressive about removing prior implementations when introducing new ones; no deprecation shims, no migration guides, no semver major bumps for breaking changes; delete dead code
  - **Post-1.0 (§2a.3)**: prefer introduce-and-deprecate over replace; consistency (§2) takes priority over backward compatibility; escalate to guidance if no compatible solution exists
  - Defines what does and does not count as a breaking change
- **§3 SDK Standards** — TypeScript SDK contract + future language binding contract
- **§4 Documentation Standards** — TSDoc requirements by tier, MDX reference doc completeness, `typecheck:docs` CI script with extraction mechanism (`scripts/extract-doc-snippets.ts`)
- **§5 Getting Started** — prerequisites (TS 5.0+, Node 18+, tsconfig), canonical hello world constraints, error message standard (references `09-error-model` for `NoeticConfigError`)
- **§6 Framework Extender Onboarding** — guides required for custom memory layers, runtime backends (including `setRuntime()` module-load-order), storage adapters, trace exporters, and full pluggable package implementations with conformance test suite requirements
- **§7 @noetic/eval DX** — CLI install, flag documentation, scorer docs, GEPA docs, eval error message standards
- **Appendix: Gap Audit** — snapshot of current violations in `@noetic/core` index exports, naming, missing documentation, and missing CI scripts

## Supporting spec changes

- **`00-overview.md`** — distinguishes current state (2 packages) from target architecture (`@noetic/memory` planned as separate package)
- **`04-spawn.md`** — clarifies `onParentUpdate` is for `spawn` only, not `fork`
- **`08-runtime.md`** — adds Runtime Registration section: `setRuntime()` singleton semantics, `RUNTIME_ALREADY_IN_USE` / `NO_RUNTIME_SET` error codes, module-load-order guidance, test isolation pattern, serverless pattern
- **`09-error-model.md`** — adds `NoeticConfigError` class (construction-time errors, separate from execution-time `NoeticError`): `code`, `hint`, `docsUrl` fields and 6 rules
- **`11-memory-layer-system.md`** — adds reactive-inspired mental model section, `onParentUpdate` hook, `ParentUpdateParams`/`ParentUpdateResult` types; moves narrowed scope to a "Future Considerations" section (not yet designed)

## No implementation in this PR

This is a spec-only PR. Implementation (adding `@internal` tags, TSDoc, framework extender guides, error classes, CI scripts, etc.) will be tracked separately.