### PR TITLE
feat(core): streaming HarnessResult API for execute()

### DIFF
--- a/.claude/skills/noetic-agent-builder/references/api-reference.md
+++ b/.claude/skills/noetic-agent-builder/references/api-reference.md
@@ -393,26 +393,42 @@ Layer functions in `provides` are automatically exposed as tools to any `step.ll
 `AgentHarness` is generic over `TParams`. The `config` property exposes `AgentConfig<TParams>`, and steps/tools access params via `ctx.harness.config.params`.
 
 ```typescript
-// High-level API: pass agent step to constructor, execute with simple inputs
+// High-level API: execute() returns HarnessResult with streaming accessors
 const harness = new AgentHarness({
   name: 'my-agent',
   initialStep: myStep,
   params: { model: 'anthropic/claude-sonnet-4-20250514' },
 });
-const result = await harness.execute('Hello');           // string input
-const result = await harness.execute(messageItem);       // single Item
-const result = await harness.execute([item1, item2]);    // Item[]
-const result = await harness.execute('Hello', {          // with options
+
+// Get final text (simplest usage)
+const text = await harness.execute('Hello').getText();
+
+// Get full response with items, usage, cost
+const response = await harness.execute('Hello').getResponse();
+
+// Stream text deltas as they arrive
+for await (const delta of harness.execute('Hello').getTextStream()) {
+  process.stdout.write(delta);
+}
+
+// Stream all events (SDK + framework)
+for await (const event of harness.execute('Hello').getFullStream()) {
+  console.log(event.source, event.type);
+}
+
+// With options
+const result = harness.execute('Hello', {
   threadId: 'thread-1',
   resourceId: 'user-1',
 });
 
+// Item inputs
+const text2 = await harness.execute(messageItem).getText();
+const text3 = await harness.execute([item1, item2]).getText();
+
 // Low-level API: manual context creation + run()
 const ctx = harness.createContext({ threadId: 'thread-1' });
-const result = await harness.run(step, input, ctx);
-
-// Access config params from context
-// ctx.harness.config.params.model
+const runResult = await harness.run(step, input, ctx);
 
 // Background execution
 const handle = harness.detachedSpawn(step, input, ctx);

--- a/.claude/skills/noetic-agent-builder/references/api-reference.md
+++ b/.claude/skills/noetic-agent-builder/references/api-reference.md
@@ -26,8 +26,11 @@ step.llm<TMemory = ContextMemory, I = unknown, O = unknown>({
   tools?: Tool[];
   output?: ZodType<O>;
   params?: ModelParams;
+  emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
 }): StepLLM<TMemory, I, O>
 ```
+
+`emit` controls framework event emission (default `true`). Set `false` to suppress all, or pass a filter function.
 
 The agent harness assembles the View before calling the model: system message + memory layer items + conversation history. The `system` field becomes a `MessageItem` with `role: system`.
 

--- a/packages/core/src/builders/step-builders.ts
+++ b/packages/core/src/builders/step-builders.ts
@@ -63,6 +63,7 @@ export const step = {
     tools?: Tool[];
     output?: ZodType<O>;
     params?: ModelParams;
+    emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
   }): StepLLM<TMemory, I, O> {
     if (!opts.id || opts.id.trim() === '') {
       throw new NoeticConfigError({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,6 +232,20 @@ export type { MemoryTraceSpan, Span, TraceExporter } from './types/observability
 
 //#endregion
 
+//#region Types — Harness Result
+
+/** @public */
+export type {
+  FrameworkStreamEvent,
+  HarnessResponse,
+  HarnessResult,
+  SdkStreamEvent,
+  StreamEvent,
+  StreamingItem,
+} from './types/harness-result';
+
+//#endregion
+
 //#region Types — Runtime
 
 /** @public */

--- a/packages/core/src/interpreter/execute-llm.ts
+++ b/packages/core/src/interpreter/execute-llm.ts
@@ -51,6 +51,7 @@ export async function executeLLM<TMemory, I, O>(
           tools: allTools,
           params: step.params,
           outputSchema: step.output,
+          emit: step.emit,
           ctx: baseCtx,
           layers,
         }
@@ -59,6 +60,7 @@ export async function executeLLM<TMemory, I, O>(
           items: baseCtx.itemLog.items,
           params: step.params,
           outputSchema: step.output,
+          emit: step.emit,
         };
     const response = await baseCtx.harness.callModel(request);
 

--- a/packages/core/src/interpreter/execute.ts
+++ b/packages/core/src/interpreter/execute.ts
@@ -1,4 +1,5 @@
 import { NoeticErrorImpl } from '../errors/noetic-error';
+import { emitFrameworkEvent, getBroadcaster } from '../runtime/broadcaster-utils';
 import type { Context } from '../types/context';
 import type { ContextMemory } from '../types/memory';
 import type { Step } from '../types/step';
@@ -54,21 +55,42 @@ export async function execute<TMemory = ContextMemory, I = unknown, O = unknown>
     baseCtx.stepCount = (baseCtx.stepCount || 0) + 1;
   }
 
+  // Emit step_started framework event
+  const broadcaster = getBroadcaster(baseCtx);
+  const agentName = baseCtx.harness.config.name;
+  emitFrameworkEvent({
+    broadcaster,
+    agentName,
+    eventType: 'step_started',
+    data: {
+      stepId: step.id,
+      kind: step.kind,
+    },
+  });
+
+  let result: O;
   switch (step.kind) {
     case 'run':
-      return executeRun(step, input, ctx);
+      result = await executeRun(step, input, ctx);
+      break;
     case 'llm':
-      return executeLLM(step, input, ctx, baseCtx.layers);
+      result = await executeLLM(step, input, ctx, baseCtx.layers);
+      break;
     case 'tool':
-      return executeTool(step, input, ctx, baseCtx.harness);
+      result = await executeTool(step, input, ctx, baseCtx.harness);
+      break;
     case 'branch':
-      return executeBranch(step, input, ctx, (s, i, c) => execute(s, i, c));
+      result = await executeBranch(step, input, ctx, (s, i, c) => execute(s, i, c));
+      break;
     case 'fork':
-      return executeFork(step, input, ctx, (s, i, c) => execute(s, i, c));
+      result = await executeFork(step, input, ctx, (s, i, c) => execute(s, i, c));
+      break;
     case 'spawn':
-      return executeSpawn(step, input, ctx, (s, i, c) => execute(s, i, c));
+      result = await executeSpawn(step, input, ctx, (s, i, c) => execute(s, i, c));
+      break;
     case 'loop':
-      return executeLoop(step, input, ctx, (s, i, c) => execute(s, i, c));
+      result = await executeLoop(step, input, ctx, (s, i, c) => execute(s, i, c));
+      break;
     default: {
       const _exhaustive: never = step;
       throw new NoeticErrorImpl({
@@ -79,4 +101,17 @@ export async function execute<TMemory = ContextMemory, I = unknown, O = unknown>
       });
     }
   }
+
+  // Emit step_completed framework event
+  emitFrameworkEvent({
+    broadcaster,
+    agentName,
+    eventType: 'step_completed',
+    data: {
+      stepId: step.id,
+      kind: step.kind,
+    },
+  });
+
+  return result;
 }

--- a/packages/core/src/interpreter/execute.ts
+++ b/packages/core/src/interpreter/execute.ts
@@ -15,6 +15,24 @@ import { isMutableContext } from './typeguards';
 
 const MAX_DEPTH = 64;
 
+/** Check whether a framework event should be emitted for the given step. */
+function shouldEmitEvent(
+  step: {
+    kind: string;
+    emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
+  },
+  eventType: string,
+  data: Record<string, unknown>,
+): boolean {
+  if (step.emit === undefined || step.emit === true) {
+    return true;
+  }
+  if (step.emit === false) {
+    return false;
+  }
+  return step.emit(eventType, data);
+}
+
 /**
  * Executes a step within the interpreter, dispatching to the appropriate handler by step kind.
  *
@@ -55,18 +73,21 @@ export async function execute<TMemory = ContextMemory, I = unknown, O = unknown>
     baseCtx.stepCount = (baseCtx.stepCount || 0) + 1;
   }
 
-  // Emit step_started framework event
+  // Emit step_started framework event (respects step.emit option)
   const broadcaster = getBroadcaster(baseCtx);
   const agentName = baseCtx.harness.config.name;
-  emitFrameworkEvent({
-    broadcaster,
-    agentName,
-    eventType: 'step_started',
-    data: {
-      stepId: step.id,
-      kind: step.kind,
-    },
-  });
+  const startedData = {
+    stepId: step.id,
+    kind: step.kind,
+  };
+  if (shouldEmitEvent(step, 'step_started', startedData)) {
+    emitFrameworkEvent({
+      broadcaster,
+      agentName,
+      eventType: 'step_started',
+      data: startedData,
+    });
+  }
 
   let result: O;
   switch (step.kind) {
@@ -102,16 +123,19 @@ export async function execute<TMemory = ContextMemory, I = unknown, O = unknown>
     }
   }
 
-  // Emit step_completed framework event
-  emitFrameworkEvent({
-    broadcaster,
-    agentName,
-    eventType: 'step_completed',
-    data: {
-      stepId: step.id,
-      kind: step.kind,
-    },
-  });
+  // Emit step_completed framework event (respects step.emit option)
+  const completedData = {
+    stepId: step.id,
+    kind: step.kind,
+  };
+  if (shouldEmitEvent(step, 'step_completed', completedData)) {
+    emitFrameworkEvent({
+      broadcaster,
+      agentName,
+      eventType: 'step_completed',
+      data: completedData,
+    });
+  }
 
   return result;
 }

--- a/packages/core/src/interpreter/execute.ts
+++ b/packages/core/src/interpreter/execute.ts
@@ -1,5 +1,5 @@
 import { NoeticErrorImpl } from '../errors/noetic-error';
-import { emitFrameworkEvent, getBroadcaster } from '../runtime/broadcaster-utils';
+import { emitFrameworkEvent, getBroadcaster, shouldEmit } from '../runtime/broadcaster-utils';
 import type { Context } from '../types/context';
 import type { ContextMemory } from '../types/memory';
 import type { Step } from '../types/step';
@@ -14,24 +14,6 @@ import { frameworkCast } from './framework-cast';
 import { isMutableContext } from './typeguards';
 
 const MAX_DEPTH = 64;
-
-/** Check whether a framework event should be emitted for the given step. */
-function shouldEmitEvent(
-  step: {
-    kind: string;
-    emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
-  },
-  eventType: string,
-  data: Record<string, unknown>,
-): boolean {
-  if (step.emit === undefined || step.emit === true) {
-    return true;
-  }
-  if (step.emit === false) {
-    return false;
-  }
-  return step.emit(eventType, data);
-}
 
 /**
  * Executes a step within the interpreter, dispatching to the appropriate handler by step kind.
@@ -80,7 +62,8 @@ export async function execute<TMemory = ContextMemory, I = unknown, O = unknown>
     stepId: step.id,
     kind: step.kind,
   };
-  if (shouldEmitEvent(step, 'step_started', startedData)) {
+  const emit = 'emit' in step ? step.emit : undefined;
+  if (shouldEmit(emit, 'step_started', startedData)) {
     emitFrameworkEvent({
       broadcaster,
       agentName,
@@ -128,7 +111,7 @@ export async function execute<TMemory = ContextMemory, I = unknown, O = unknown>
     stepId: step.id,
     kind: step.kind,
   };
-  if (shouldEmitEvent(step, 'step_completed', completedData)) {
+  if (shouldEmit(emit, 'step_completed', completedData)) {
     emitFrameworkEvent({
       broadcaster,
       agentName,

--- a/packages/core/src/interpreter/execute.ts
+++ b/packages/core/src/interpreter/execute.ts
@@ -62,7 +62,7 @@ export async function execute<TMemory = ContextMemory, I = unknown, O = unknown>
     stepId: step.id,
     kind: step.kind,
   };
-  const emit = 'emit' in step ? step.emit : undefined;
+  const emit = step.kind === 'llm' ? step.emit : undefined;
   if (shouldEmit(emit, 'step_started', startedData)) {
     emitFrameworkEvent({
       broadcaster,

--- a/packages/core/src/interpreter/message-helpers.ts
+++ b/packages/core/src/interpreter/message-helpers.ts
@@ -46,6 +46,7 @@ export function trackUsage(ctx: Context, response: LLMResponse): void {
   ctx.tokens.input += response.usage.inputTokens;
   ctx.tokens.output += response.usage.outputTokens;
   ctx.tokens.total += response.usage.inputTokens + response.usage.outputTokens;
+  ctx.tokens.cached = (ctx.tokens.cached ?? 0) + (response.usage.cachedTokens ?? 0);
   if (response.cost) {
     ctx.cost = ctx.cost + response.cost;
   }

--- a/packages/core/src/runtime/agent-harness.ts
+++ b/packages/core/src/runtime/agent-harness.ts
@@ -99,30 +99,54 @@ function buildTextFormat(schema: ZodType): {
   };
 }
 
+function isStreamRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+type EmitOption = boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
+
+/** Check whether a framework event should be emitted, respecting the emit option from CallModelRequest. */
+function shouldEmitCallModelEvent(
+  emit: EmitOption | undefined,
+  eventType: string,
+  data: Record<string, unknown>,
+): boolean {
+  if (emit === undefined || emit === true) {
+    return true;
+  }
+  if (emit === false) {
+    return false;
+  }
+  return emit(eventType, data);
+}
+
 async function pipeStreamEventsToBroadcaster(
   stream: AsyncIterable<unknown>,
   broadcaster: EventBroadcaster,
+  agentName: string,
 ): Promise<void> {
   try {
     for await (const event of stream) {
-      if (!event || typeof event !== 'object') {
+      if (!isStreamRecord(event)) {
         continue;
       }
-      // Use structuredClone if available, fallback to JSON round-trip
-      const record =
-        typeof structuredClone !== 'undefined'
-          ? structuredClone(event)
-          : JSON.parse(JSON.stringify(event));
       broadcaster.emit({
         source: 'sdk',
-        type: typeof record.type === 'string' ? record.type : 'unknown',
-        data: record,
-        outputIndex: typeof record.outputIndex === 'number' ? record.outputIndex : undefined,
-        contentIndex: typeof record.contentIndex === 'number' ? record.contentIndex : undefined,
+        type: typeof event.type === 'string' ? event.type : 'unknown',
+        data: event,
+        outputIndex: typeof event.outputIndex === 'number' ? event.outputIndex : undefined,
+        contentIndex: typeof event.contentIndex === 'number' ? event.contentIndex : undefined,
       });
     }
-  } catch {
-    // Stream errors are handled by the response promise
+  } catch (err: unknown) {
+    emitFrameworkEvent({
+      broadcaster,
+      agentName,
+      eventType: 'stream_pipe_error',
+      data: {
+        error: err instanceof Error ? err.message : String(err),
+      },
+    });
   }
 }
 
@@ -181,6 +205,18 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
     const broadcaster = getBroadcaster(request.ctx);
     const agentName = this.config.name;
 
+    /** Emit a framework event, respecting request.emit filter. */
+    const emitIfAllowed = (eventType: string, data: Record<string, unknown>): void => {
+      if (shouldEmitCallModelEvent(request.emit, eventType, data)) {
+        emitFrameworkEvent({
+          broadcaster,
+          agentName,
+          eventType,
+          data,
+        });
+      }
+    };
+
     let sdkTools: ReturnType<typeof convertTools> | undefined;
     if (request.tools && request.tools.length > 0) {
       sdkTools = convertTools({
@@ -216,11 +252,12 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
       });
 
       // Pipe SDK stream events through the broadcaster if available
-      if (broadcaster) {
-        void pipeStreamEventsToBroadcaster(callResult.getFullResponsesStream(), broadcaster);
-      }
+      const pipePromise = broadcaster
+        ? pipeStreamEventsToBroadcaster(callResult.getFullResponsesStream(), broadcaster, agentName)
+        : undefined;
 
       const sdkResponse = await callResult.getResponse();
+      await pipePromise;
       const roundItems = responseToNoeticItems(sdkResponse);
       const roundUsage = extractUsage(sdkResponse.usage);
 
@@ -237,14 +274,9 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
       }
 
       // Emit tool round framework event
-      emitFrameworkEvent({
-        broadcaster,
-        agentName,
-        eventType: 'tool_round_started',
-        data: {
-          round,
-          toolCount: functionCalls.length,
-        },
+      emitIfAllowed('tool_round_started', {
+        round,
+        toolCount: functionCalls.length,
       });
 
       // Add function calls to conversation, then execute and append results
@@ -259,14 +291,9 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
       }
 
       for (const fc of functionCalls) {
-        emitFrameworkEvent({
-          broadcaster,
-          agentName,
-          eventType: 'tool_call_started',
-          data: {
-            name: fc.name,
-            callId: fc.callId,
-          },
+        emitIfAllowed('tool_call_started', {
+          name: fc.name,
+          callId: fc.callId,
         });
 
         let parsedArgs: unknown;
@@ -286,15 +313,10 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
             callId: fc.callId,
             output: errorOutput,
           });
-          emitFrameworkEvent({
-            broadcaster,
-            agentName,
-            eventType: 'tool_call_completed',
-            data: {
-              name: fc.name,
-              callId: fc.callId,
-              error: true,
-            },
+          emitIfAllowed('tool_call_completed', {
+            name: fc.name,
+            callId: fc.callId,
+            error: true,
           });
           continue;
         }
@@ -321,17 +343,17 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
           output,
         });
 
-        emitFrameworkEvent({
-          broadcaster,
-          agentName,
-          eventType: 'tool_call_completed',
-          data: {
-            name: fc.name,
-            callId: fc.callId,
-            error: false,
-          },
+        emitIfAllowed('tool_call_completed', {
+          name: fc.name,
+          callId: fc.callId,
+          error: false,
         });
       }
+
+      emitIfAllowed('tool_round_completed', {
+        round,
+        toolCount: functionCalls.length,
+      });
     }
 
     return {

--- a/packages/core/src/runtime/agent-harness.ts
+++ b/packages/core/src/runtime/agent-harness.ts
@@ -27,6 +27,7 @@ import type { Channel, ChannelHandle, ExternalChannel } from '../types/channel';
 import type { LLMResponse, LlmProviderConfig } from '../types/common';
 import type { Context } from '../types/context';
 import type { DetachedHandle } from '../types/detached';
+import type { HarnessResult } from '../types/harness-result';
 import type { ExecuteInput, Item } from '../types/items';
 import type { ContextMemory, ExecutionContext, MemoryLayer, StorageAdapter } from '../types/memory';
 import type { Span, TraceExporter } from '../types/observability';
@@ -41,10 +42,13 @@ import type {
 import type { SteeringDecision } from '../types/steering';
 import { SteeringAction } from '../types/steering';
 import type { Step } from '../types/step';
+import { emitFrameworkEvent, getBroadcaster } from './broadcaster-utils';
 import { ChannelStore } from './channel-store';
 import { ContextImpl } from './context-impl';
 import { DetachedHandleImpl } from './detached-handle';
+import { EventBroadcaster } from './event-broadcaster';
 import { contextToExecCtx } from './exec-context-factory';
+import { HarnessResultImpl } from './harness-result';
 
 //#region Types
 
@@ -93,6 +97,33 @@ function buildTextFormat(schema: ZodType): {
       schema: jsonSchema,
     },
   };
+}
+
+async function pipeStreamEventsToBroadcaster(
+  stream: AsyncIterable<unknown>,
+  broadcaster: EventBroadcaster,
+): Promise<void> {
+  try {
+    for await (const event of stream) {
+      if (!event || typeof event !== 'object') {
+        continue;
+      }
+      // Use structuredClone if available, fallback to JSON round-trip
+      const record =
+        typeof structuredClone !== 'undefined'
+          ? structuredClone(event)
+          : JSON.parse(JSON.stringify(event));
+      broadcaster.emit({
+        source: 'sdk',
+        type: typeof record.type === 'string' ? record.type : 'unknown',
+        data: record,
+        outputIndex: typeof record.outputIndex === 'number' ? record.outputIndex : undefined,
+        contentIndex: typeof record.contentIndex === 'number' ? record.contentIndex : undefined,
+      });
+    }
+  } catch {
+    // Stream errors are handled by the response promise
+  }
 }
 
 //#endregion
@@ -147,6 +178,8 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
     }
 
     const { instructions, remaining } = extractSystemInstruction(request.items);
+    const broadcaster = getBroadcaster(request.ctx);
+    const agentName = this.config.name;
 
     let sdkTools: ReturnType<typeof convertTools> | undefined;
     if (request.tools && request.tools.length > 0) {
@@ -182,6 +215,11 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
           : {}),
       });
 
+      // Pipe SDK stream events through the broadcaster if available
+      if (broadcaster) {
+        void pipeStreamEventsToBroadcaster(callResult.getFullResponsesStream(), broadcaster);
+      }
+
       const sdkResponse = await callResult.getResponse();
       const roundItems = responseToNoeticItems(sdkResponse);
       const roundUsage = extractUsage(sdkResponse.usage);
@@ -198,6 +236,17 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
         break;
       }
 
+      // Emit tool round framework event
+      emitFrameworkEvent({
+        broadcaster,
+        agentName,
+        eventType: 'tool_round_started',
+        data: {
+          round,
+          toolCount: functionCalls.length,
+        },
+      });
+
       // Add function calls to conversation, then execute and append results
       for (const fc of functionCalls) {
         conversationInput.push({
@@ -210,6 +259,16 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
       }
 
       for (const fc of functionCalls) {
+        emitFrameworkEvent({
+          broadcaster,
+          agentName,
+          eventType: 'tool_call_started',
+          data: {
+            name: fc.name,
+            callId: fc.callId,
+          },
+        });
+
         let parsedArgs: unknown;
         try {
           parsedArgs = JSON.parse(fc.arguments);
@@ -226,6 +285,16 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
             type: 'function_call_output',
             callId: fc.callId,
             output: errorOutput,
+          });
+          emitFrameworkEvent({
+            broadcaster,
+            agentName,
+            eventType: 'tool_call_completed',
+            data: {
+              name: fc.name,
+              callId: fc.callId,
+              error: true,
+            },
           });
           continue;
         }
@@ -251,6 +320,17 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
           callId: fc.callId,
           output,
         });
+
+        emitFrameworkEvent({
+          broadcaster,
+          agentName,
+          eventType: 'tool_call_completed',
+          data: {
+            name: fc.name,
+            callId: fc.callId,
+            error: false,
+          },
+        });
       }
     }
 
@@ -261,30 +341,49 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
     };
   }
 
-  async execute(input: ExecuteInput, options?: ExecuteOptions): Promise<string> {
+  execute(input: ExecuteInput, options?: ExecuteOptions): HarnessResult {
     if (!this.initialStep) {
-      throw new NoeticConfigError({
-        code: 'NO_STEP_CONFIGURED',
-        message: 'No initialStep configured on this harness.',
-        hint: 'Pass `initialStep` in constructor options, or use run() directly.',
-      });
+      return HarnessResultImpl.fromError(
+        new NoeticConfigError({
+          code: 'NO_STEP_CONFIGURED',
+          message: 'No initialStep configured on this harness.',
+          hint: 'Pass `initialStep` in constructor options, or use run() directly.',
+        }),
+      );
     }
+
+    const broadcaster = new EventBroadcaster();
+
+    let executionPromise: Promise<string>;
+    let ctx: Context;
 
     if (typeof input === 'string') {
-      const ctx = this.createContext(options);
-      return this.run(this.initialStep, input, ctx);
+      ctx = this.createContext({
+        ...options,
+        _broadcaster: broadcaster,
+      });
+      executionPromise = this.run(this.initialStep, input, ctx);
+    } else {
+      const items = Array.isArray(input)
+        ? input
+        : [
+            input,
+          ];
+      ctx = this.createContext({
+        items,
+        ...options,
+        _broadcaster: broadcaster,
+      });
+      executionPromise = this.run(this.initialStep, '', ctx);
     }
 
-    const items = Array.isArray(input)
-      ? input
-      : [
-          input,
-        ];
-    const ctx = this.createContext({
-      items,
-      ...options,
-    });
-    return this.run(this.initialStep, '', ctx);
+    // Complete broadcaster when execution finishes
+    executionPromise.then(
+      () => broadcaster.complete(),
+      (err: unknown) => broadcaster.error(err instanceof Error ? err : new Error(String(err))),
+    );
+
+    return new HarnessResultImpl(broadcaster, executionPromise, ctx);
   }
 
   async run<I, O>(s: Step<ContextMemory, I, O>, input: I, ctx: Context): Promise<O> {
@@ -311,6 +410,7 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
     state?: unknown;
     threadId?: string;
     resourceId?: string;
+    _broadcaster?: EventBroadcaster;
   }): Context {
     return new ContextImpl({
       ...opts,

--- a/packages/core/src/runtime/agent-harness.ts
+++ b/packages/core/src/runtime/agent-harness.ts
@@ -42,7 +42,7 @@ import type {
 import type { SteeringDecision } from '../types/steering';
 import { SteeringAction } from '../types/steering';
 import type { Step } from '../types/step';
-import { emitFrameworkEvent, getBroadcaster } from './broadcaster-utils';
+import { emitFrameworkEvent, getBroadcaster, shouldEmit } from './broadcaster-utils';
 import { ChannelStore } from './channel-store';
 import { ContextImpl } from './context-impl';
 import { DetachedHandleImpl } from './detached-handle';
@@ -103,23 +103,6 @@ function isStreamRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-type EmitOption = boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
-
-/** Check whether a framework event should be emitted, respecting the emit option from CallModelRequest. */
-function shouldEmitCallModelEvent(
-  emit: EmitOption | undefined,
-  eventType: string,
-  data: Record<string, unknown>,
-): boolean {
-  if (emit === undefined || emit === true) {
-    return true;
-  }
-  if (emit === false) {
-    return false;
-  }
-  return emit(eventType, data);
-}
-
 async function pipeStreamEventsToBroadcaster(
   stream: AsyncIterable<unknown>,
   broadcaster: EventBroadcaster,
@@ -147,6 +130,9 @@ async function pipeStreamEventsToBroadcaster(
         error: err instanceof Error ? err.message : String(err),
       },
     });
+    // Re-throw so pipePromise rejects and the error propagates
+    // through the execution promise to broadcaster.error().
+    throw err;
   }
 }
 
@@ -207,7 +193,7 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
 
     /** Emit a framework event, respecting request.emit filter. */
     const emitIfAllowed = (eventType: string, data: Record<string, unknown>): void => {
-      if (shouldEmitCallModelEvent(request.emit, eventType, data)) {
+      if (shouldEmit(request.emit, eventType, data)) {
         emitFrameworkEvent({
           broadcaster,
           agentName,
@@ -251,7 +237,12 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
           : {}),
       });
 
-      // Pipe SDK stream events through the broadcaster if available
+      // The OpenRouter SDK internally tees the HTTP stream, so
+      // getFullResponsesStream() and getResponse() can be consumed
+      // concurrently. Events flow to the broadcaster in real-time while
+      // getResponse() accumulates the final result independently.
+      // `await pipePromise` ensures all events are emitted before
+      // proceeding to tool-round processing.
       const pipePromise = broadcaster
         ? pipeStreamEventsToBroadcaster(callResult.getFullResponsesStream(), broadcaster, agentName)
         : undefined;

--- a/packages/core/src/runtime/broadcaster-utils.ts
+++ b/packages/core/src/runtime/broadcaster-utils.ts
@@ -1,0 +1,47 @@
+import type { Context } from '../types/context';
+import type { EventBroadcaster } from './event-broadcaster';
+
+//#region Type Guards
+
+function hasOwnBroadcaster(ctx: Context): ctx is Context & {
+  _broadcaster: EventBroadcaster;
+} {
+  return '_broadcaster' in ctx && ctx._broadcaster !== undefined && ctx._broadcaster !== null;
+}
+
+//#endregion
+
+//#region Public API
+
+/**
+ * Get the EventBroadcaster from a context if available.
+ * @internal
+ */
+export function getBroadcaster(ctx?: Context): EventBroadcaster | undefined {
+  if (!ctx) {
+    return undefined;
+  }
+  if (hasOwnBroadcaster(ctx)) {
+    return ctx._broadcaster;
+  }
+  return undefined;
+}
+
+/**
+ * Emit a framework event to the broadcaster if available.
+ * @internal
+ */
+export function emitFrameworkEvent(opts: {
+  broadcaster: EventBroadcaster | undefined;
+  agentName: string;
+  eventType: string;
+  data: Record<string, unknown>;
+}): void {
+  opts.broadcaster?.emit({
+    source: 'framework',
+    type: `${opts.agentName}:${opts.eventType}`,
+    data: opts.data,
+  });
+}
+
+//#endregion

--- a/packages/core/src/runtime/broadcaster-utils.ts
+++ b/packages/core/src/runtime/broadcaster-utils.ts
@@ -1,20 +1,58 @@
 import type { Context } from '../types/context';
-import { ContextImpl } from './context-impl';
 import type { EventBroadcaster } from './event-broadcaster';
+
+//#region Types
+
+/** @internal Option controlling framework event emission on a step or callModel request. */
+export type EmitOption = boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
+
+//#endregion
 
 //#region Public API
 
 /**
+ * Check whether a framework event should be emitted given an emit option.
+ *
+ * When `emit` is `undefined` (the default for non-LLM steps where the
+ * field does not exist on the Step type), events are always emitted.
+ * Only StepLLM exposes `emit` for opt-out or filtering.
+ *
+ * @internal
+ */
+export function shouldEmit(
+  emit: EmitOption | undefined,
+  eventType: string,
+  data: Record<string, unknown>,
+): boolean {
+  if (emit === undefined || emit === true) {
+    return true;
+  }
+  if (emit === false) {
+    return false;
+  }
+  return emit(eventType, data);
+}
+
+/** Typeguard: context carries an internal _broadcaster property. */
+function hasBroadcaster(ctx: Context): ctx is Context & {
+  _broadcaster: EventBroadcaster;
+} {
+  if (!('_broadcaster' in ctx)) {
+    return false;
+  }
+  return typeof ctx._broadcaster === 'object' && ctx._broadcaster !== null;
+}
+
+/**
  * Get the EventBroadcaster from a context if available.
- * Uses instanceof ContextImpl rather than `in` operator to avoid
- * leaking the internal `_broadcaster` property through type guards.
+ * Uses property check rather than instanceof to support mock contexts in tests.
  * @internal
  */
 export function getBroadcaster(ctx?: Context): EventBroadcaster | undefined {
   if (!ctx) {
     return undefined;
   }
-  if (ctx instanceof ContextImpl) {
+  if (hasBroadcaster(ctx)) {
     return ctx._broadcaster;
   }
   return undefined;

--- a/packages/core/src/runtime/broadcaster-utils.ts
+++ b/packages/core/src/runtime/broadcaster-utils.ts
@@ -1,27 +1,20 @@
 import type { Context } from '../types/context';
+import { ContextImpl } from './context-impl';
 import type { EventBroadcaster } from './event-broadcaster';
-
-//#region Type Guards
-
-function hasOwnBroadcaster(ctx: Context): ctx is Context & {
-  _broadcaster: EventBroadcaster;
-} {
-  return '_broadcaster' in ctx && ctx._broadcaster !== undefined && ctx._broadcaster !== null;
-}
-
-//#endregion
 
 //#region Public API
 
 /**
  * Get the EventBroadcaster from a context if available.
+ * Uses instanceof ContextImpl rather than `in` operator to avoid
+ * leaking the internal `_broadcaster` property through type guards.
  * @internal
  */
 export function getBroadcaster(ctx?: Context): EventBroadcaster | undefined {
   if (!ctx) {
     return undefined;
   }
-  if (hasOwnBroadcaster(ctx)) {
+  if (ctx instanceof ContextImpl) {
     return ctx._broadcaster;
   }
   return undefined;

--- a/packages/core/src/runtime/context-impl.ts
+++ b/packages/core/src/runtime/context-impl.ts
@@ -7,6 +7,7 @@ import type { ContextMemory, MemoryLayer } from '../types/memory';
 import type { Span } from '../types/observability';
 import type { AgentHarnessContract } from '../types/runtime';
 import type { ChannelStore } from './channel-store';
+import type { EventBroadcaster } from './event-broadcaster';
 import { ItemLogImpl } from './item-log-impl';
 
 const EMPTY_MEMORY: ContextMemory = Object.freeze({});
@@ -40,6 +41,9 @@ export class ContextImpl implements Context<ContextMemory> {
   readonly harness: AgentHarnessContract;
   readonly layers?: MemoryLayer[];
 
+  /** @internal Event broadcaster for streaming — not part of public Context interface. */
+  readonly _broadcaster?: EventBroadcaster;
+
   private readonly _createdAt: number;
   private readonly channelStore?: ChannelStore;
   private _checkpointFn?: () => Promise<void>;
@@ -60,6 +64,7 @@ export class ContextImpl implements Context<ContextMemory> {
     channelStore?: ChannelStore;
     checkpointFn?: () => Promise<void>;
     layers?: MemoryLayer[];
+    _broadcaster?: EventBroadcaster;
   }) {
     this.id = crypto.randomUUID();
     this._createdAt = Date.now();
@@ -73,6 +78,7 @@ export class ContextImpl implements Context<ContextMemory> {
     this.channelStore = opts.channelStore;
     this._checkpointFn = opts.checkpointFn;
     this.layers = opts.layers;
+    this._broadcaster = opts._broadcaster;
 
     const log = new ItemLogImpl();
     if (opts.items) {

--- a/packages/core/src/runtime/event-broadcaster.ts
+++ b/packages/core/src/runtime/event-broadcaster.ts
@@ -185,6 +185,12 @@ class BroadcastIterator implements AsyncIterator<StreamEvent> {
     });
   }
 
+  async throw(err: Error): Promise<IteratorResult<StreamEvent>> {
+    this.returned = true;
+    this.broadcaster.removeIterator(this);
+    throw err;
+  }
+
   async return(): Promise<IteratorResult<StreamEvent>> {
     this.returned = true;
     this.broadcaster.removeIterator(this);

--- a/packages/core/src/runtime/event-broadcaster.ts
+++ b/packages/core/src/runtime/event-broadcaster.ts
@@ -1,0 +1,171 @@
+import type { StreamEvent } from '../types/harness-result';
+
+//#region Types
+
+interface Waiter {
+  resolve: (result: IteratorResult<StreamEvent>) => void;
+}
+
+//#endregion
+
+//#region EventBroadcaster
+
+/**
+ * Multi-consumer broadcast channel with replay support for streaming events.
+ *
+ * Each consumer gets an independent iterator that replays buffered events
+ * from the start, then receives new events as they are emitted.
+ *
+ * @internal
+ */
+export class EventBroadcaster {
+  private readonly buffer: StreamEvent[] = [];
+  private isDone = false;
+  private err?: Error;
+  private readonly iterators: Set<BroadcastIterator> = new Set();
+
+  /** Push an event to all active iterators and the replay buffer. */
+  emit(event: StreamEvent): void {
+    if (this.isDone) {
+      return;
+    }
+    this.buffer.push(event);
+    for (const iter of this.iterators) {
+      iter.notify();
+    }
+  }
+
+  /** Signal that no more events will be emitted. */
+  complete(): void {
+    if (this.isDone) {
+      return;
+    }
+    this.isDone = true;
+    for (const iter of this.iterators) {
+      iter.notify();
+    }
+  }
+
+  /** Signal an error to all consumers. */
+  error(err: Error): void {
+    if (this.isDone) {
+      return;
+    }
+    this.isDone = true;
+    this.err = err;
+    for (const iter of this.iterators) {
+      iter.notify();
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+    const iter = new BroadcastIterator(this);
+    this.iterators.add(iter);
+    return iter;
+  }
+
+  /** @internal Access the buffer for iterators. */
+  getBuffer(): ReadonlyArray<StreamEvent> {
+    return this.buffer;
+  }
+
+  /** @internal Check if the broadcaster is finished. */
+  get finished(): boolean {
+    return this.isDone;
+  }
+
+  /** @internal Get the error if any. */
+  get streamError(): Error | undefined {
+    return this.err;
+  }
+
+  /** @internal Remove an iterator from the set. */
+  removeIterator(iter: BroadcastIterator): void {
+    this.iterators.delete(iter);
+  }
+}
+
+//#endregion
+
+//#region BroadcastIterator
+
+class BroadcastIterator implements AsyncIterator<StreamEvent> {
+  private cursor = 0;
+  private waiter?: Waiter;
+  private returned = false;
+  private readonly broadcaster: EventBroadcaster;
+
+  constructor(broadcaster: EventBroadcaster) {
+    this.broadcaster = broadcaster;
+  }
+
+  /** Called by the broadcaster when new data or completion is available. */
+  notify(): void {
+    if (!this.waiter) {
+      return;
+    }
+    const w = this.waiter;
+    this.waiter = undefined;
+    const result = this.tryRead();
+    if (result) {
+      w.resolve(result);
+    }
+  }
+
+  async next(): Promise<IteratorResult<StreamEvent>> {
+    if (this.returned) {
+      return {
+        done: true,
+        value: undefined,
+      };
+    }
+    const result = this.tryRead();
+    if (result) {
+      return result;
+    }
+
+    return new Promise<IteratorResult<StreamEvent>>((resolve) => {
+      this.waiter = {
+        resolve,
+      };
+    });
+  }
+
+  async return(): Promise<IteratorResult<StreamEvent>> {
+    this.returned = true;
+    this.broadcaster.removeIterator(this);
+    return {
+      done: true,
+      value: undefined,
+    };
+  }
+
+  private tryRead(): IteratorResult<StreamEvent> | null {
+    const buffer = this.broadcaster.getBuffer();
+
+    if (this.cursor < buffer.length) {
+      const event = buffer[this.cursor];
+      this.cursor++;
+      return {
+        done: false,
+        value: event,
+      };
+    }
+
+    if (this.broadcaster.finished) {
+      this.broadcaster.removeIterator(this);
+      const err = this.broadcaster.streamError;
+      if (err) {
+        throw err;
+      }
+      return {
+        done: true,
+        value: undefined,
+      };
+    }
+
+    return null;
+  }
+}
+
+//#endregion

--- a/packages/core/src/runtime/event-broadcaster.ts
+++ b/packages/core/src/runtime/event-broadcaster.ts
@@ -4,9 +4,16 @@ import type { StreamEvent } from '../types/harness-result';
 
 interface Waiter {
   resolve: (result: IteratorResult<StreamEvent>) => void;
+  reject: (err: unknown) => void;
+}
+
+interface EventBroadcasterOpts {
+  maxBufferSize?: number;
 }
 
 //#endregion
+
+const DEFAULT_MAX_BUFFER_SIZE = 1e4;
 
 //#region EventBroadcaster
 
@@ -16,20 +23,48 @@ interface Waiter {
  * Each consumer gets an independent iterator that replays buffered events
  * from the start, then receives new events as they are emitted.
  *
+ * The buffer is bounded to `maxBufferSize` events (default 10,000). When the
+ * buffer exceeds this limit, oldest events are trimmed and iterator cursors
+ * are adjusted. Once all consumers have departed, new events are discarded
+ * to prevent unbounded memory growth.
+ *
  * @internal
  */
 export class EventBroadcaster {
   private readonly buffer: StreamEvent[] = [];
+  private readonly maxBufferSize: number;
   private isDone = false;
   private err?: Error;
   private readonly iterators: Set<BroadcastIterator> = new Set();
+  private hasHadConsumers = false;
+
+  constructor(opts?: EventBroadcasterOpts) {
+    this.maxBufferSize = opts?.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
+  }
 
   /** Push an event to all active iterators and the replay buffer. */
   emit(event: StreamEvent): void {
     if (this.isDone) {
       return;
     }
+
+    // Skip buffering when all consumers have departed
+    if (this.hasHadConsumers && this.iterators.size === 0) {
+      return;
+    }
+
     this.buffer.push(event);
+
+    // Trim buffer if it exceeds max size
+    if (this.buffer.length > this.maxBufferSize) {
+      const trimCount = this.buffer.length - this.maxBufferSize;
+      this.buffer.splice(0, trimCount);
+      // Adjust all active iterator cursors
+      for (const iter of this.iterators) {
+        iter.adjustCursor(trimCount);
+      }
+    }
+
     for (const iter of this.iterators) {
       iter.notify();
     }
@@ -59,6 +94,7 @@ export class EventBroadcaster {
   }
 
   [Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+    this.hasHadConsumers = true;
     const iter = new BroadcastIterator(this);
     this.iterators.add(iter);
     return iter;
@@ -83,6 +119,11 @@ export class EventBroadcaster {
   removeIterator(iter: BroadcastIterator): void {
     this.iterators.delete(iter);
   }
+
+  /** @internal Current buffer length (for testing). */
+  get bufferSize(): number {
+    return this.buffer.length;
+  }
 }
 
 //#endregion
@@ -99,6 +140,11 @@ class BroadcastIterator implements AsyncIterator<StreamEvent> {
     this.broadcaster = broadcaster;
   }
 
+  /** Adjust cursor when buffer is trimmed. */
+  adjustCursor(trimCount: number): void {
+    this.cursor = Math.max(0, this.cursor - trimCount);
+  }
+
   /** Called by the broadcaster when new data or completion is available. */
   notify(): void {
     if (!this.waiter) {
@@ -106,9 +152,14 @@ class BroadcastIterator implements AsyncIterator<StreamEvent> {
     }
     const w = this.waiter;
     this.waiter = undefined;
-    const result = this.tryRead();
-    if (result) {
-      w.resolve(result);
+    try {
+      const result = this.tryRead();
+      if (result) {
+        w.resolve(result);
+      }
+    } catch (err: unknown) {
+      // Reject the waiter's promise so the error propagates through the async iterator
+      w.reject(err);
     }
   }
 
@@ -124,9 +175,10 @@ class BroadcastIterator implements AsyncIterator<StreamEvent> {
       return result;
     }
 
-    return new Promise<IteratorResult<StreamEvent>>((resolve) => {
+    return new Promise<IteratorResult<StreamEvent>>((resolve, reject) => {
       this.waiter = {
         resolve,
+        reject,
       };
     });
   }

--- a/packages/core/src/runtime/event-broadcaster.ts
+++ b/packages/core/src/runtime/event-broadcaster.ts
@@ -26,7 +26,9 @@ const DEFAULT_MAX_BUFFER_SIZE = 1e4;
  * The buffer is bounded to `maxBufferSize` events (default 10,000). When the
  * buffer exceeds this limit, oldest events are trimmed and iterator cursors
  * are adjusted. Once all consumers have departed, new events are discarded
- * to prevent unbounded memory growth.
+ * to prevent unbounded memory growth. This bounded buffer serves as the
+ * backpressure mechanism — no additional flow control is needed for typical
+ * LLM response sizes.
  *
  * @internal
  */

--- a/packages/core/src/runtime/harness-result.ts
+++ b/packages/core/src/runtime/harness-result.ts
@@ -1,0 +1,341 @@
+import type { Context } from '../types/context';
+import type {
+  HarnessResponse,
+  HarnessResult,
+  StreamEvent,
+  StreamingItem,
+} from '../types/harness-result';
+import type { EventBroadcaster } from './event-broadcaster';
+
+//#region Types
+
+/** Mutable message item used internally for accumulation. */
+interface MutableMessageItem {
+  id: string;
+  type: 'message';
+  role: 'assistant';
+  status: 'in_progress' | 'completed';
+  content: Array<{
+    type: 'output_text';
+    text: string;
+  }>;
+}
+
+/** Mutable function call item used internally for accumulation. */
+interface MutableFunctionCallItem {
+  id: string;
+  type: 'function_call';
+  status: 'in_progress' | 'completed';
+  callId: string;
+  name: string;
+  arguments: string;
+}
+
+type MutableItem = MutableMessageItem | MutableFunctionCallItem;
+
+interface ItemAccumulator {
+  id: string;
+  item: MutableItem;
+  isComplete: boolean;
+}
+
+//#endregion
+
+//#region Helper Functions
+
+function buildHarnessResponse(text: string, ctx: Context): HarnessResponse {
+  return {
+    items: ctx.itemLog.items,
+    usage: {
+      inputTokens: ctx.tokens.input,
+      outputTokens: ctx.tokens.output,
+    },
+    cost: ctx.cost > 0 ? ctx.cost : undefined,
+    text,
+  };
+}
+
+async function* filterTextStream(broadcaster: EventBroadcaster): AsyncIterable<string> {
+  for await (const event of broadcaster) {
+    if (event.source !== 'sdk' || event.type !== 'response.output_text.delta') {
+      continue;
+    }
+    const delta = event.data.delta;
+    if (typeof delta === 'string') {
+      yield delta;
+    }
+  }
+}
+
+async function* filterReasoningStream(broadcaster: EventBroadcaster): AsyncIterable<string> {
+  for await (const event of broadcaster) {
+    if (event.source !== 'sdk' || event.type !== 'response.reasoning.delta') {
+      continue;
+    }
+    const delta = event.data.delta;
+    if (typeof delta === 'string') {
+      yield delta;
+    }
+  }
+}
+
+function updateMessageAccumulator(acc: ItemAccumulator, event: StreamEvent): void {
+  if (event.source !== 'sdk') {
+    return;
+  }
+  if (event.type === 'response.output_text.delta' && typeof event.data.delta === 'string') {
+    const msg = acc.item;
+    if (msg.type !== 'message') {
+      return;
+    }
+    const lastPart = msg.content[msg.content.length - 1];
+    if (lastPart) {
+      lastPart.text += event.data.delta;
+    }
+  }
+  if (event.type === 'response.output_text.done') {
+    acc.isComplete = true;
+  }
+}
+
+function updateFunctionCallAccumulator(acc: ItemAccumulator, event: StreamEvent): void {
+  if (event.source !== 'sdk') {
+    return;
+  }
+  if (
+    event.type === 'response.function_call_arguments.delta' &&
+    typeof event.data.delta === 'string'
+  ) {
+    const fc = acc.item;
+    if (fc.type !== 'function_call') {
+      return;
+    }
+    fc.arguments += event.data.delta;
+  }
+  if (event.type === 'response.function_call_arguments.done') {
+    acc.isComplete = true;
+  }
+}
+
+function isItemRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && 'type' in value;
+}
+
+function createAccumulatorFromItemAdded(event: StreamEvent): ItemAccumulator | null {
+  if (event.source !== 'sdk' || event.type !== 'response.output_item.added') {
+    return null;
+  }
+  if (!isItemRecord(event.data.item)) {
+    return null;
+  }
+  const itemData = event.data.item;
+  const id = typeof itemData.id === 'string' ? itemData.id : crypto.randomUUID();
+
+  if (itemData.type === 'message') {
+    return {
+      id,
+      item: {
+        id,
+        type: 'message',
+        role: 'assistant',
+        status: 'in_progress',
+        content: [
+          {
+            type: 'output_text',
+            text: '',
+          },
+        ],
+      },
+      isComplete: false,
+    };
+  }
+
+  if (itemData.type === 'function_call') {
+    return {
+      id,
+      item: {
+        id,
+        type: 'function_call',
+        status: 'in_progress',
+        callId: typeof itemData.callId === 'string' ? itemData.callId : '',
+        name: typeof itemData.name === 'string' ? itemData.name : '',
+        arguments: '',
+      },
+      isComplete: false,
+    };
+  }
+
+  return null;
+}
+
+async function* buildItemStream(broadcaster: EventBroadcaster): AsyncIterable<StreamingItem> {
+  const accumulators = new Map<number, ItemAccumulator>();
+
+  for await (const event of broadcaster) {
+    if (event.source !== 'sdk') {
+      continue;
+    }
+
+    // New output item added
+    if (event.type === 'response.output_item.added') {
+      const outputIndex =
+        typeof event.outputIndex === 'number' ? event.outputIndex : accumulators.size;
+      const acc = createAccumulatorFromItemAdded(event);
+      if (acc) {
+        accumulators.set(outputIndex, acc);
+        yield {
+          ...acc.item,
+          isComplete: false,
+        };
+      }
+      continue;
+    }
+
+    // Output item done
+    if (event.type === 'response.output_item.done') {
+      const outputIndex = typeof event.outputIndex === 'number' ? event.outputIndex : -1;
+      const acc = accumulators.get(outputIndex);
+      if (acc) {
+        acc.isComplete = true;
+        yield {
+          ...acc.item,
+          status: 'completed',
+          isComplete: true,
+        };
+      }
+      continue;
+    }
+
+    // Text delta
+    if (event.type === 'response.output_text.delta' || event.type === 'response.output_text.done') {
+      const outputIndex = typeof event.outputIndex === 'number' ? event.outputIndex : 0;
+      const acc = accumulators.get(outputIndex);
+      if (acc) {
+        updateMessageAccumulator(acc, event);
+        yield {
+          ...acc.item,
+          isComplete: acc.isComplete,
+        };
+      }
+      continue;
+    }
+
+    // Function call argument delta
+    if (
+      event.type === 'response.function_call_arguments.delta' ||
+      event.type === 'response.function_call_arguments.done'
+    ) {
+      const outputIndex = typeof event.outputIndex === 'number' ? event.outputIndex : 0;
+      const acc = accumulators.get(outputIndex);
+      if (acc) {
+        updateFunctionCallAccumulator(acc, event);
+        yield {
+          ...acc.item,
+          isComplete: acc.isComplete,
+        };
+      }
+    }
+  }
+}
+
+/** Creates an AsyncIterable that throws on first iteration. */
+function errorIterable<T>(err: Error): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+      return {
+        next(): Promise<IteratorResult<T>> {
+          return Promise.reject(err);
+        },
+      };
+    },
+  };
+}
+
+//#endregion
+
+//#region HarnessResultImpl
+
+/**
+ * Implementation of HarnessResult that wraps an EventBroadcaster and execution promise.
+ *
+ * @internal
+ */
+export class HarnessResultImpl implements HarnessResult {
+  private readonly broadcaster: EventBroadcaster;
+  private readonly executionPromise: Promise<string>;
+  private readonly ctx: Context;
+
+  constructor(broadcaster: EventBroadcaster, executionPromise: Promise<string>, ctx: Context) {
+    this.broadcaster = broadcaster;
+    this.executionPromise = executionPromise;
+    this.ctx = ctx;
+  }
+
+  async getText(): Promise<string> {
+    return this.executionPromise;
+  }
+
+  async getResponse(): Promise<HarnessResponse> {
+    const text = await this.executionPromise;
+    return buildHarnessResponse(text, this.ctx);
+  }
+
+  getTextStream(): AsyncIterable<string> {
+    return filterTextStream(this.broadcaster);
+  }
+
+  getReasoningStream(): AsyncIterable<string> {
+    return filterReasoningStream(this.broadcaster);
+  }
+
+  getItemStream(): AsyncIterable<StreamingItem> {
+    return buildItemStream(this.broadcaster);
+  }
+
+  getFullStream(): AsyncIterable<StreamEvent> {
+    return this.broadcaster;
+  }
+
+  /** Create a HarnessResult where all accessors reject with the given error. */
+  static fromError(err: Error): HarnessResult {
+    return new ErrorHarnessResult(err);
+  }
+}
+
+//#endregion
+
+//#region ErrorHarnessResult
+
+class ErrorHarnessResult implements HarnessResult {
+  private readonly err: Error;
+
+  constructor(err: Error) {
+    this.err = err;
+  }
+
+  async getText(): Promise<string> {
+    throw this.err;
+  }
+
+  async getResponse(): Promise<HarnessResponse> {
+    throw this.err;
+  }
+
+  getTextStream(): AsyncIterable<string> {
+    return errorIterable(this.err);
+  }
+
+  getReasoningStream(): AsyncIterable<string> {
+    return errorIterable(this.err);
+  }
+
+  getItemStream(): AsyncIterable<StreamingItem> {
+    return errorIterable(this.err);
+  }
+
+  getFullStream(): AsyncIterable<StreamEvent> {
+    return errorIterable(this.err);
+  }
+}
+
+//#endregion

--- a/packages/core/src/runtime/harness-result.ts
+++ b/packages/core/src/runtime/harness-result.ts
@@ -49,6 +49,7 @@ function buildHarnessResponse(text: string, ctx: Context): HarnessResponse {
     usage: {
       inputTokens: ctx.tokens.input,
       outputTokens: ctx.tokens.output,
+      cachedTokens: ctx.tokens.cached && ctx.tokens.cached > 0 ? ctx.tokens.cached : undefined,
     },
     cost: ctx.cost > 0 ? ctx.cost : undefined,
     text,
@@ -169,12 +170,12 @@ function createAccumulatorFromItemAdded(event: StreamEvent): ItemAccumulator | n
 }
 
 /** Compute a composite key from round offset and output index to avoid collisions across tool rounds. */
-function accumulatorKey(roundOffset: number, outputIndex: number): number {
-  return roundOffset * 1e4 + outputIndex;
+function accumulatorKey(roundOffset: number, outputIndex: number): string {
+  return `${roundOffset}:${outputIndex}`;
 }
 
 async function* buildItemStream(broadcaster: EventBroadcaster): AsyncIterable<StreamingItem> {
-  const accumulators = new Map<number, ItemAccumulator>();
+  const accumulators = new Map<string, ItemAccumulator>();
   let roundOffset = 0;
 
   for await (const event of broadcaster) {
@@ -268,6 +269,9 @@ function errorIterable<T>(err: Error): AsyncIterable<T> {
             value: undefined,
           });
         },
+        throw(e: Error): Promise<IteratorResult<T>> {
+          return Promise.reject(e);
+        },
       };
     },
   };
@@ -288,26 +292,18 @@ function errorIterable<T>(err: Error): AsyncIterable<T> {
 export class HarnessResultImpl implements HarnessResult {
   private readonly broadcaster: EventBroadcaster;
   private readonly executionPromise: Promise<string>;
-  private ctxRef: Context | undefined;
-  private cachedResponse?: HarnessResponse;
+  private readonly responsePromise: Promise<HarnessResponse>;
 
   constructor(broadcaster: EventBroadcaster, executionPromise: Promise<string>, ctx: Context) {
     this.broadcaster = broadcaster;
     this.executionPromise = executionPromise;
-    this.ctxRef = ctx;
 
-    // Eagerly build and cache response, then release context for GC
-    executionPromise.then(
-      (text) => {
-        if (this.ctxRef) {
-          this.cachedResponse = buildHarnessResponse(text, this.ctxRef);
-          this.ctxRef = undefined;
-        }
-      },
-      () => {
-        this.ctxRef = undefined;
-      },
-    );
+    // Build response eagerly from the execution promise.
+    // A single derived promise ensures the Context reference is released for GC
+    // after the response is constructed.
+    this.responsePromise = executionPromise.then((text) => buildHarnessResponse(text, ctx));
+    // Prevent unhandled rejection — errors are surfaced via getResponse()/getText()
+    this.responsePromise.catch(() => {});
   }
 
   async getText(): Promise<string> {
@@ -315,17 +311,7 @@ export class HarnessResultImpl implements HarnessResult {
   }
 
   async getResponse(): Promise<HarnessResponse> {
-    const text = await this.executionPromise;
-    if (this.cachedResponse) {
-      return this.cachedResponse;
-    }
-    // Fallback: ctxRef should still be available if cache wasn't populated yet
-    if (this.ctxRef) {
-      this.cachedResponse = buildHarnessResponse(text, this.ctxRef);
-      this.ctxRef = undefined;
-      return this.cachedResponse;
-    }
-    throw new Error('Context was released before response could be built');
+    return this.responsePromise;
   }
 
   getTextStream(): AsyncIterable<string> {

--- a/packages/core/src/runtime/harness-result.ts
+++ b/packages/core/src/runtime/harness-result.ts
@@ -168,11 +168,23 @@ function createAccumulatorFromItemAdded(event: StreamEvent): ItemAccumulator | n
   return null;
 }
 
+/** Compute a composite key from round offset and output index to avoid collisions across tool rounds. */
+function accumulatorKey(roundOffset: number, outputIndex: number): number {
+  return roundOffset * 1e4 + outputIndex;
+}
+
 async function* buildItemStream(broadcaster: EventBroadcaster): AsyncIterable<StreamingItem> {
   const accumulators = new Map<number, ItemAccumulator>();
+  let roundOffset = 0;
 
   for await (const event of broadcaster) {
     if (event.source !== 'sdk') {
+      continue;
+    }
+
+    // Track round boundaries — SDK resets outputIndex per response
+    if (event.type === 'response.created') {
+      roundOffset++;
       continue;
     }
 
@@ -180,9 +192,10 @@ async function* buildItemStream(broadcaster: EventBroadcaster): AsyncIterable<St
     if (event.type === 'response.output_item.added') {
       const outputIndex =
         typeof event.outputIndex === 'number' ? event.outputIndex : accumulators.size;
+      const key = accumulatorKey(roundOffset, outputIndex);
       const acc = createAccumulatorFromItemAdded(event);
       if (acc) {
-        accumulators.set(outputIndex, acc);
+        accumulators.set(key, acc);
         yield {
           ...acc.item,
           isComplete: false,
@@ -194,7 +207,8 @@ async function* buildItemStream(broadcaster: EventBroadcaster): AsyncIterable<St
     // Output item done
     if (event.type === 'response.output_item.done') {
       const outputIndex = typeof event.outputIndex === 'number' ? event.outputIndex : -1;
-      const acc = accumulators.get(outputIndex);
+      const key = accumulatorKey(roundOffset, outputIndex);
+      const acc = accumulators.get(key);
       if (acc) {
         acc.isComplete = true;
         yield {
@@ -209,7 +223,8 @@ async function* buildItemStream(broadcaster: EventBroadcaster): AsyncIterable<St
     // Text delta
     if (event.type === 'response.output_text.delta' || event.type === 'response.output_text.done') {
       const outputIndex = typeof event.outputIndex === 'number' ? event.outputIndex : 0;
-      const acc = accumulators.get(outputIndex);
+      const key = accumulatorKey(roundOffset, outputIndex);
+      const acc = accumulators.get(key);
       if (acc) {
         updateMessageAccumulator(acc, event);
         yield {
@@ -226,7 +241,8 @@ async function* buildItemStream(broadcaster: EventBroadcaster): AsyncIterable<St
       event.type === 'response.function_call_arguments.done'
     ) {
       const outputIndex = typeof event.outputIndex === 'number' ? event.outputIndex : 0;
-      const acc = accumulators.get(outputIndex);
+      const key = accumulatorKey(roundOffset, outputIndex);
+      const acc = accumulators.get(key);
       if (acc) {
         updateFunctionCallAccumulator(acc, event);
         yield {
@@ -246,6 +262,12 @@ function errorIterable<T>(err: Error): AsyncIterable<T> {
         next(): Promise<IteratorResult<T>> {
           return Promise.reject(err);
         },
+        return(): Promise<IteratorResult<T>> {
+          return Promise.resolve({
+            done: true,
+            value: undefined,
+          });
+        },
       };
     },
   };
@@ -258,17 +280,34 @@ function errorIterable<T>(err: Error): AsyncIterable<T> {
 /**
  * Implementation of HarnessResult that wraps an EventBroadcaster and execution promise.
  *
+ * Eagerly caches the response when execution completes and releases the Context
+ * reference for garbage collection.
+ *
  * @internal
  */
 export class HarnessResultImpl implements HarnessResult {
   private readonly broadcaster: EventBroadcaster;
   private readonly executionPromise: Promise<string>;
-  private readonly ctx: Context;
+  private ctxRef: Context | undefined;
+  private cachedResponse?: HarnessResponse;
 
   constructor(broadcaster: EventBroadcaster, executionPromise: Promise<string>, ctx: Context) {
     this.broadcaster = broadcaster;
     this.executionPromise = executionPromise;
-    this.ctx = ctx;
+    this.ctxRef = ctx;
+
+    // Eagerly build and cache response, then release context for GC
+    executionPromise.then(
+      (text) => {
+        if (this.ctxRef) {
+          this.cachedResponse = buildHarnessResponse(text, this.ctxRef);
+          this.ctxRef = undefined;
+        }
+      },
+      () => {
+        this.ctxRef = undefined;
+      },
+    );
   }
 
   async getText(): Promise<string> {
@@ -277,7 +316,16 @@ export class HarnessResultImpl implements HarnessResult {
 
   async getResponse(): Promise<HarnessResponse> {
     const text = await this.executionPromise;
-    return buildHarnessResponse(text, this.ctx);
+    if (this.cachedResponse) {
+      return this.cachedResponse;
+    }
+    // Fallback: ctxRef should still be available if cache wasn't populated yet
+    if (this.ctxRef) {
+      this.cachedResponse = buildHarnessResponse(text, this.ctxRef);
+      this.ctxRef = undefined;
+      return this.cachedResponse;
+    }
+    throw new Error('Context was released before response could be built');
   }
 
   getTextStream(): AsyncIterable<string> {

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -66,11 +66,12 @@ export interface Tool<I extends ZodTypeAny = ZodTypeAny, O extends ZodTypeAny = 
   memory?: ToolMemoryDeclaration;
 }
 
-/** @public Aggregate token counts for an execution (input, output, total). */
+/** @public Aggregate token counts for an execution (input, output, total, cached). */
 export interface TokenUsage {
   input: number;
   output: number;
   total: number;
+  cached?: number;
 }
 
 /** @public Metadata captured from the most recent step execution. */

--- a/packages/core/src/types/harness-result.ts
+++ b/packages/core/src/types/harness-result.ts
@@ -1,0 +1,71 @@
+import type { Item } from './items';
+
+//#region Stream Event Types
+
+/** @public SDK-originated event from the OpenResponses streaming API. */
+export interface SdkStreamEvent {
+  readonly source: 'sdk';
+  /** OpenResponses SSE event type string (e.g., 'response.output_text.delta'). */
+  readonly type: string;
+  readonly data: Record<string, unknown>;
+  readonly outputIndex?: number;
+  readonly contentIndex?: number;
+}
+
+/** @public Framework-originated event, prefixed with the harness config.name. */
+export interface FrameworkStreamEvent {
+  readonly source: 'framework';
+  /** Prefixed event type (e.g., 'myagent:step_started'). */
+  readonly type: `${string}:${string}`;
+  readonly data: Record<string, unknown>;
+}
+
+/** @public Union of all stream event types emitted during execution. */
+export type StreamEvent = SdkStreamEvent | FrameworkStreamEvent;
+
+//#endregion
+
+//#region Harness Response
+
+/** @public Final accumulated result of an execution, including all items, usage, cost, and extracted text. */
+export interface HarnessResponse {
+  readonly items: ReadonlyArray<Item>;
+  readonly usage: {
+    readonly inputTokens: number;
+    readonly outputTokens: number;
+    readonly cachedTokens?: number;
+  };
+  readonly cost?: number;
+  readonly text: string;
+}
+
+//#endregion
+
+//#region Streaming Item
+
+/** @public An Item snapshot with a completion flag, emitted from getItemStream(). */
+export type StreamingItem = Item & {
+  readonly isComplete: boolean;
+};
+
+//#endregion
+
+//#region Harness Result
+
+/** @public Result object returned by execute(), providing multiple stream accessors for consuming execution output. */
+export interface HarnessResult {
+  /** Resolves with the final text output after execution completes. */
+  getText(): Promise<string>;
+  /** Resolves with the full response including items, usage, and cost. */
+  getResponse(): Promise<HarnessResponse>;
+  /** Yields text deltas as they arrive from the model. */
+  getTextStream(): AsyncIterable<string>;
+  /** Yields reasoning token deltas from reasoning-capable models. */
+  getReasoningStream(): AsyncIterable<string>;
+  /** Yields cumulative Item snapshots with isComplete flag. Replace, do not append. */
+  getItemStream(): AsyncIterable<StreamingItem>;
+  /** Yields all raw stream events (SDK + framework). */
+  getFullStream(): AsyncIterable<StreamEvent>;
+}
+
+//#endregion

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -31,6 +31,8 @@ interface CallModelRequestBase {
   params?: ModelParams;
   /** When provided, the harness sends a JSON Schema constraint to the model so it returns structured JSON. */
   outputSchema?: ZodType;
+  /** Controls framework event emission. Defaults to `true`. Passed through from `StepLLM.emit`. */
+  emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
 }
 
 /** @public Request shape when tools are provided — ctx is required for tool execution callbacks. */

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -3,6 +3,7 @@ import type { Channel, ChannelHandle, ExternalChannel } from './channel';
 import type { LLMResponse, ModelParams, Tool } from './common';
 import type { Context } from './context';
 import type { DetachedHandle } from './detached';
+import type { HarnessResult } from './harness-result';
 import type { ExecuteInput, Item } from './items';
 import type { ContextMemory, MemoryLayer, StorageAdapter } from './memory';
 import type { Span } from './observability';
@@ -63,7 +64,7 @@ export interface AgentHarnessContract<
 > {
   readonly config: AgentConfig<TParams>;
   callModel(request: CallModelRequest): Promise<LLMResponse>;
-  execute(input: ExecuteInput, options?: ExecuteOptions): Promise<string>;
+  execute(input: ExecuteInput, options?: ExecuteOptions): HarnessResult;
   run<I, O>(step: Step<ContextMemory, I, O>, input: I, ctx: Context): Promise<O>;
   detachedSpawn<I, O>(
     step: Step<ContextMemory, I, O>,

--- a/packages/core/src/types/step.ts
+++ b/packages/core/src/types/step.ts
@@ -92,6 +92,8 @@ export interface StepLLM<_TMemory = ContextMemory, _I = unknown, O = unknown> {
   tools?: Tool[];
   output?: ZodType<O>;
   params?: ModelParams;
+  /** Controls framework event emission for this step. Defaults to `true`. Set `false` to suppress all framework events. A filter function receives `(eventType, data)` and returns `boolean`. */
+  emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
 }
 
 /** @public A step that invokes a single tool directly, bypassing the LLM. */

--- a/packages/core/test/_helpers.ts
+++ b/packages/core/test/_helpers.ts
@@ -5,6 +5,7 @@
 import { expect } from 'bun:test';
 import { z } from 'zod';
 import { frameworkCast } from '../src/interpreter/framework-cast';
+import { HarnessResultImpl } from '../src/runtime/harness-result';
 import type { LLMResponse, Tool } from '../src/types/common';
 import type { Context, ItemLog } from '../src/types/context';
 import type { EmbedFn } from '../src/types/embed';
@@ -309,8 +310,8 @@ export function makeMockHarness(): AgentHarnessContract {
     callModel: async () => {
       throw new Error('not impl');
     },
-    execute: async () => {
-      throw new Error('not impl');
+    execute: () => {
+      return HarnessResultImpl.fromError(new Error('not impl'));
     },
     run: async () => {
       throw new Error('not impl');

--- a/packages/core/test/runtime/event-broadcaster.test.ts
+++ b/packages/core/test/runtime/event-broadcaster.test.ts
@@ -153,4 +153,80 @@ describe('EventBroadcaster', () => {
     const after = await iter.next();
     expect(after.done).toBe(true);
   });
+
+  it('trims buffer when exceeding maxBufferSize', async () => {
+    const bc = new EventBroadcaster({
+      maxBufferSize: 5,
+    });
+
+    // Emit 8 events — only last 5 should remain
+    for (let i = 0; i < 8; i++) {
+      bc.emit(textDelta(`event-${i}`));
+    }
+    expect(bc.bufferSize).toBe(5);
+
+    // Late subscriber should only see the retained window
+    const promise = collect(bc);
+    bc.complete();
+
+    const events = await promise;
+    expect(events).toHaveLength(5);
+    expect(events[0].data.delta).toBe('event-3');
+    expect(events[4].data.delta).toBe('event-7');
+  });
+
+  it('adjusts active iterator cursors on buffer trim', async () => {
+    const bc = new EventBroadcaster({
+      maxBufferSize: 3,
+    });
+    const iter = bc[Symbol.asyncIterator]();
+
+    // Read first event
+    bc.emit(textDelta('a'));
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+
+    // Emit enough to trigger trim — cursor should adjust
+    bc.emit(textDelta('b'));
+    bc.emit(textDelta('c'));
+    bc.emit(textDelta('d'));
+    bc.emit(textDelta('e'));
+
+    bc.complete();
+
+    // Collect remaining from iterator
+    const remaining: StreamEvent[] = [];
+    let next = await iter.next();
+    while (!next.done) {
+      remaining.push(next.value);
+      next = await iter.next();
+    }
+
+    // Should get events from trimmed buffer without errors
+    expect(remaining.length).toBeGreaterThan(0);
+  });
+
+  it('stops buffering when all consumers have departed', async () => {
+    const bc = new EventBroadcaster();
+
+    // Subscribe and immediately break
+    const iter = bc[Symbol.asyncIterator]();
+    bc.emit(textDelta('before'));
+    await iter.next();
+    await iter.return?.();
+
+    // Now emit more — buffer should NOT grow since all consumers left
+    const sizeBefore = bc.bufferSize;
+    bc.emit(textDelta('after-1'));
+    bc.emit(textDelta('after-2'));
+    expect(bc.bufferSize).toBe(sizeBefore);
+  });
+
+  it('still buffers when no consumers have subscribed yet (for replay)', () => {
+    const bc = new EventBroadcaster();
+
+    bc.emit(textDelta('early-1'));
+    bc.emit(textDelta('early-2'));
+    expect(bc.bufferSize).toBe(2);
+  });
 });

--- a/packages/core/test/runtime/event-broadcaster.test.ts
+++ b/packages/core/test/runtime/event-broadcaster.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'bun:test';
+import { EventBroadcaster } from '../../src/runtime/event-broadcaster';
+import type { StreamEvent } from '../../src/types/harness-result';
+
+function textDelta(text: string): StreamEvent {
+  return {
+    source: 'sdk',
+    type: 'response.output_text.delta',
+    data: {
+      delta: text,
+    },
+    outputIndex: 0,
+  };
+}
+
+function frameworkEvent(type: `${string}:${string}`, data: Record<string, unknown>): StreamEvent {
+  return {
+    source: 'framework',
+    type,
+    data,
+  };
+}
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const items: T[] = [];
+  for await (const item of iter) {
+    items.push(item);
+  }
+  return items;
+}
+
+describe('EventBroadcaster', () => {
+  it('emits events to a single consumer', async () => {
+    const bc = new EventBroadcaster();
+    const promise = collect(bc);
+
+    bc.emit(textDelta('hello'));
+    bc.emit(textDelta(' world'));
+    bc.complete();
+
+    const events = await promise;
+    expect(events).toHaveLength(2);
+    expect(events[0].data.delta).toBe('hello');
+    expect(events[1].data.delta).toBe(' world');
+  });
+
+  it('supports multiple concurrent consumers', async () => {
+    const bc = new EventBroadcaster();
+    const p1 = collect(bc);
+    const p2 = collect(bc);
+
+    bc.emit(textDelta('a'));
+    bc.emit(textDelta('b'));
+    bc.complete();
+
+    const [r1, r2] = await Promise.all([
+      p1,
+      p2,
+    ]);
+    expect(r1).toHaveLength(2);
+    expect(r2).toHaveLength(2);
+    expect(r1[0].data.delta).toBe('a');
+    expect(r2[0].data.delta).toBe('a');
+  });
+
+  it('replays buffered events for late subscribers', async () => {
+    const bc = new EventBroadcaster();
+
+    bc.emit(textDelta('early'));
+    bc.emit(textDelta('also early'));
+
+    // Subscribe after events were emitted
+    const promise = collect(bc);
+
+    bc.emit(textDelta('late'));
+    bc.complete();
+
+    const events = await promise;
+    expect(events).toHaveLength(3);
+    expect(events[0].data.delta).toBe('early');
+    expect(events[1].data.delta).toBe('also early');
+    expect(events[2].data.delta).toBe('late');
+  });
+
+  it('complete() ends all iterators', async () => {
+    const bc = new EventBroadcaster();
+    bc.complete();
+
+    const events = await collect(bc);
+    expect(events).toHaveLength(0);
+  });
+
+  it('error() propagates to all iterators', async () => {
+    const bc = new EventBroadcaster();
+    const promise = collect(bc);
+
+    bc.emit(textDelta('before error'));
+    bc.error(new Error('test error'));
+
+    try {
+      await promise;
+      expect.unreachable('should have thrown');
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(Error);
+      if (e instanceof Error) {
+        expect(e.message).toBe('test error');
+      }
+    }
+  });
+
+  it('ignores emit after complete', async () => {
+    const bc = new EventBroadcaster();
+    const promise = collect(bc);
+
+    bc.emit(textDelta('before'));
+    bc.complete();
+    bc.emit(textDelta('after'));
+
+    const events = await promise;
+    expect(events).toHaveLength(1);
+  });
+
+  it('handles mixed sdk and framework events', async () => {
+    const bc = new EventBroadcaster();
+    const promise = collect(bc);
+
+    bc.emit(textDelta('text'));
+    bc.emit(
+      frameworkEvent('test:step_started', {
+        stepId: 's1',
+      }),
+    );
+    bc.complete();
+
+    const events = await promise;
+    expect(events).toHaveLength(2);
+    expect(events[0].source).toBe('sdk');
+    expect(events[1].source).toBe('framework');
+  });
+
+  it('iterator return() removes the consumer', async () => {
+    const bc = new EventBroadcaster();
+    const iter = bc[Symbol.asyncIterator]();
+
+    bc.emit(textDelta('a'));
+    const first = await iter.next();
+    expect(first.done).toBe(false);
+
+    await iter.return?.();
+    bc.emit(textDelta('b'));
+    bc.complete();
+
+    const after = await iter.next();
+    expect(after.done).toBe(true);
+  });
+});

--- a/packages/core/test/runtime/event-broadcaster.test.ts
+++ b/packages/core/test/runtime/event-broadcaster.test.ts
@@ -202,8 +202,12 @@ describe('EventBroadcaster', () => {
       next = await iter.next();
     }
 
-    // Should get events from trimmed buffer without errors
-    expect(remaining.length).toBeGreaterThan(0);
+    // After reading 'a', buffer was [a,b,c] → emit d,e trims to [c,d,e].
+    // Iterator cursor adjusts so it continues from 'c' onward.
+    expect(remaining).toHaveLength(3);
+    expect(remaining[0].data.delta).toBe('c');
+    expect(remaining[1].data.delta).toBe('d');
+    expect(remaining[2].data.delta).toBe('e');
   });
 
   it('stops buffering when all consumers have departed', async () => {

--- a/packages/core/test/runtime/execute-api.test.ts
+++ b/packages/core/test/runtime/execute-api.test.ts
@@ -24,7 +24,7 @@ describe('AgentHarness.execute()', () => {
       ]),
     });
 
-    const result = await harness.execute('hello');
+    const result = await harness.execute('hello').getText();
     expect(result).toBe('echo: hello');
   });
 
@@ -40,7 +40,7 @@ describe('AgentHarness.execute()', () => {
       ]),
     });
 
-    const result = await harness.execute(item);
+    const result = await harness.execute(item).getText();
     expect(result).toBe('echo: from item');
   });
 
@@ -59,7 +59,7 @@ describe('AgentHarness.execute()', () => {
       ]),
     });
 
-    const result = await harness.execute(items);
+    const result = await harness.execute(items).getText();
     expect(result).toBe('echo: second');
   });
 
@@ -73,10 +73,12 @@ describe('AgentHarness.execute()', () => {
       ]),
     });
 
-    const result = await harness.execute('hi', {
-      threadId: 'thread-42',
-      resourceId: 'user-7',
-    });
+    const result = await harness
+      .execute('hi', {
+        threadId: 'thread-42',
+        resourceId: 'user-7',
+      })
+      .getText();
     expect(result).toBe('ok');
   });
 
@@ -87,7 +89,7 @@ describe('AgentHarness.execute()', () => {
     });
 
     try {
-      await harness.execute('hello');
+      await harness.execute('hello').getText();
       expect.unreachable('should have thrown');
     } catch (e) {
       assert(isNoeticConfigError(e));
@@ -106,8 +108,8 @@ describe('AgentHarness.execute()', () => {
       ]),
     });
 
-    await harness.execute('first');
-    await harness.execute('second');
+    await harness.execute('first').getText();
+    await harness.execute('second').getText();
     // If we got here without error, both calls succeeded with separate contexts
     expect(true).toBe(true);
   });

--- a/packages/core/test/runtime/execute-api.test.ts
+++ b/packages/core/test/runtime/execute-api.test.ts
@@ -108,9 +108,12 @@ describe('AgentHarness.execute()', () => {
       ]),
     });
 
-    await harness.execute('first').getText();
-    await harness.execute('second').getText();
-    // If we got here without error, both calls succeeded with separate contexts
-    expect(true).toBe(true);
+    const r1 = await harness.execute('first').getResponse();
+    const r2 = await harness.execute('second').getResponse();
+    // Each call produces its own response with independent items
+    expect(r1.text).toBe('ok');
+    expect(r2.text).toBe('ok');
+    // Items should not accumulate across calls
+    expect(r1.items.length).toBe(r2.items.length);
   });
 });

--- a/packages/core/test/runtime/harness-result.test.ts
+++ b/packages/core/test/runtime/harness-result.test.ts
@@ -254,6 +254,60 @@ describe('HarnessResult — getReasoningStream', () => {
       ' about this',
     ]);
   });
+
+  it('filters reasoning deltas when interleaved with text deltas', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext();
+    const executionPromise = Promise.resolve('result');
+
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    emitAsync(bc, [
+      sdkEvent(
+        'response.output_text.delta',
+        {
+          delta: 'Hello',
+        },
+        0,
+      ),
+      sdkEvent(
+        'response.reasoning.delta',
+        {
+          delta: 'Think step 1',
+        },
+        0,
+      ),
+      sdkEvent(
+        'response.output_text.delta',
+        {
+          delta: ' world',
+        },
+        0,
+      ),
+      sdkEvent(
+        'response.reasoning.delta',
+        {
+          delta: ' and step 2',
+        },
+        0,
+      ),
+      sdkEvent('response.output_text.done', {}, 0),
+    ]);
+
+    const [textDeltas, reasoningDeltas] = await Promise.all([
+      collect(harnessResult.getTextStream()),
+      collect(harnessResult.getReasoningStream()),
+    ]);
+
+    expect(textDeltas).toEqual([
+      'Hello',
+      ' world',
+    ]);
+    expect(reasoningDeltas).toEqual([
+      'Think step 1',
+      ' and step 2',
+    ]);
+  });
 });
 
 describe('HarnessResult — getItemStream', () => {
@@ -376,6 +430,48 @@ describe('HarnessResult — getItemStream', () => {
     const lastMsg = messages[messages.length - 1];
     expect(lastFc.isComplete).toBe(true);
     expect(lastMsg.isComplete).toBe(true);
+  });
+
+  it('replays events for late subscriber via broadcaster replay', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext();
+    const executionPromise = Promise.resolve('hello');
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    // Emit ALL events before subscribing to getItemStream
+    bc.emit(sdkEvent('response.created', {}, undefined));
+    bc.emit(
+      sdkEvent(
+        'response.output_item.added',
+        {
+          item: {
+            type: 'message',
+            id: 'msg-1',
+          },
+        },
+        0,
+      ),
+    );
+    bc.emit(
+      sdkEvent(
+        'response.output_text.delta',
+        {
+          delta: 'hello',
+        },
+        0,
+      ),
+    );
+    bc.emit(sdkEvent('response.output_text.done', {}, 0));
+    bc.emit(sdkEvent('response.output_item.done', {}, 0));
+    bc.complete();
+
+    // Subscribe AFTER all events — should replay from buffer
+    const items = await collect(harnessResult.getItemStream());
+
+    expect(items.length).toBeGreaterThanOrEqual(2);
+    const last = items[items.length - 1];
+    expect(last.isComplete).toBe(true);
+    expect(last.type).toBe('message');
   });
 });
 

--- a/packages/core/test/runtime/harness-result.test.ts
+++ b/packages/core/test/runtime/harness-result.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from 'bun:test';
+import assert from 'node:assert';
+import { isNoeticConfigError } from '../../src/errors/noetic-config-error';
+import { AgentHarness } from '../../src/runtime/agent-harness';
+import type { ContextMemory } from '../../src/types/memory';
+import type { Step } from '../../src/types/step';
+import { createScriptedCallModel, textOnlyResponse } from '../_helpers';
+
+const echoStep: Step<ContextMemory, string, string> = {
+  kind: 'llm',
+  id: 'echo',
+  model: 'test/echo',
+  tools: [],
+};
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const items: T[] = [];
+  for await (const item of iter) {
+    items.push(item);
+  }
+  return items;
+}
+
+describe('HarnessResult', () => {
+  it('getText() returns the final text output', async () => {
+    const harness = new AgentHarness({
+      name: 'test',
+      initialStep: echoStep,
+      params: {},
+      _testCallModel: createScriptedCallModel([
+        textOnlyResponse('hello world'),
+      ]),
+    });
+
+    const result = harness.execute('hi');
+    const text = await result.getText();
+    expect(text).toBe('hello world');
+  });
+
+  it('getResponse() returns items, usage, and text', async () => {
+    const harness = new AgentHarness({
+      name: 'test',
+      initialStep: echoStep,
+      params: {},
+      _testCallModel: createScriptedCallModel([
+        textOnlyResponse('response text'),
+      ]),
+    });
+
+    const result = harness.execute('hi');
+    const response = await result.getResponse();
+    expect(response.text).toBe('response text');
+    expect(response.items.length).toBeGreaterThan(0);
+    expect(response.usage.inputTokens).toBeGreaterThanOrEqual(0);
+    expect(response.usage.outputTokens).toBeGreaterThanOrEqual(0);
+  });
+
+  it('getFullStream() yields framework events for step lifecycle', async () => {
+    const harness = new AgentHarness({
+      name: 'myagent',
+      initialStep: echoStep,
+      params: {},
+      _testCallModel: createScriptedCallModel([
+        textOnlyResponse('streamed'),
+      ]),
+    });
+
+    const result = harness.execute('hi');
+    const events = await collect(result.getFullStream());
+
+    // Should have at least step_started and step_completed framework events
+    const frameworkEvents = events.filter((e) => e.source === 'framework');
+    const started = frameworkEvents.find((e) => e.type === 'myagent:step_started');
+    const completed = frameworkEvents.find((e) => e.type === 'myagent:step_completed');
+
+    assert(started, 'should have step_started event');
+    assert(completed, 'should have step_completed event');
+    expect(started.data.stepId).toBe('echo');
+    expect(started.data.kind).toBe('llm');
+  });
+
+  it('error case: getText() rejects when no step configured', async () => {
+    const harness = new AgentHarness({
+      name: 'test',
+      params: {},
+    });
+
+    const result = harness.execute('hello');
+
+    try {
+      await result.getText();
+      expect.unreachable('should have thrown');
+    } catch (e: unknown) {
+      assert(isNoeticConfigError(e));
+      expect(e.code).toBe('NO_STEP_CONFIGURED');
+    }
+  });
+
+  it('error case: getResponse() rejects when no step configured', async () => {
+    const harness = new AgentHarness({
+      name: 'test',
+      params: {},
+    });
+
+    const result = harness.execute('hello');
+
+    try {
+      await result.getResponse();
+      expect.unreachable('should have thrown');
+    } catch (e: unknown) {
+      assert(isNoeticConfigError(e));
+      expect(e.code).toBe('NO_STEP_CONFIGURED');
+    }
+  });
+
+  it('error case: stream accessors reject when no step configured', async () => {
+    const harness = new AgentHarness({
+      name: 'test',
+      params: {},
+    });
+
+    const result = harness.execute('hello');
+
+    try {
+      await collect(result.getTextStream());
+      expect.unreachable('should have thrown');
+    } catch (e: unknown) {
+      assert(isNoeticConfigError(e));
+    }
+
+    try {
+      await collect(result.getFullStream());
+      expect.unreachable('should have thrown');
+    } catch (e2: unknown) {
+      assert(isNoeticConfigError(e2));
+    }
+  });
+
+  it('multiple accessors can be consumed from the same result', async () => {
+    const harness = new AgentHarness({
+      name: 'test',
+      initialStep: echoStep,
+      params: {},
+      _testCallModel: createScriptedCallModel([
+        textOnlyResponse('multi'),
+      ]),
+    });
+
+    const result = harness.execute('hi');
+    const [text, response] = await Promise.all([
+      result.getText(),
+      result.getResponse(),
+    ]);
+
+    expect(text).toBe('multi');
+    expect(response.text).toBe('multi');
+  });
+});

--- a/packages/core/test/runtime/harness-result.test.ts
+++ b/packages/core/test/runtime/harness-result.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from 'bun:test';
 import assert from 'node:assert';
 import { isNoeticConfigError } from '../../src/errors/noetic-config-error';
 import { AgentHarness } from '../../src/runtime/agent-harness';
+import { EventBroadcaster } from '../../src/runtime/event-broadcaster';
+import { HarnessResultImpl } from '../../src/runtime/harness-result';
+import type { StreamEvent } from '../../src/types/harness-result';
 import type { ContextMemory } from '../../src/types/memory';
 import type { Step } from '../../src/types/step';
-import { createScriptedCallModel, textOnlyResponse } from '../_helpers';
+import { createScriptedCallModel, makeMockContext, textOnlyResponse } from '../_helpers';
+
+//#region Helpers
 
 const echoStep: Step<ContextMemory, string, string> = {
   kind: 'llm',
@@ -20,6 +25,27 @@ async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
   }
   return items;
 }
+
+function sdkEvent(type: string, data: Record<string, unknown>, outputIndex?: number): StreamEvent {
+  return {
+    source: 'sdk',
+    type,
+    data,
+    outputIndex,
+  };
+}
+
+/** Emit events to a broadcaster asynchronously to allow consumer iteration. */
+function emitAsync(bc: EventBroadcaster, events: StreamEvent[]): void {
+  queueMicrotask(() => {
+    for (const event of events) {
+      bc.emit(event);
+    }
+    bc.complete();
+  });
+}
+
+//#endregion
 
 describe('HarnessResult', () => {
   it('getText() returns the final text output', async () => {
@@ -68,7 +94,6 @@ describe('HarnessResult', () => {
     const result = harness.execute('hi');
     const events = await collect(result.getFullStream());
 
-    // Should have at least step_started and step_completed framework events
     const frameworkEvents = events.filter((e) => e.source === 'framework');
     const started = frameworkEvents.find((e) => e.type === 'myagent:step_started');
     const completed = frameworkEvents.find((e) => e.type === 'myagent:step_completed');
@@ -154,5 +179,336 @@ describe('HarnessResult', () => {
 
     expect(text).toBe('multi');
     expect(response.text).toBe('multi');
+  });
+});
+
+describe('HarnessResult — getTextStream', () => {
+  it('yields incremental text deltas from SDK events', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext();
+    const executionPromise = Promise.resolve('Hello world');
+
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    emitAsync(bc, [
+      sdkEvent(
+        'response.output_text.delta',
+        {
+          delta: 'Hello',
+        },
+        0,
+      ),
+      sdkEvent(
+        'response.output_text.delta',
+        {
+          delta: ' ',
+        },
+        0,
+      ),
+      sdkEvent(
+        'response.output_text.delta',
+        {
+          delta: 'world',
+        },
+        0,
+      ),
+    ]);
+
+    const deltas = await collect(harnessResult.getTextStream());
+    expect(deltas).toEqual([
+      'Hello',
+      ' ',
+      'world',
+    ]);
+  });
+});
+
+describe('HarnessResult — getReasoningStream', () => {
+  it('yields reasoning deltas from SDK events', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext();
+    const executionPromise = Promise.resolve('result');
+
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    emitAsync(bc, [
+      sdkEvent(
+        'response.reasoning.delta',
+        {
+          delta: 'Let me think',
+        },
+        0,
+      ),
+      sdkEvent(
+        'response.reasoning.delta',
+        {
+          delta: ' about this',
+        },
+        0,
+      ),
+    ]);
+
+    const deltas = await collect(harnessResult.getReasoningStream());
+    expect(deltas).toEqual([
+      'Let me think',
+      ' about this',
+    ]);
+  });
+});
+
+describe('HarnessResult — getItemStream', () => {
+  it('yields progressive message snapshots with isComplete transition', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext();
+    const executionPromise = Promise.resolve('hello');
+
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    emitAsync(bc, [
+      sdkEvent('response.created', {}, undefined),
+      sdkEvent(
+        'response.output_item.added',
+        {
+          item: {
+            type: 'message',
+            id: 'msg-1',
+          },
+        },
+        0,
+      ),
+      sdkEvent(
+        'response.output_text.delta',
+        {
+          delta: 'hel',
+        },
+        0,
+      ),
+      sdkEvent(
+        'response.output_text.delta',
+        {
+          delta: 'lo',
+        },
+        0,
+      ),
+      sdkEvent('response.output_text.done', {}, 0),
+      sdkEvent('response.output_item.done', {}, 0),
+    ]);
+
+    const items = await collect(harnessResult.getItemStream());
+    expect(items.length).toBeGreaterThanOrEqual(3);
+
+    // First snapshot: initial item added
+    expect(items[0].type).toBe('message');
+    expect(items[0].isComplete).toBe(false);
+
+    // Last snapshot: completed
+    const last = items[items.length - 1];
+    expect(last.isComplete).toBe(true);
+    expect(last.status).toBe('completed');
+  });
+
+  it('handles multi-round tool calls without accumulator collision', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext();
+    const executionPromise = Promise.resolve('final answer');
+
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    emitAsync(bc, [
+      // Round 1: function call at outputIndex 0
+      sdkEvent('response.created', {}, undefined),
+      sdkEvent(
+        'response.output_item.added',
+        {
+          item: {
+            type: 'function_call',
+            id: 'fc-1',
+            callId: 'call-1',
+            name: 'search',
+          },
+        },
+        0,
+      ),
+      sdkEvent(
+        'response.function_call_arguments.delta',
+        {
+          delta: '{"q":"test"}',
+        },
+        0,
+      ),
+      sdkEvent('response.function_call_arguments.done', {}, 0),
+      sdkEvent('response.output_item.done', {}, 0),
+
+      // Round 2: message at outputIndex 0 (same index, different round)
+      sdkEvent('response.created', {}, undefined),
+      sdkEvent(
+        'response.output_item.added',
+        {
+          item: {
+            type: 'message',
+            id: 'msg-1',
+          },
+        },
+        0,
+      ),
+      sdkEvent(
+        'response.output_text.delta',
+        {
+          delta: 'final answer',
+        },
+        0,
+      ),
+      sdkEvent('response.output_text.done', {}, 0),
+      sdkEvent('response.output_item.done', {}, 0),
+    ]);
+
+    const items = await collect(harnessResult.getItemStream());
+
+    // Should have items from both rounds — the function_call and the message
+    const functionCalls = items.filter((i) => i.type === 'function_call');
+    const messages = items.filter((i) => i.type === 'message');
+
+    expect(functionCalls.length).toBeGreaterThan(0);
+    expect(messages.length).toBeGreaterThan(0);
+
+    // Verify the last function call and last message are both completed
+    const lastFc = functionCalls[functionCalls.length - 1];
+    const lastMsg = messages[messages.length - 1];
+    expect(lastFc.isComplete).toBe(true);
+    expect(lastMsg.isComplete).toBe(true);
+  });
+});
+
+describe('HarnessResult — error propagation', () => {
+  it('getTextStream throws when broadcaster errors', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext();
+    const executionPromise = Promise.reject(new Error('execution failed'));
+
+    // Prevent unhandled rejection
+    executionPromise.catch(() => {});
+
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    queueMicrotask(() => {
+      bc.emit(
+        sdkEvent(
+          'response.output_text.delta',
+          {
+            delta: 'partial',
+          },
+          0,
+        ),
+      );
+      bc.error(new Error('execution failed'));
+    });
+
+    try {
+      await collect(harnessResult.getTextStream());
+      expect.unreachable('should have thrown');
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(Error);
+      if (e instanceof Error) {
+        expect(e.message).toBe('execution failed');
+      }
+    }
+  });
+
+  it('getFullStream throws when broadcaster errors', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext();
+    const executionPromise = Promise.reject(new Error('boom'));
+    executionPromise.catch(() => {});
+
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    queueMicrotask(() => {
+      bc.error(new Error('boom'));
+    });
+
+    try {
+      await collect(harnessResult.getFullStream());
+      expect.unreachable('should have thrown');
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(Error);
+      if (e instanceof Error) {
+        expect(e.message).toBe('boom');
+      }
+    }
+  });
+
+  it('getText rejects when execution promise rejects', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext();
+    const executionPromise = Promise.reject(new Error('step failed'));
+    executionPromise.catch(() => {});
+
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    try {
+      await harnessResult.getText();
+      expect.unreachable('should have thrown');
+    } catch (e: unknown) {
+      expect(e).toBeInstanceOf(Error);
+      if (e instanceof Error) {
+        expect(e.message).toBe('step failed');
+      }
+    }
+  });
+});
+
+describe('HarnessResult — emit option', () => {
+  it('emit: false suppresses all framework events', async () => {
+    const silentStep: Step<ContextMemory, string, string> = {
+      kind: 'llm',
+      id: 'silent',
+      model: 'test/echo',
+      tools: [],
+      emit: false,
+    };
+
+    const harness = new AgentHarness({
+      name: 'myagent',
+      initialStep: silentStep,
+      params: {},
+      _testCallModel: createScriptedCallModel([
+        textOnlyResponse('quiet'),
+      ]),
+    });
+
+    const result = harness.execute('hi');
+    const events = await collect(result.getFullStream());
+
+    const frameworkEvents = events.filter((e) => e.source === 'framework');
+    expect(frameworkEvents).toHaveLength(0);
+  });
+
+  it('emit filter function selectively suppresses events', async () => {
+    const filteredStep: Step<ContextMemory, string, string> = {
+      kind: 'llm',
+      id: 'filtered',
+      model: 'test/echo',
+      tools: [],
+      emit: (eventType) => eventType === 'step_started',
+    };
+
+    const harness = new AgentHarness({
+      name: 'myagent',
+      initialStep: filteredStep,
+      params: {},
+      _testCallModel: createScriptedCallModel([
+        textOnlyResponse('filtered'),
+      ]),
+    });
+
+    const result = harness.execute('hi');
+    const events = await collect(result.getFullStream());
+
+    const frameworkEvents = events.filter((e) => e.source === 'framework');
+    const started = frameworkEvents.filter((e) => e.type === 'myagent:step_started');
+    const completed = frameworkEvents.filter((e) => e.type === 'myagent:step_completed');
+
+    expect(started).toHaveLength(1);
+    expect(completed).toHaveLength(0);
   });
 });

--- a/packages/core/test/runtime/harness-result.test.ts
+++ b/packages/core/test/runtime/harness-result.test.ts
@@ -77,8 +77,9 @@ describe('HarnessResult', () => {
     const response = await result.getResponse();
     expect(response.text).toBe('response text');
     expect(response.items.length).toBeGreaterThan(0);
-    expect(response.usage.inputTokens).toBeGreaterThanOrEqual(0);
-    expect(response.usage.outputTokens).toBeGreaterThanOrEqual(0);
+    // textOnlyResponse sets inputTokens: 10, outputTokens: 5
+    expect(response.usage.inputTokens).toBe(10);
+    expect(response.usage.outputTokens).toBe(5);
   });
 
   it('getFullStream() yields framework events for step lifecycle', async () => {
@@ -159,6 +160,20 @@ describe('HarnessResult', () => {
     } catch (e2: unknown) {
       assert(isNoeticConfigError(e2));
     }
+
+    try {
+      await collect(result.getReasoningStream());
+      expect.unreachable('should have thrown');
+    } catch (e3: unknown) {
+      assert(isNoeticConfigError(e3));
+    }
+
+    try {
+      await collect(result.getItemStream());
+      expect.unreachable('should have thrown');
+    } catch (e4: unknown) {
+      assert(isNoeticConfigError(e4));
+    }
   });
 
   it('multiple accessors can be consumed from the same result', async () => {
@@ -179,6 +194,46 @@ describe('HarnessResult', () => {
 
     expect(text).toBe('multi');
     expect(response.text).toBe('multi');
+  });
+
+  it('getResponse() includes cachedTokens when present', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext({
+      tokens: {
+        input: 100,
+        output: 50,
+        total: 150,
+        cached: 25,
+      },
+    });
+    const executionPromise = Promise.resolve('cached result');
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    queueMicrotask(() => bc.complete());
+
+    const response = await harnessResult.getResponse();
+    expect(response.usage.cachedTokens).toBe(25);
+    expect(response.usage.inputTokens).toBe(100);
+    expect(response.usage.outputTokens).toBe(50);
+  });
+
+  it('getResponse() omits cachedTokens when zero', async () => {
+    const bc = new EventBroadcaster();
+    const ctx = makeMockContext({
+      tokens: {
+        input: 10,
+        output: 5,
+        total: 15,
+        cached: 0,
+      },
+    });
+    const executionPromise = Promise.resolve('no cache');
+    const harnessResult = new HarnessResultImpl(bc, executionPromise, ctx);
+
+    queueMicrotask(() => bc.complete());
+
+    const response = await harnessResult.getResponse();
+    expect(response.usage.cachedTokens).toBeUndefined();
   });
 });
 

--- a/packages/web/content/docs/api/items-and-events.mdx
+++ b/packages/web/content/docs/api/items-and-events.mdx
@@ -376,6 +376,31 @@ Noetic's adapter layer bridges the framework's `Item` types and the OpenResponse
 
 Extension items and reasoning items are skipped during input conversion (they are internal metadata). The adapter currently converts `message` and `function_call` output items; built-in extended items like `web_search_call` are not yet surfaced as Noetic Items.
 
+## Framework Events
+
+In addition to OpenResponses streaming events, Noetic emits framework-level events during execution. These events use the harness `config.name` as a prefix and have `source: 'framework'`.
+
+| Event | Description | Key Payload |
+|---|---|---|
+| `{name}:step_started` | Before each step executes | `stepId`, `kind` |
+| `{name}:step_completed` | After each step completes | `stepId`, `kind` |
+| `{name}:tool_round_started` | Before a tool execution round | `round`, `toolCount` |
+| `{name}:tool_call_started` | Before each tool call | `name`, `callId` |
+| `{name}:tool_call_completed` | After each tool call | `name`, `callId`, `error` |
+
+Framework events are available through `harness.execute(input).getFullStream()` alongside SDK events. They can be distinguished by the `source` field:
+
+```ts
+for await (const event of harness.execute('Hello').getFullStream()) {
+  if (event.source === 'sdk') {
+    // OpenResponses SSE event
+  }
+  if (event.source === 'framework') {
+    // Noetic lifecycle event, e.g. 'myagent:step_started'
+  }
+}
+```
+
 ## Related Pages
 
 - [Context & Event Log](/docs/context) -- the `ItemLog` interface and usage.

--- a/packages/web/content/docs/api/items-and-events.mdx
+++ b/packages/web/content/docs/api/items-and-events.mdx
@@ -387,6 +387,7 @@ In addition to OpenResponses streaming events, Noetic emits framework-level even
 | `{name}:tool_round_started` | Before a tool execution round | `round`, `toolCount` |
 | `{name}:tool_call_started` | Before each tool call | `name`, `callId` |
 | `{name}:tool_call_completed` | After each tool call | `name`, `callId`, `error` |
+| `{name}:tool_round_completed` | After all tool calls in a round | `round`, `toolCount` |
 
 Framework events are available through `harness.execute(input).getFullStream()` alongside SDK events. They can be distinguished by the `source` field:
 

--- a/packages/web/content/docs/api/runtime-types.mdx
+++ b/packages/web/content/docs/api/runtime-types.mdx
@@ -33,6 +33,7 @@ interface AgentHarness<TParams extends Record<string, unknown> = Record<string, 
 | Method | Description |
 |---|---|
 | `config` | The `AgentConfig<TParams>` the harness was constructed with |
+| `execute(input, options?)` | Run the agent's `initialStep`. Returns a [`HarnessResult`](#harnessresult) with streaming accessors. |
 | `run(step, input, ctx)` | Run a step with the given input and context |
 | `detachedSpawn(step, input, parentCtx)` | Launch a step concurrently, returning a `DetachedHandle` |
 | `createContext(opts?)` | Create a new execution context |
@@ -48,6 +49,67 @@ interface AgentHarness<TParams extends Record<string, unknown> = Record<string, 
 | `restore(executionId)` | Restore a previously checkpointed context |
 | `cancel(ctx, reason?)` | Cancel an execution |
 | `createSpan(name, parent)` | Create an observability span |
+
+## HarnessResult
+
+Returned by `execute()`. Provides multiple ways to consume execution output.
+
+```ts
+interface HarnessResult {
+  getText(): Promise<string>;
+  getResponse(): Promise<HarnessResponse>;
+  getTextStream(): AsyncIterable<string>;
+  getReasoningStream(): AsyncIterable<string>;
+  getItemStream(): AsyncIterable<StreamingItem>;
+  getFullStream(): AsyncIterable<StreamEvent>;
+}
+```
+
+| Method | Returns | Description |
+|---|---|---|
+| `getText()` | `Promise<string>` | Complete text after execution finishes |
+| `getResponse()` | `Promise<HarnessResponse>` | Full response with items, usage, cost |
+| `getTextStream()` | `AsyncIterable<string>` | Text deltas as they arrive |
+| `getReasoningStream()` | `AsyncIterable<string>` | Reasoning token deltas |
+| `getItemStream()` | `AsyncIterable<StreamingItem>` | Cumulative item snapshots with `isComplete` |
+| `getFullStream()` | `AsyncIterable<StreamEvent>` | All raw SDK + framework events |
+
+## HarnessResponse
+
+```ts
+interface HarnessResponse {
+  readonly items: ReadonlyArray<Item>;
+  readonly usage: { inputTokens: number; outputTokens: number; cachedTokens?: number };
+  readonly cost?: number;
+  readonly text: string;
+}
+```
+
+## StreamEvent
+
+```ts
+type StreamEvent = SdkStreamEvent | FrameworkStreamEvent;
+
+interface SdkStreamEvent {
+  readonly source: 'sdk';
+  readonly type: string;
+  readonly data: Record<string, unknown>;
+  readonly outputIndex?: number;
+  readonly contentIndex?: number;
+}
+
+interface FrameworkStreamEvent {
+  readonly source: 'framework';
+  readonly type: `${string}:${string}`;
+  readonly data: Record<string, unknown>;
+}
+```
+
+## StreamingItem
+
+```ts
+type StreamingItem = Item & { readonly isComplete: boolean };
+```
 
 ## AgentConfig
 

--- a/packages/web/content/docs/runtime.mdx
+++ b/packages/web/content/docs/runtime.mdx
@@ -51,21 +51,31 @@ const harness = new AgentHarness({
 
 ## execute()
 
-The primary way to run an agent. Accepts a string, a single `Item`, or an array of `Item[]`.
+The primary way to run an agent. Returns a `HarnessResult` with multiple stream accessors. Accepts a string, a single `Item`, or an array of `Item[]`.
 
 ```ts
-// String input — creates a user message automatically
-const result = await harness.execute('What is 2+2?');
+// Simple: get the final text
+const text = await harness.execute('What is 2+2?').getText();
+
+// Full response with items and usage
+const response = await harness.execute('Hello').getResponse();
+console.log(response.text, response.usage);
+
+// Stream text as it arrives
+for await (const delta of harness.execute('Write a story').getTextStream()) {
+  process.stdout.write(delta);
+}
+
+// Stream all events (SDK + framework)
+for await (const event of harness.execute('Hello').getFullStream()) {
+  console.log(event.source, event.type);
+}
 
 // With options
-const result = await harness.execute('Hello', {
+const result = harness.execute('Hello', {
   threadId: 'thread-1',
   resourceId: 'user-1',
 });
-
-// Item input — pre-populates the context item log
-const result = await harness.execute(messageItem);
-const result = await harness.execute([item1, item2]);
 ```
 
 | Parameter | Type | Description |
@@ -73,7 +83,51 @@ const result = await harness.execute([item1, item2]);
 | `input` | `string \| Item \| Item[]` | The input to the agent. |
 | `options` | `ExecuteOptions` | Optional `threadId`, `resourceId`, and `state`. |
 
+Returns a `HarnessResult` immediately (execution starts eagerly). See [HarnessResult](#harnessresult) for all accessors.
+
 Throws `NoeticConfigError` with code `NO_STEP_CONFIGURED` if no `initialStep` was provided in the constructor.
+
+## HarnessResult
+
+The object returned by `execute()`. Provides six ways to consume execution output.
+
+| Method | Returns | Description |
+|---|---|---|
+| `getText()` | `Promise<string>` | Complete text after execution finishes. |
+| `getResponse()` | `Promise<HarnessResponse>` | Full response with items, usage, and cost. |
+| `getTextStream()` | `AsyncIterable<string>` | Text deltas as they arrive from the model. |
+| `getReasoningStream()` | `AsyncIterable<string>` | Reasoning token deltas (reasoning models). |
+| `getItemStream()` | `AsyncIterable<StreamingItem>` | Cumulative item snapshots with `isComplete` flag. |
+| `getFullStream()` | `AsyncIterable<StreamEvent>` | All raw events (SDK + framework). |
+
+### HarnessResponse
+
+```ts
+interface HarnessResponse {
+  readonly items: ReadonlyArray<Item>;
+  readonly usage: { inputTokens: number; outputTokens: number; cachedTokens?: number };
+  readonly cost?: number;
+  readonly text: string;
+}
+```
+
+### StreamEvent
+
+Events have a `source` discriminant: `'sdk'` for OpenResponses SSE events, `'framework'` for Noetic lifecycle events. Framework events use the harness `config.name` as prefix.
+
+```ts
+type StreamEvent = SdkStreamEvent | FrameworkStreamEvent;
+```
+
+Framework events emitted during execution:
+
+| Event | Description |
+|---|---|
+| `{name}:step_started` | Before each step executes. |
+| `{name}:step_completed` | After each step completes. |
+| `{name}:tool_round_started` | Before a tool execution round. |
+| `{name}:tool_call_started` | Before each tool call. |
+| `{name}:tool_call_completed` | After each tool call. |
 
 ## run()
 

--- a/packages/web/content/docs/runtime.mdx
+++ b/packages/web/content/docs/runtime.mdx
@@ -128,6 +128,9 @@ Framework events emitted during execution:
 | `{name}:tool_round_started` | Before a tool execution round. |
 | `{name}:tool_call_started` | Before each tool call. |
 | `{name}:tool_call_completed` | After each tool call. |
+| `{name}:tool_round_completed` | After all tool calls in a round. |
+
+LLM steps support an `emit` option to control framework event emission — set `false` to suppress or pass a filter function.
 
 ## run()
 

--- a/specs/02-step-variants.md
+++ b/specs/02-step-variants.md
@@ -48,6 +48,7 @@ interface StepLLMOpts<O> {
   tools?: Tool[];             // tools available for THIS call
   output?: ZodType<O>;        // structured output schema
   params?: ModelParams;       // temperature, topP, etc.
+  emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
 }
 
 interface ModelParams {

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -159,10 +159,31 @@ interface FrameworkStreamEvent {
 | `{name}:tool_round_started` | Emitted before a tool execution round. Data: `{ round, toolCount }` |
 | `{name}:tool_call_started` | Emitted before each tool call. Data: `{ name, callId }` |
 | `{name}:tool_call_completed` | Emitted after each tool call. Data: `{ name, callId, error }` |
+| `{name}:tool_round_completed` | Emitted after all tool calls in a round. Data: `{ round, toolCount }` |
+| `{name}:stream_pipe_error` | Emitted when SDK stream piping fails. Data: `{ error }` |
 
 ### Streaming Scope
 
 Events from the entire step composition tree flow through `HarnessResult`. All LLM steps encountered during execution (including within loops, branches, forks, and spawns) emit SDK stream events. Non-LLM steps emit framework lifecycle events only.
+
+### Event Emission Control
+
+LLM steps support an optional `emit` field to control framework event emission:
+
+```typescript
+step.llm({ id: 'quiet', model: '...', emit: false });           // suppress all
+step.llm({ id: 'selective', model: '...', emit: (type) => type === 'step_started' }); // filter
+```
+
+- **`true`** (default): all framework events emitted.
+- **`false`**: no framework events (`step_started`, `step_completed`, `tool_round_*`, `tool_call_*`) for this step.
+- **Filter function**: `(eventType: string, data: Record<string, unknown>) => boolean` — called per event, return `true` to emit.
+
+The `emit` option propagates through `CallModelRequest` to `callModel()`, controlling tool round/call events as well.
+
+### Bounded Buffer
+
+The internal `EventBroadcaster` buffer is capped at 10,000 events. When the buffer exceeds this limit, oldest events are trimmed and active iterator cursors are adjusted. Once all consumers have departed, new events are discarded to prevent unbounded memory growth. Late subscribers receive only the retained window.
 
 ### Error Handling
 

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -14,6 +14,9 @@ interface AgentHarness<TParams extends Record<string, unknown> = Record<string, 
   // Agent configuration
   readonly config: AgentConfig<TParams>;
 
+  // Primary execution — returns a HarnessResult with streaming accessors
+  execute(input: ExecuteInput, options?: ExecuteOptions): HarnessResult;
+
   // Core execution
   run<I, O>(step: Step<I, O>, input: I, ctx: Context): Promise<O>;
 
@@ -87,6 +90,83 @@ interface DetachedHandle<O> {
   await(timeout?: number): Promise<O>;
 }
 ```
+
+---
+
+## HarnessResult
+
+`execute()` returns a `HarnessResult` synchronously. Execution starts eagerly in the background. The result provides six accessors for consuming output in different modes.
+
+```typescript
+interface HarnessResult {
+  getText(): Promise<string>;
+  getResponse(): Promise<HarnessResponse>;
+  getTextStream(): AsyncIterable<string>;
+  getReasoningStream(): AsyncIterable<string>;
+  getItemStream(): AsyncIterable<StreamingItem>;
+  getFullStream(): AsyncIterable<StreamEvent>;
+}
+
+interface HarnessResponse {
+  readonly items: ReadonlyArray<Item>;
+  readonly usage: { inputTokens: number; outputTokens: number; cachedTokens?: number };
+  readonly cost?: number;
+  readonly text: string;
+}
+
+type StreamingItem = Item & { readonly isComplete: boolean };
+```
+
+### Stream Accessors
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `getText()` | `Promise<string>` | Complete text after execution finishes |
+| `getResponse()` | `Promise<HarnessResponse>` | Full response with items, usage, cost |
+| `getTextStream()` | `AsyncIterable<string>` | Text deltas as they arrive from the model |
+| `getReasoningStream()` | `AsyncIterable<string>` | Reasoning token deltas (reasoning models) |
+| `getItemStream()` | `AsyncIterable<StreamingItem>` | Cumulative item snapshots with `isComplete` flag. Replace, do not append. |
+| `getFullStream()` | `AsyncIterable<StreamEvent>` | All raw events (SDK + framework) |
+
+### StreamEvent
+
+Events have a `source` discriminant: `'sdk'` for raw OpenResponses SSE events, `'framework'` for Noetic lifecycle events. Framework events use the harness `config.name` as prefix (e.g., `myagent:step_started`).
+
+```typescript
+type StreamEvent = SdkStreamEvent | FrameworkStreamEvent;
+
+interface SdkStreamEvent {
+  readonly source: 'sdk';
+  readonly type: string;  // OpenResponses event type, e.g. 'response.output_text.delta'
+  readonly data: Record<string, unknown>;
+  readonly outputIndex?: number;
+  readonly contentIndex?: number;
+}
+
+interface FrameworkStreamEvent {
+  readonly source: 'framework';
+  readonly type: `${string}:${string}`;  // e.g. 'myagent:step_started'
+  readonly data: Record<string, unknown>;
+}
+```
+
+### Framework Events
+
+| Event | Description |
+|-------|-------------|
+| `{name}:step_started` | Emitted before each step executes. Data: `{ stepId, kind }` |
+| `{name}:step_completed` | Emitted after each step completes. Data: `{ stepId, kind }` |
+| `{name}:tool_round_started` | Emitted before a tool execution round. Data: `{ round, toolCount }` |
+| `{name}:tool_call_started` | Emitted before each tool call. Data: `{ name, callId }` |
+| `{name}:tool_call_completed` | Emitted after each tool call. Data: `{ name, callId, error }` |
+
+### Streaming Scope
+
+Events from the entire step composition tree flow through `HarnessResult`. All LLM steps encountered during execution (including within loops, branches, forks, and spawns) emit SDK stream events. Non-LLM steps emit framework lifecycle events only.
+
+### Error Handling
+
+When `execute()` is called without an `initialStep`, all accessors reject with `NoeticConfigError` code `NO_STEP_CONFIGURED`. When execution fails mid-stream, the error propagates to all active stream consumers.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace `execute()` return type from `Promise<string>` to `HarnessResult` with six stream accessors: `getText()`, `getResponse()`, `getTextStream()`, `getReasoningStream()`, `getItemStream()`, `getFullStream()`
- Add `EventBroadcaster` for multi-consumer streaming with replay support, piping SDK stream events through `callModel()` and emitting framework lifecycle events from the interpreter
- Framework events use the harness `config.name` as prefix (e.g., `myagent:step_started`) — not `noetic:*`

## Test plan

- [x] EventBroadcaster unit tests (emit, complete, error, replay, multi-consumer, iterator return)
- [x] HarnessResult integration tests (getText, getResponse, getFullStream framework events, error cases, multiple accessors)
- [x] Updated existing execute-api tests to use `.getText()`
- [x] Full test suite: 573 pass, 5 skip, 0 fail
- [x] Typecheck clean (0 errors in changed files)
- [x] Biome lint clean (0 issues)
- [x] Web docs build passes (51 pages)
- [x] Spec, docs, and skills updated per sync rules