### PR TITLE
feat(core): add provide() operator and memory on AgentHarness

### DIFF
--- a/guides/claude-code-agent-with-noetic.md
+++ b/guides/claude-code-agent-with-noetic.md
@@ -1,0 +1,716 @@
+# Building a Claude Code-Like Agent with Noetic
+
+This guide walks through how to recreate the core architecture of Claude Code — its 5 specialized agent types, plan/act mode, coordinator pattern, and sub-agent delegation — using Noetic's step primitives, memory layers, and patterns.
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [The Single Harness](#the-single-harness)
+- [Tool Sets Per Agent Type](#tool-sets-per-agent-type)
+- [Branching Between Agent Types](#branching-between-agent-types)
+- [Plan Mode vs Act Mode](#plan-mode-vs-act-mode)
+- [The Full Loop](#the-full-loop)
+- [Async Sub-Agents](#async-sub-agents)
+- [Inter-Agent Communication](#inter-agent-communication)
+- [Context Compaction](#context-compaction)
+- [Doom Loop Detection](#doom-loop-detection)
+- [Putting It All Together](#putting-it-all-together)
+- [What Doesn't Map Directly](#what-doesnt-map-directly)
+
+---
+
+## Architecture Overview
+
+Claude Code's architecture has five key subsystems:
+
+1. **QueryEngine** — the main LLM loop (stream tokens, process tool calls, repeat)
+2. **Tool System** — ~40 tools with permission-gated execution
+3. **Coordinator** — multi-agent orchestration (research → synthesize → implement → verify)
+4. **Plan/Act Mode** — permission gating that blocks write tools in plan mode
+5. **Compaction** — context management when conversations grow long
+
+Noetic maps these to composable primitives:
+
+| Claude Code Subsystem | Noetic Primitive | Controls |
+|---|---|---|
+| QueryEngine (LLM + tool loop) | `loop([step.llm(...)], until.noToolCalls())` | Execution flow |
+| Tool System (per-agent tool sets) | `tools` param on `step.llm()` | What the model **can call** — different per agent type |
+| Agent type switching | `branch()` inside the loop | Which `step.llm()` (with which tools) runs each iteration |
+| Plan/Act Mode | `branch()` over mode state | Which agent types are available |
+| Memory layers | `memory` on `AgentHarness` | What memory layers are available to steps |
+| Compaction | `observationalMemory()` layer | What the model **sees in context** |
+
+**Key principle**: Each agent type is a different `step.llm()` with its own `tools` array. The `tools` param is the hard capability boundary — it defines what function calls the LLM can make. Memory layers are a separate concern that controls prompt context (what the model sees), not capabilities (what the model can do).
+
+Everything runs through a single `AgentHarness` instance.
+
+---
+
+## The Single Harness
+
+All execution — the coordinator loop, every branched agent step, and any spawned sub-agents — shares one `AgentHarness`. The harness provides the LLM client, channel store, tracing, and storage.
+
+```typescript
+import { AgentHarness } from '@noetic/core';
+
+const harness = new AgentHarness({
+  name: 'claude-code-agent',
+  initialStep: mainLoop,       // a loop() — see below
+  memory: memoryLayers,        // memory layers for context management
+  params: {},
+  llm: { provider: 'openrouter' },
+});
+
+const result = await harness.execute(userInput);
+```
+
+The `AgentHarness` **is** the agent. The `initialStep` is the loop that defines what the agent does. `memory` provides memory layers (compaction, steering, working memory) to every execution. Calling `execute()` creates a fresh context with those layers and runs the step.
+
+Events (tool calls, model responses) flow through the harness in real-time — there's no isolation boundary between the main loop and the UI. Reserve `spawn` for sub-agents that need isolated contexts.
+
+---
+
+## Tool Sets Per Agent Type
+
+Claude Code has 5 built-in agent types. The primary difference between them is their **tool set** — each `step.llm()` gets a different `tools` array:
+
+| Agent Type | Model | Tool Set | Notes |
+|---|---|---|---|
+| **Explore** | `haiku` | `[glob, grep, read, bash_readonly]` | Fast, cheap, read-only |
+| **Plan** | parent model | `[glob, grep, read, bash_readonly]` | Same tools as explore, different system prompt |
+| **Verification** | parent model | `[glob, grep, read, bash_readonly, bash_tmp]` | Read-only + can write scripts to `/tmp` |
+| **General** | parent model | `[glob, grep, read, write, edit, bash]` | Full capability — only type that writes project files |
+| **Guide** | `haiku` | `[glob, grep, read, web_fetch]` | Documentation lookup |
+
+Define each as a pre-built `step.llm()`:
+
+```typescript
+import { step } from '@noetic/core';
+
+const readOnlyTools = createCodebaseTools(rootDir);          // glob, grep, read, bash-readonly
+const fullTools = [...readOnlyTools, ...createWriteTools(rootDir)]; // + write, edit, bash
+const verifyTools = [...readOnlyTools, ...createTmpWriteTools()];  // + bash limited to /tmp
+const guideTools = [...readOnlyTools, ...createWebTools()];        // + web_fetch
+
+// Each agent type = a step.llm with its own tools and system prompt
+const exploreStep = step.llm({
+  id: 'explore',
+  model: 'anthropic/claude-haiku-4',
+  system: 'You are a fast codebase exploration agent. Read files, search code, report findings.',
+  tools: readOnlyTools,
+});
+
+const planStep = step.llm({
+  id: 'plan',
+  model: 'anthropic/claude-sonnet-4-20250514',
+  system: 'You are a software architect. Explore the code, then output a step-by-step implementation plan.',
+  tools: readOnlyTools,
+});
+
+const verifyStep = step.llm({
+  id: 'verify',
+  model: 'anthropic/claude-sonnet-4-20250514',
+  system: [
+    'You are an adversarial verification agent. Run builds, tests, linters.',
+    'Try boundary values. End with VERDICT: PASS, VERDICT: FAIL, or VERDICT: NEEDS_REVISION.',
+  ].join('\n'),
+  tools: verifyTools,
+});
+
+const generalStep = step.llm({
+  id: 'general',
+  model: 'anthropic/claude-sonnet-4-20250514',
+  system: 'Complete the task fully. Do not gold-plate, but do not leave it half-done.',
+  tools: fullTools,
+});
+
+const guideStep = step.llm({
+  id: 'guide',
+  model: 'anthropic/claude-haiku-4',
+  system: 'You answer questions about Claude Code, the Agent SDK, and the Claude API.',
+  tools: guideTools,
+});
+```
+
+No factories, no resolvers, no dynamic step construction. Each agent type is a static `step.llm()` with its tools baked in.
+
+---
+
+## Branching Between Agent Types
+
+The core pattern: the loop body contains a `branch` that routes each iteration to the appropriate `step.llm()` based on state. The model's output from one iteration feeds into the routing decision for the next.
+
+```typescript
+import { branch } from '@noetic/core';
+
+const agentRouter = branch({
+  id: 'agent-type-router',
+  route: (input, ctx) => {
+    // Read which agent type to use from working memory or input
+    const agentType = ctx.state.nextAgentType ?? 'explore';
+
+    const routes: Record<string, Step> = {
+      explore: exploreStep,
+      plan: planStep,
+      verification: verifyStep,
+      general: generalStep,
+      'claude-code-guide': guideStep,
+    };
+
+    return routes[agentType] ?? exploreStep;
+  },
+});
+```
+
+Each iteration of the loop:
+1. The `branch` reads the current agent type from state
+2. Routes to that type's `step.llm()` (with its specific tools)
+3. The model runs with only those tools available
+4. Output flows to the next iteration, where a coordinator step decides what to do next
+
+---
+
+## Plan Mode vs Act Mode
+
+Plan mode restricts which agent types are available. In Noetic, this is just another layer of branching — the `route` function checks the mode and filters agent types.
+
+### Branch-Based Mode Restriction
+
+```typescript
+const PLAN_MODE_AGENTS = new Set(['explore', 'plan', 'claude-code-guide']);
+const ACT_MODE_AGENTS = new Set(['explore', 'plan', 'verification', 'general', 'claude-code-guide']);
+
+const agentRouter = branch({
+  id: 'agent-type-router',
+  route: (input, ctx) => {
+    const mode = ctx.state.mode ?? 'plan';
+    const agentType = ctx.state.nextAgentType ?? 'explore';
+    const allowed = mode === 'plan' ? PLAN_MODE_AGENTS : ACT_MODE_AGENTS;
+
+    if (!allowed.has(agentType)) {
+      // In plan mode, trying to use 'general' → fall back to 'plan'
+      return planStep;
+    }
+
+    return routes[agentType] ?? exploreStep;
+  },
+});
+```
+
+This is a hard boundary — in plan mode, the `general` step (with write tools) literally never runs. The model never sees write tools. No steering needed for this.
+
+### Mode Switching
+
+The coordinator step (see next section) decides when to switch modes. It has a `set_mode` tool that updates `ctx.state.mode`:
+
+```typescript
+const setModeTool = tool({
+  name: 'set_mode',
+  description: 'Switch between plan mode (read-only agents) and act mode (all agents including writes).',
+  input: z.object({ mode: z.enum(['plan', 'act']) }),
+  output: z.object({ mode: z.enum(['plan', 'act']), previous: z.enum(['plan', 'act']) }),
+  execute: async (args, toolCtx) => {
+    const previous = toolCtx.ctx.state.mode;
+    toolCtx.ctx.state.mode = args.mode;
+    return { mode: args.mode, previous };
+  },
+});
+```
+
+---
+
+## The Full Loop
+
+The loop body has two steps per iteration:
+1. **Coordinator step** — an LLM that decides what to do next (which agent type, what task). It has only delegation/control tools, no codebase tools.
+2. **Agent branch** — routes to the chosen agent type's `step.llm()` with its specific tools.
+
+```typescript
+import {
+  AgentHarness, loop, step, branch,
+  workingMemory, observationalMemory,
+} from '@noetic/core';
+import { any, until } from '@noetic/core';
+
+const MODEL = 'anthropic/claude-sonnet-4-20250514';
+const ROOT_DIR = process.cwd();
+
+// --- Tool sets (per agent type) ---
+const readOnlyTools = createCodebaseTools(ROOT_DIR);
+const fullTools = [...readOnlyTools, ...createWriteTools(ROOT_DIR)];
+const verifyTools = [...readOnlyTools, ...createTmpWriteTools()];
+const guideTools = [...readOnlyTools, ...createWebTools()];
+
+// --- Pre-built agent steps (each with its own tools) ---
+const agentSteps = {
+  explore: step.llm({
+    id: 'explore',
+    model: 'anthropic/claude-haiku-4',
+    system: 'You are a fast codebase exploration agent. Report findings concisely.',
+    tools: readOnlyTools,
+  }),
+  plan: step.llm({
+    id: 'plan',
+    model: MODEL,
+    system: 'You are a software architect. Produce a step-by-step implementation plan.',
+    tools: readOnlyTools,
+  }),
+  verification: step.llm({
+    id: 'verify',
+    model: MODEL,
+    system: 'You are an adversarial verifier. Run builds/tests/lints. End with VERDICT: PASS/FAIL/NEEDS_REVISION.',
+    tools: verifyTools,
+  }),
+  general: step.llm({
+    id: 'general',
+    model: MODEL,
+    system: 'Complete the task fully.',
+    tools: fullTools,
+  }),
+  'claude-code-guide': step.llm({
+    id: 'guide',
+    model: 'anthropic/claude-haiku-4',
+    system: 'You answer questions about Claude Code, the Agent SDK, and the Claude API.',
+    tools: guideTools,
+  }),
+};
+
+// --- Coordinator step (decides what agent to use next) ---
+const coordinatorStep = step.llm({
+  id: 'coordinator',
+  model: MODEL,
+  system: COORDINATOR_SYSTEM_PROMPT,
+  tools: [
+    setModeTool,
+    selectAgentTool,  // sets ctx.state.nextAgentType
+  ],
+  output: z.object({
+    agentType: z.enum(['explore', 'plan', 'verification', 'general', 'claude-code-guide']),
+    task: z.string(),
+    done: z.boolean(),
+  }),
+});
+
+// --- Agent type branch ---
+const PLAN_MODE_AGENTS = new Set(['explore', 'plan', 'claude-code-guide']);
+
+const agentBranch = branch({
+  id: 'agent-router',
+  route: (input, ctx) => {
+    const mode = ctx.state.mode ?? 'plan';
+    const agentType = ctx.state.nextAgentType ?? 'explore';
+
+    if (mode === 'plan' && !PLAN_MODE_AGENTS.has(agentType)) {
+      return agentSteps.plan; // fallback in plan mode
+    }
+    return agentSteps[agentType] ?? agentSteps.explore;
+  },
+});
+
+// --- The harness IS the agent ---
+const harness = new AgentHarness({
+  name: 'claude-code-agent',
+  initialStep: loop({
+    id: 'main-loop',
+    steps: [coordinatorStep, agentBranch],
+    until: any(
+      until.noToolCalls(),
+      until.maxSteps(50),
+      until.maxCost(10),
+    ),
+  }),
+  memory: [
+    workingMemory({ scope: 'thread' }),
+    observationalMemory({ bufferThreshold: 3_000 }),
+  ],
+  params: {},
+  llm: { provider: 'openrouter' },
+});
+
+const result = await harness.execute('Add a dark mode toggle to the settings page.');
+```
+
+### How It Flows
+
+```
+Iteration 1:
+  coordinatorStep → decides: { agentType: 'explore', task: 'find settings components' }
+  agentBranch → exploreStep (haiku, read-only tools) → runs, returns file list
+
+Iteration 2:
+  coordinatorStep → decides: { agentType: 'plan', task: 'design dark mode toggle' }
+  agentBranch → planStep (sonnet, read-only tools) → runs, returns plan
+
+Iteration 3:
+  coordinatorStep → calls set_mode({ mode: 'act' }), decides: { agentType: 'general', task: 'implement plan' }
+  agentBranch → generalStep (sonnet, ALL tools including write/edit/bash) → implements
+
+Iteration 4:
+  coordinatorStep → decides: { agentType: 'verification', task: 'verify implementation' }
+  agentBranch → verifyStep (sonnet, read-only + /tmp) → returns VERDICT: PASS
+
+Iteration 5:
+  coordinatorStep → { done: true } → until.noToolCalls() fires → loop ends
+```
+
+Each iteration, the model only sees the tools for its agent type. The explore step has no write tools. The general step has everything. The branch handles this — no steering needed, no dynamic step construction.
+
+---
+
+## Async Sub-Agents
+
+The loop-with-branch approach above is sequential — one agent type per iteration. For parallel sub-agents (Claude Code's async delegation), you need `spawn` + `detachedSpawn` + an inbox channel. This is an extension of the base pattern, not a replacement.
+
+### When to Use Each
+
+| Pattern | When | How |
+|---|---|---|
+| **Branch in loop** | Sequential agent switching (explore → plan → implement → verify) | `branch()` routes to different `step.llm()` configs |
+| **Sync spawn** | Need a sub-agent result before continuing | `spawn()` inside a `step.run()` via `harness.run()` |
+| **Async detached spawn** | Can continue while sub-agent works | `detachedSpawn()` + inbox channel |
+
+### Adding Async Delegation
+
+Add a `launch_agent` tool to the coordinator step. When the coordinator calls it, a background sub-agent runs and posts results to the inbox:
+
+```typescript
+const inbox = channel('agent-inbox', { schema: z.string(), mode: 'queue' });
+const handles = new Map<string, DetachedHandle<string>>();
+
+const launchAgentTool = tool({
+  name: 'launch_agent',
+  description: 'Launch a sub-agent in the background. Results arrive via inbox.',
+  input: z.object({
+    type: z.enum(['explore', 'plan', 'verification', 'general', 'claude-code-guide']),
+    task: z.string(),
+  }),
+  output: z.object({ agentId: z.string() }),
+  execute: async (args, toolCtx) => {
+    // Build the sub-agent step with its tools (same steps defined above)
+    const agentStep = agentSteps[args.type];
+    const spawnStep = spawn({ id: `sub-${args.type}`, child: agentStep });
+    const handle = toolCtx.harness.detachedSpawn(spawnStep, args.task, toolCtx.ctx);
+    handles.set(handle.id, handle);
+
+    // Notify inbox when done (fire-and-forget)
+    void handle.await().then(
+      (result) => {
+        handles.delete(handle.id);
+        toolCtx.harness.send(inbox, `[Agent ${handle.id} completed] ${result}`, toolCtx.ctx);
+      },
+      (err: unknown) => {
+        handles.delete(handle.id);
+        const msg = err instanceof Error ? err.message : String(err);
+        toolCtx.harness.send(inbox, `[Agent ${handle.id} failed] ${msg}`, toolCtx.ctx);
+      },
+    );
+
+    return { agentId: handle.id };
+  },
+});
+```
+
+Add `inbox` and `parkTimeout` to the loop so it wakes up when async agents finish:
+
+```typescript
+const mainLoop = loop({
+  id: 'main-loop',
+  steps: [coordinatorStep, agentBranch],
+  until: any(until.noToolCalls(), until.maxSteps(50)),
+  inbox,
+  parkTimeout: 30_000, // wait up to 30s for background agents
+});
+```
+
+---
+
+## Inter-Agent Communication
+
+### The Inbox Channel
+
+When the `until` predicate fires (e.g., no tool calls), the loop checks the inbox before truly stopping. If a background agent just posted a result, the loop **continues** with the result injected as a developer message.
+
+The flow:
+
+1. Coordinator calls `launch_agent` → sub-agent runs in background
+2. Coordinator has no more tool calls → `until.noToolCalls()` fires
+3. Loop checks inbox → nothing yet → parks for up to 30s
+4. Sub-agent finishes → posts to inbox
+5. Loop wakes → injects message → coordinator gets the result and continues
+
+### External Channels (User Input)
+
+For a user-facing system where new messages can arrive mid-execution:
+
+```typescript
+const userInput = channel('user-input', {
+  schema: z.string(),
+  mode: 'queue',
+  external: true, // writable from outside the execution tree
+});
+
+// After starting the agent:
+const handle = harness.getChannelHandle(userInput, ctx.id);
+handle.send('Actually, also add error handling.'); // injects into the running loop
+```
+
+---
+
+## Context Compaction
+
+### How Claude Code Does It
+
+A 4-stage pipeline (snip → microcompact → context collapse → autocompact) triggers when context grows too large.
+
+### The Noetic Equivalent: Observational Memory
+
+`observationalMemory()` buffers raw conversation items. When the buffer crosses a token threshold, it calls an `observer` function to distill them into compact observations. This is a **memory layer** — it controls what the model sees in its prompt, not what tools are available:
+
+```typescript
+import { observationalMemory } from '@noetic/core';
+
+const compactor = observationalMemory({
+  bufferThreshold: 50_000, // tokens before distilling
+  maxObservations: 50,
+  observer: async (buffer) => {
+    return [`Summary of ${buffer.length} exchanges: ${buffer.map(b => b.slice(0, 80)).join('; ')}`];
+  },
+});
+```
+
+Memory layers are provided at the harness level via the `memory` option (see [The Single Harness](#the-single-harness)). Every `execute()` call creates a context with those layers attached — no `spawn` wrapper needed. If a sub-agent needs different layers, use `provide()` to override within that subtree, or `spawn()` to create a fully isolated context.
+
+Short-lived agent types (explore, guide) don't need compaction — they run for a few iterations and terminate. Longer-running types (general, plan) benefit from it.
+
+---
+
+## Doom Loop Detection
+
+### How Claude Code Does It
+
+A lifecycle hook inspects conversation history for repetitive patterns and injects a `system_reminder` nudging the model to try a different approach.
+
+### The Noetic Equivalent: Steering Layer
+
+`steering()` is a memory layer that can intercept tool calls (`beforeToolCall`) and model responses (`afterModelCall`). For doom loop detection, we use `afterModelCall` to check for repetitive patterns and inject guidance:
+
+```typescript
+import { steering, SteeringAction } from '@noetic/core';
+
+const doomLoopDetector = steering({
+  rules: [{
+    id: 'doom-loop-detector',
+    appliesTo: ['afterModelCall'],
+    predicate: (params) => {
+      const items = params.ctx.itemLog.items;
+      const recentToolCalls = items
+        .filter((i): i is FunctionCallItem => i.type === 'function_call')
+        .slice(-6);
+
+      if (recentToolCalls.length >= 6) {
+        const names = recentToolCalls.map(t => t.name);
+        const isRepeating = names[0] === names[2] && names[2] === names[4];
+        if (isRepeating) {
+          return {
+            action: SteeringAction.Guide,
+            guidance: 'You are repeating the same actions. Step back and try a fundamentally different approach.',
+          };
+        }
+      }
+      return { action: SteeringAction.Allow };
+    },
+  }],
+});
+```
+
+When `Guide` is returned, the guidance is injected as a developer message and the model is called again (up to 3 retries). Note: steering intercepts tool calls or model responses — it doesn't change which tools are available. That's the `tools` array's job.
+
+---
+
+## Putting It All Together
+
+```typescript
+import {
+  AgentHarness, step, branch, loop, spawn, tool, channel,
+  workingMemory, observationalMemory, steering, SteeringAction,
+} from '@noetic/core';
+import { any, until } from '@noetic/core';
+import { z } from 'zod';
+
+const MODEL = 'anthropic/claude-sonnet-4-20250514';
+const ROOT_DIR = process.cwd();
+
+// ─── Tool sets (capability boundaries per agent type) ───
+
+const readOnlyTools = createCodebaseTools(ROOT_DIR);
+const fullTools = [...readOnlyTools, ...createWriteTools(ROOT_DIR)];
+const verifyTools = [...readOnlyTools, ...createTmpWriteTools()];
+const guideTools = [...readOnlyTools, ...createWebTools()];
+
+// ─── Agent steps (each with its own tools — the hard capability boundary) ───
+
+const agentSteps: Record<string, Step> = {
+  explore: step.llm({
+    id: 'explore', model: 'anthropic/claude-haiku-4',
+    system: 'Fast codebase exploration. Report findings concisely.',
+    tools: readOnlyTools,
+  }),
+  plan: step.llm({
+    id: 'plan', model: MODEL,
+    system: 'Software architect. Produce a step-by-step implementation plan.',
+    tools: readOnlyTools,
+  }),
+  verification: step.llm({
+    id: 'verify', model: MODEL,
+    system: 'Adversarial verifier. Run builds/tests/lints. End with VERDICT: PASS/FAIL/NEEDS_REVISION.',
+    tools: verifyTools,
+  }),
+  general: step.llm({
+    id: 'general', model: MODEL,
+    system: 'Complete the task. Do not gold-plate, do not leave half-done.',
+    tools: fullTools,
+  }),
+  'claude-code-guide': step.llm({
+    id: 'guide', model: 'anthropic/claude-haiku-4',
+    system: 'Answer questions about Claude Code, the Agent SDK, and the Claude API.',
+    tools: guideTools,
+  }),
+};
+
+// ─── Coordinator tools (control flow, not codebase) ───
+
+const setModeTool = tool({
+  name: 'set_mode',
+  description: 'Switch between plan mode (read-only) and act mode (full capability).',
+  input: z.object({ mode: z.enum(['plan', 'act']) }),
+  output: z.object({ mode: z.enum(['plan', 'act']) }),
+  execute: async (args, toolCtx) => {
+    toolCtx.ctx.state.mode = args.mode;
+    return { mode: args.mode };
+  },
+});
+
+const selectAgentTool = tool({
+  name: 'select_agent',
+  description: 'Choose which agent type handles the next task.',
+  input: z.object({
+    type: z.enum(['explore', 'plan', 'verification', 'general', 'claude-code-guide']),
+  }),
+  output: z.object({ selected: z.string() }),
+  execute: async (args, toolCtx) => {
+    toolCtx.ctx.state.nextAgentType = args.type;
+    return { selected: args.type };
+  },
+});
+
+// ─── Coordinator step (decides what to do, has no codebase tools) ───
+
+const coordinatorStep = step.llm({
+  id: 'coordinator',
+  model: MODEL,
+  system: `You are a software engineering coordinator.
+
+## Modes
+You start in PLAN mode. In plan mode: explore, plan, and guide agents only.
+Call set_mode({ mode: "act" }) to enable general and verification agents.
+
+## Agent Types (use select_agent to choose)
+- explore:           Fast read-only codebase search (cheap)
+- plan:              Software architect — produces implementation plans
+- verification:      Adversarial verifier — outputs VERDICT
+- general:           Full capability including file writes (only type that can edit code)
+- claude-code-guide: Documentation lookup (cheap)
+
+## Workflow
+1. select_agent → explore (understand codebase)
+2. select_agent → plan (design approach)
+3. set_mode → act
+4. select_agent → general (implement)
+5. select_agent → verification (validate)`,
+  tools: [setModeTool, selectAgentTool],
+});
+
+// ─── Branch: routes to the selected agent type's step.llm ───
+
+const PLAN_MODE_AGENTS = new Set(['explore', 'plan', 'claude-code-guide']);
+
+const agentBranch = branch({
+  id: 'agent-router',
+  route: (input, ctx) => {
+    const mode = ctx.state.mode ?? 'plan';
+    const agentType = ctx.state.nextAgentType ?? 'explore';
+
+    // Plan mode blocks write-capable agents
+    if (mode === 'plan' && !PLAN_MODE_AGENTS.has(agentType)) {
+      return agentSteps.plan;
+    }
+    return agentSteps[agentType] ?? agentSteps.explore;
+  },
+});
+
+// ─── The harness IS the agent ───
+
+const harness = new AgentHarness({
+  name: 'claude-code-agent',
+  initialStep: loop({
+    id: 'main-loop',
+    steps: [coordinatorStep, agentBranch],
+    until: any(
+      until.noToolCalls(),
+      until.maxSteps(50),
+      until.maxCost(10),
+    ),
+  }),
+  memory: [
+    doomLoopDetector,                                // steering: intercepts repetitive patterns
+    workingMemory({ scope: 'thread' }),              // prompt: scratchpad for task state
+    observationalMemory({ bufferThreshold: 3_000 }), // prompt: compressed history
+  ],
+  params: {},
+  llm: { provider: 'openrouter' },
+});
+
+const result = await harness.execute('Add a dark mode toggle to the settings page.');
+```
+
+### Execution Flow
+
+```
+Iteration 1:
+  coordinator → select_agent({ type: 'explore' })
+  branch → exploreStep (haiku, read-only tools)
+  → "Found SettingsPage.tsx, ThemeContext.tsx..."
+
+Iteration 2:
+  coordinator → select_agent({ type: 'plan' })
+  branch → planStep (sonnet, read-only tools)
+  → "Plan: 1) Add dark mode to ThemeContext  2) Add toggle component  3) Wire to settings..."
+
+Iteration 3:
+  coordinator → set_mode({ mode: 'act' }), select_agent({ type: 'general' })
+  branch → generalStep (sonnet, ALL tools — write_file, edit_file, bash)
+  → writes DarkModeToggle.tsx, edits ThemeContext.tsx, edits SettingsPage.tsx
+
+Iteration 4:
+  coordinator → select_agent({ type: 'verification' })
+  branch → verifyStep (sonnet, read-only + /tmp bash)
+  → runs build, tests, linter → "VERDICT: PASS"
+
+Iteration 5:
+  coordinator → no tool calls → loop ends
+```
+
+---
+
+## What Doesn't Map Directly
+
+| Claude Code Feature | Gap | Possible Workaround |
+|---|---|---|
+| **Streaming tokens to UI** | `callModel()` returns completed responses, no SSE surface | Wrap the OpenRouter SDK's streaming directly, outside of Noetic's step model |
+| **Agent continuation** (`SendMessage` to existing agent) | `detachedSpawn` is fire-and-forget; can't add messages to a running agent's conversation | Use `inbox` channel on the sub-agent's loop — messages arrive as developer items via `parkTimeout` |
+| **Request transformer pipeline** (SortTools, ImageHandling, etc.) | No user-facing request transform hook | Implement in a memory layer's `recall` hook (for prompt-side transforms) |
+| **Interactive permission prompts** (`needsApproval` → user confirms in UI) | The flag exists on `tool()` but has no built-in UI | Pause on `ctx.recv(approvalChannel)`, external UI calls `handle.send('approved')` |
+| **Dynamic model downgrade** (200k+ context → cheaper model in plan mode) | `step.llm` model is fixed at build time | Use `branch()` to route to different `step.llm` configs based on `ctx.tokens.total` |
+| **Prompt cache key preservation** | Provider-specific optimization not exposed | Would require a custom adapter layer |
+| **tmux pane routing for teams** | No process/terminal management | External concern — Noetic handles agent logic, not UI |
+| **`criticalSystemReminder`** (re-injected every turn for verification) | No per-turn system injection outside memory layers | Use `staticContent({ load: async () => reminder })` — it injects at `recall`, which fires before every LLM call |

--- a/packages/core/src/builders/provide-builder.ts
+++ b/packages/core/src/builders/provide-builder.ts
@@ -1,0 +1,41 @@
+import { NoeticConfigError } from '../errors/noetic-config-error';
+import type { ContextMemory, MemoryConfig, MemoryLayer } from '../types/memory';
+import type { Step, StepProvide } from '../types/step';
+
+/**
+ * Creates a provide step that attaches memory layers to its child without creating an isolated context.
+ * Like React's Context.Provider — layers are available to all descendant steps.
+ * Spawn and detachedSpawn break the inheritance chain.
+ *
+ * @public
+ * @param opts.id - Unique step identifier used in traces and error messages.
+ * @param opts.child - Step to execute with the provided layers.
+ * @param opts.memory - Memory layers to provide to descendant steps.
+ * @returns A `StepProvide` step.
+ * @throws `NoeticConfigError` with code `EMPTY_STEP_ID` if `id` is empty.
+ * @throws `NoeticConfigError` with code `MISSING_CHILD_STEP` if `child` is not provided.
+ */
+export function provide<TMemory = ContextMemory, I = unknown, O = unknown>(opts: {
+  id: string;
+  child: Step<TMemory, I, O>;
+  memory: MemoryConfig | MemoryLayer[];
+}): StepProvide<TMemory, I, O> {
+  if (!opts.id?.trim()) {
+    throw new NoeticConfigError({
+      code: 'EMPTY_STEP_ID',
+      message: 'provide() requires a non-empty id.',
+      hint: 'Pass a unique string as the id field, e.g. provide({ id: "my-provider", ... }).',
+    });
+  }
+  if (!opts.child) {
+    throw new NoeticConfigError({
+      code: 'MISSING_CHILD_STEP',
+      message: 'provide() requires a child step.',
+      hint: 'Provide a child step to execute with the provided memory layers.',
+    });
+  }
+  return {
+    kind: 'provide',
+    ...opts,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,8 @@ export { loop } from './builders/loop-builder';
 /** @public */
 export { memory } from './builders/memory-builder';
 /** @public */
+export { provide } from './builders/provide-builder';
+/** @public */
 export { spawn } from './builders/spawn-builder';
 /** @public */
 export { step } from './builders/step-builders';
@@ -280,6 +282,7 @@ export type {
   StepForkSettle,
   StepLLM,
   StepLoop,
+  StepProvide,
   StepRun,
   StepSpawn,
   StepTool,

--- a/packages/core/src/interpreter/execute-provide.ts
+++ b/packages/core/src/interpreter/execute-provide.ts
@@ -1,0 +1,72 @@
+import type { Context } from '../types/context';
+import type { ContextMemory, MemoryConfig, MemoryLayer } from '../types/memory';
+import type { ExecuteStepFn, StepProvide } from '../types/step';
+import { frameworkCast } from './framework-cast';
+
+//#region Helper Functions
+
+function isMemoryConfig(value: unknown): value is MemoryConfig {
+  return typeof value === 'object' && value !== null && 'layers' in value;
+}
+
+function resolveLayers<TMemory, I, O>(step: StepProvide<TMemory, I, O>): MemoryLayer[] {
+  if (isMemoryConfig(step.memory)) {
+    return [
+      ...step.memory.layers,
+    ];
+  }
+  return step.memory;
+}
+
+function mergeLayers(existing: MemoryLayer[] | undefined, provided: MemoryLayer[]): MemoryLayer[] {
+  if (!existing || existing.length === 0) {
+    return provided;
+  }
+
+  // Provided layers override existing layers with the same id (like nested React context)
+  const providedIds = new Set(provided.map((l) => l.id));
+  const kept = existing.filter((l) => !providedIds.has(l.id));
+  return [
+    ...kept,
+    ...provided,
+  ];
+}
+
+//#endregion
+
+//#region Public API
+
+/**
+ * Executes a provide step by attaching memory layers to the current context
+ * without creating an isolated child context.
+ *
+ * Unlike spawn, provide does not create a new itemLog or clone state.
+ * Events flow through to the parent in real-time.
+ */
+export async function executeProvide<TMemory, I, O>(
+  step: StepProvide<TMemory, I, O>,
+  input: I,
+  ctx: Context<TMemory>,
+  executeStep: ExecuteStepFn,
+): Promise<O> {
+  const baseCtx = frameworkCast<
+    Context<ContextMemory> & {
+      layers?: MemoryLayer[];
+    }
+  >(ctx);
+  const previousLayers = baseCtx.layers;
+  const newLayers = resolveLayers(step);
+  const mergedLayers = mergeLayers(previousLayers, newLayers);
+
+  // Attach layers to the current context (no isolation)
+  baseCtx.layers = mergedLayers;
+
+  try {
+    return await executeStep<TMemory, I, O>(step.child, input, ctx);
+  } finally {
+    // Restore previous layers so siblings are not affected
+    baseCtx.layers = previousLayers;
+  }
+}
+
+//#endregion

--- a/packages/core/src/interpreter/execute.ts
+++ b/packages/core/src/interpreter/execute.ts
@@ -6,6 +6,7 @@ import { executeBranch } from './execute-branch';
 import { executeFork } from './execute-fork';
 import { executeLLM } from './execute-llm';
 import { executeLoop } from './execute-loop';
+import { executeProvide } from './execute-provide';
 import { executeRun } from './execute-run';
 import { executeSpawn } from './execute-spawn';
 import { executeTool } from './execute-tool';
@@ -67,6 +68,8 @@ export async function execute<TMemory = ContextMemory, I = unknown, O = unknown>
       return executeFork(step, input, ctx, (s, i, c) => execute(s, i, c));
     case 'spawn':
       return executeSpawn(step, input, ctx, (s, i, c) => execute(s, i, c));
+    case 'provide':
+      return executeProvide(step, input, ctx, (s, i, c) => execute(s, i, c));
     case 'loop':
       return executeLoop(step, input, ctx, (s, i, c) => execute(s, i, c));
     default: {

--- a/packages/core/src/runtime/agent-harness.ts
+++ b/packages/core/src/runtime/agent-harness.ts
@@ -51,6 +51,8 @@ import { contextToExecCtx } from './exec-context-factory';
 interface AgentHarnessOpts<TParams extends Record<string, unknown> = Record<string, unknown>> {
   name: string;
   initialStep?: Step<ContextMemory, string, string>;
+  /** Default memory layers applied to every context created via `createContext()` / `execute()`. */
+  memory?: MemoryLayer[];
   storage?: StorageAdapter;
   hooks?: AgentHooks;
   params: TParams;
@@ -110,6 +112,7 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
 {
   readonly config: AgentConfig<TParams>;
   private readonly initialStep?: Step<ContextMemory, string, string>;
+  private readonly _memory?: MemoryLayer[];
   private readonly client?: OpenRouter;
   private readonly channelStore: ChannelStore;
   private readonly callModelOverride?: (request: CallModelRequest) => Promise<LLMResponse>;
@@ -126,6 +129,7 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
       params: validatedParams,
     };
     this.initialStep = opts.initialStep;
+    this._memory = opts.memory;
     this.callModelOverride = opts._testCallModel;
     this.client = opts._testCallModel ? undefined : createClient(opts.llm);
     this.channelStore = new ChannelStore();
@@ -311,11 +315,14 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
     state?: unknown;
     threadId?: string;
     resourceId?: string;
+    memory?: MemoryLayer[];
   }): Context {
+    const { memory: memoryLayers, ...rest } = opts ?? {};
     return new ContextImpl({
-      ...opts,
+      ...rest,
       harness: this,
       channelStore: this.channelStore,
+      layers: memoryLayers ?? this._memory,
     });
   }
 

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -55,6 +55,8 @@ export interface ExecuteOptions {
   threadId?: string;
   resourceId?: string;
   state?: unknown;
+  /** Memory layers to apply to the execution context. Overrides harness-level memory if provided. */
+  memory?: MemoryLayer[];
 }
 
 /** @public Type-level contract for the agent runtime. Used for type annotations throughout the interpreter, memory layers, and context. Implemented by `AgentHarness`. */
@@ -76,6 +78,7 @@ export interface AgentHarnessContract<
     state?: unknown;
     threadId?: string;
     resourceId?: string;
+    memory?: MemoryLayer[];
   }): Context;
   send<T>(channel: Channel<T>, value: T, ctx: Context): void;
   recv<T>(

--- a/packages/core/src/types/step.ts
+++ b/packages/core/src/types/step.ts
@@ -73,6 +73,7 @@ export type Step<TMemory = ContextMemory, I = unknown, O = unknown> =
   | StepBranch<TMemory, I, O>
   | StepFork<TMemory, I, O>
   | StepSpawn<TMemory, I, O>
+  | StepProvide<TMemory, I, O>
   | StepLoop<TMemory, I, O>;
 
 /** @public A step that executes arbitrary async logic via a user-supplied function. */
@@ -149,6 +150,19 @@ export interface StepForkSettle<TMemory = ContextMemory, I = unknown, O = unknow
   merge: (results: SettleResult<O>[], ctx: Context<TMemory>) => O;
   concurrency?: number;
   _optimizable?: Step<TMemory>[];
+}
+
+/**
+ * A step that provides memory layers to its child without creating an isolated context.
+ * Like React's Context.Provider — layers are available to all descendant steps.
+ * Spawn and detachedSpawn break the inheritance chain.
+ * @public
+ */
+export interface StepProvide<TMemory = ContextMemory, I = unknown, O = unknown> {
+  kind: 'provide';
+  id: string;
+  child: Step<TMemory, I, O>;
+  memory: MemoryConfig | MemoryLayer[];
 }
 
 /** @public A step that launches a child execution with its own memory scope. */

--- a/packages/core/test/interpreter/execute-provide.test.ts
+++ b/packages/core/test/interpreter/execute-provide.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from 'bun:test';
+import { executeProvide } from '../../src/interpreter/execute-provide';
+import { ContextImpl } from '../../src/runtime/context-impl';
+import type { Context } from '../../src/types/context';
+import type { ContextMemory, MemoryLayer } from '../../src/types/memory';
+import { Slot } from '../../src/types/memory';
+import type { StepProvide } from '../../src/types/step';
+import { makeMessage, makeMockHarness, simpleExecute } from '../_helpers';
+
+//#region Helper Functions
+
+function makeProvideStep<TMemory = ContextMemory, I = unknown, O = unknown>(
+  id: string,
+  execute: (input: I, ctx: Context<TMemory>) => Promise<O>,
+  memory: MemoryLayer[],
+): StepProvide<TMemory, I, O> {
+  return {
+    kind: 'provide',
+    id,
+    child: {
+      kind: 'run',
+      id: `${id}-child`,
+      execute,
+    },
+    memory,
+  };
+}
+
+function makeLayer(id: string, slot: number): MemoryLayer {
+  return {
+    id,
+    name: id,
+    slot,
+    scope: 'execution',
+    hooks: {},
+  };
+}
+
+//#endregion
+
+//#region Tests
+
+describe('executeProvide', () => {
+  describe('layer attachment', () => {
+    it('child step receives layers on context', async () => {
+      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const layer = makeLayer('test-layer', Slot.Steering);
+      let receivedLayers: MemoryLayer[] | undefined;
+
+      const step = makeProvideStep(
+        'provide-layers',
+        async (_input, childCtx) => {
+          receivedLayers = (childCtx as Context<ContextMemory> & { layers?: MemoryLayer[] }).layers;
+          return 'done';
+        },
+        [layer],
+      );
+
+      await executeProvide(step, 'input', ctx, simpleExecute);
+      expect(receivedLayers).toBeDefined();
+      expect(receivedLayers).toHaveLength(1);
+      expect(receivedLayers![0].id).toBe('test-layer');
+    });
+
+    it('layers are restored after child completes', async () => {
+      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const layer = makeLayer('temp-layer', Slot.Steering);
+
+      const step = makeProvideStep(
+        'provide-restore',
+        async () => 'done',
+        [layer],
+      );
+
+      expect(ctx.layers).toBeUndefined();
+      await executeProvide(step, 'input', ctx, simpleExecute);
+      expect(ctx.layers).toBeUndefined();
+    });
+
+    it('layers are restored even when child throws', async () => {
+      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const layer = makeLayer('temp-layer', Slot.Steering);
+
+      const step = makeProvideStep(
+        'provide-error',
+        async () => {
+          throw new Error('child error');
+        },
+        [layer],
+      );
+
+      expect(ctx.layers).toBeUndefined();
+      await expect(executeProvide(step, 'input', ctx, simpleExecute)).rejects.toThrow('child error');
+      expect(ctx.layers).toBeUndefined();
+    });
+  });
+
+  describe('no isolation (shared context)', () => {
+    it('events from child append to same itemLog', async () => {
+      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      ctx.itemLog.append(makeMessage('user', 'hello', 'p1'));
+
+      const step = makeProvideStep(
+        'provide-shared-log',
+        async (_input, childCtx) => {
+          childCtx.itemLog.append(makeMessage('assistant', 'world', 'c1'));
+          return 'done';
+        },
+        [makeLayer('l1', Slot.Steering)],
+      );
+
+      await executeProvide(step, 'input', ctx, simpleExecute);
+      expect(ctx.itemLog.items).toHaveLength(2);
+      expect(ctx.itemLog.items[0].id).toBe('p1');
+      expect(ctx.itemLog.items[1].id).toBe('c1');
+    });
+
+    it('state mutations in child are visible to parent', async () => {
+      const ctx = new ContextImpl({ harness: makeMockHarness(), state: { count: 0 } });
+
+      const step = makeProvideStep(
+        'provide-shared-state',
+        async (_input, childCtx) => {
+          (childCtx.state as { count: number }).count = 42;
+          return 'done';
+        },
+        [makeLayer('l1', Slot.Steering)],
+      );
+
+      await executeProvide(step, 'input', ctx, simpleExecute);
+      expect((ctx.state as { count: number }).count).toBe(42);
+    });
+  });
+
+  describe('layer merging (inheritance)', () => {
+    it('nested provide: inner layers merge with outer', async () => {
+      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const outerLayer = makeLayer('outer', Slot.Steering);
+      const innerLayer = makeLayer('inner', Slot.Working);
+      let receivedLayers: MemoryLayer[] | undefined;
+
+      const innerStep: StepProvide<ContextMemory, string, string> = {
+        kind: 'provide',
+        id: 'inner-provide',
+        child: {
+          kind: 'run',
+          id: 'capture',
+          execute: async (_input, childCtx) => {
+            receivedLayers = (childCtx as Context<ContextMemory> & { layers?: MemoryLayer[] }).layers;
+            return 'done';
+          },
+        },
+        memory: [innerLayer],
+      };
+
+      const outerStep: StepProvide<ContextMemory, string, string> = {
+        kind: 'provide',
+        id: 'outer-provide',
+        child: innerStep,
+        memory: [outerLayer],
+      };
+
+      // Need a recursive execute that handles provide
+      const recursiveExecute = async <TMemory, I, O>(
+        s: { kind: string; id: string; execute?: (input: I, ctx: Context<TMemory>) => Promise<O> },
+        input: I,
+        c: Context<TMemory>,
+      ): Promise<O> => {
+        if (s.kind === 'provide') {
+          return executeProvide(
+            s as unknown as StepProvide<TMemory, I, O>,
+            input,
+            c,
+            recursiveExecute as Parameters<typeof executeProvide>[3],
+          );
+        }
+        if (s.kind === 'run' && s.execute) {
+          return s.execute(input, c);
+        }
+        throw new Error(`Unsupported: ${s.kind}`);
+      };
+
+      await executeProvide(
+        outerStep,
+        'input',
+        ctx,
+        recursiveExecute as Parameters<typeof executeProvide>[3],
+      );
+
+      expect(receivedLayers).toBeDefined();
+      expect(receivedLayers).toHaveLength(2);
+      const layerIds = receivedLayers!.map((l) => l.id);
+      expect(layerIds).toContain('outer');
+      expect(layerIds).toContain('inner');
+    });
+
+    it('inner layer overrides outer layer with same id', async () => {
+      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const outerLayer = makeLayer('shared-id', Slot.Steering);
+      const innerLayer = makeLayer('shared-id', Slot.Working);
+      let receivedLayers: MemoryLayer[] | undefined;
+
+      const innerStep: StepProvide<ContextMemory, string, string> = {
+        kind: 'provide',
+        id: 'inner-provide',
+        child: {
+          kind: 'run',
+          id: 'capture',
+          execute: async (_input, childCtx) => {
+            receivedLayers = (childCtx as Context<ContextMemory> & { layers?: MemoryLayer[] }).layers;
+            return 'done';
+          },
+        },
+        memory: [innerLayer],
+      };
+
+      const outerStep: StepProvide<ContextMemory, string, string> = {
+        kind: 'provide',
+        id: 'outer-provide',
+        child: innerStep,
+        memory: [outerLayer],
+      };
+
+      const recursiveExecute = async <TMemory, I, O>(
+        s: { kind: string; id: string; execute?: (input: I, ctx: Context<TMemory>) => Promise<O> },
+        input: I,
+        c: Context<TMemory>,
+      ): Promise<O> => {
+        if (s.kind === 'provide') {
+          return executeProvide(
+            s as unknown as StepProvide<TMemory, I, O>,
+            input,
+            c,
+            recursiveExecute as Parameters<typeof executeProvide>[3],
+          );
+        }
+        if (s.kind === 'run' && s.execute) {
+          return s.execute(input, c);
+        }
+        throw new Error(`Unsupported: ${s.kind}`);
+      };
+
+      await executeProvide(
+        outerStep,
+        'input',
+        ctx,
+        recursiveExecute as Parameters<typeof executeProvide>[3],
+      );
+
+      // Only one layer — inner overrode outer
+      expect(receivedLayers).toHaveLength(1);
+      expect(receivedLayers![0].slot).toBe(Slot.Working);
+    });
+  });
+
+  describe('MemoryConfig support', () => {
+    it('resolves layers from MemoryConfig object', async () => {
+      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const layer = makeLayer('config-layer', Slot.Steering);
+      let receivedLayers: MemoryLayer[] | undefined;
+
+      const step: StepProvide<ContextMemory, string, string> = {
+        kind: 'provide',
+        id: 'provide-config',
+        child: {
+          kind: 'run',
+          id: 'capture',
+          execute: async (_input, childCtx) => {
+            receivedLayers = (childCtx as Context<ContextMemory> & { layers?: MemoryLayer[] }).layers;
+            return 'done';
+          },
+        },
+        memory: { layers: [layer] },
+      };
+
+      await executeProvide(step, 'input', ctx, simpleExecute);
+      expect(receivedLayers).toHaveLength(1);
+      expect(receivedLayers![0].id).toBe('config-layer');
+    });
+  });
+
+  describe('output pass-through', () => {
+    it('returns child output directly', async () => {
+      const ctx = new ContextImpl({ harness: makeMockHarness() });
+
+      const step = makeProvideStep(
+        'provide-passthrough',
+        async () => 'result-value',
+        [makeLayer('l1', Slot.Steering)],
+      );
+
+      const result = await executeProvide(step, 'input', ctx, simpleExecute);
+      expect(result).toBe('result-value');
+    });
+  });
+});
+
+//#endregion

--- a/packages/core/test/interpreter/execute-provide.test.ts
+++ b/packages/core/test/interpreter/execute-provide.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 import { executeProvide } from '../../src/interpreter/execute-provide';
+import { frameworkCast } from '../../src/interpreter/framework-cast';
 import { ContextImpl } from '../../src/runtime/context-impl';
 import type { Context } from '../../src/types/context';
 import type { ContextMemory, MemoryLayer } from '../../src/types/memory';
 import { Slot } from '../../src/types/memory';
-import type { StepProvide } from '../../src/types/step';
+import type { ExecuteStepFn, StepProvide } from '../../src/types/step';
 import { makeMessage, makeMockHarness, simpleExecute } from '../_helpers';
 
 //#region Helper Functions
@@ -36,6 +37,33 @@ function makeLayer(id: string, slot: number): MemoryLayer {
   };
 }
 
+function getLayers(ctx: Context): MemoryLayer[] | undefined {
+  return frameworkCast<{
+    layers?: MemoryLayer[];
+  }>(ctx).layers;
+}
+
+function provideExecute(): ExecuteStepFn {
+  const fn: ExecuteStepFn = async <TMemory, I, O>(
+    s: {
+      kind: string;
+      id: string;
+      execute?: (input: I, ctx: Context<TMemory>) => Promise<O>;
+    },
+    input: I,
+    c: Context<TMemory>,
+  ): Promise<O> => {
+    if (s.kind === 'provide') {
+      return executeProvide(frameworkCast<StepProvide<TMemory, I, O>>(s), input, c, fn);
+    }
+    if (s.kind === 'run' && s.execute) {
+      return s.execute(input, c);
+    }
+    throw new Error(`Unsupported: ${s.kind}`);
+  };
+  return fn;
+}
+
 //#endregion
 
 //#region Tests
@@ -43,17 +71,21 @@ function makeLayer(id: string, slot: number): MemoryLayer {
 describe('executeProvide', () => {
   describe('layer attachment', () => {
     it('child step receives layers on context', async () => {
-      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const ctx = new ContextImpl({
+        harness: makeMockHarness(),
+      });
       const layer = makeLayer('test-layer', Slot.Steering);
       let receivedLayers: MemoryLayer[] | undefined;
 
       const step = makeProvideStep(
         'provide-layers',
         async (_input, childCtx) => {
-          receivedLayers = (childCtx as Context<ContextMemory> & { layers?: MemoryLayer[] }).layers;
+          receivedLayers = getLayers(frameworkCast<Context>(childCtx));
           return 'done';
         },
-        [layer],
+        [
+          layer,
+        ],
       );
 
       await executeProvide(step, 'input', ctx, simpleExecute);
@@ -63,14 +95,14 @@ describe('executeProvide', () => {
     });
 
     it('layers are restored after child completes', async () => {
-      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const ctx = new ContextImpl({
+        harness: makeMockHarness(),
+      });
       const layer = makeLayer('temp-layer', Slot.Steering);
 
-      const step = makeProvideStep(
-        'provide-restore',
-        async () => 'done',
-        [layer],
-      );
+      const step = makeProvideStep('provide-restore', async () => 'done', [
+        layer,
+      ]);
 
       expect(ctx.layers).toBeUndefined();
       await executeProvide(step, 'input', ctx, simpleExecute);
@@ -78,26 +110,30 @@ describe('executeProvide', () => {
     });
 
     it('layers are restored even when child throws', async () => {
-      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const ctx = new ContextImpl({
+        harness: makeMockHarness(),
+      });
       const layer = makeLayer('temp-layer', Slot.Steering);
 
-      const step = makeProvideStep(
-        'provide-error',
-        async () => {
-          throw new Error('child error');
-        },
-        [layer],
-      );
+      const step = makeProvideStep('provide-error', async () => {
+        throw new Error('child error');
+      }, [
+        layer,
+      ]);
 
       expect(ctx.layers).toBeUndefined();
-      await expect(executeProvide(step, 'input', ctx, simpleExecute)).rejects.toThrow('child error');
+      await expect(executeProvide(step, 'input', ctx, simpleExecute)).rejects.toThrow(
+        'child error',
+      );
       expect(ctx.layers).toBeUndefined();
     });
   });
 
   describe('no isolation (shared context)', () => {
     it('events from child append to same itemLog', async () => {
-      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const ctx = new ContextImpl({
+        harness: makeMockHarness(),
+      });
       ctx.itemLog.append(makeMessage('user', 'hello', 'p1'));
 
       const step = makeProvideStep(
@@ -106,7 +142,9 @@ describe('executeProvide', () => {
           childCtx.itemLog.append(makeMessage('assistant', 'world', 'c1'));
           return 'done';
         },
-        [makeLayer('l1', Slot.Steering)],
+        [
+          makeLayer('l1', Slot.Steering),
+        ],
       );
 
       await executeProvide(step, 'input', ctx, simpleExecute);
@@ -116,25 +154,40 @@ describe('executeProvide', () => {
     });
 
     it('state mutations in child are visible to parent', async () => {
-      const ctx = new ContextImpl({ harness: makeMockHarness(), state: { count: 0 } });
+      const ctx = new ContextImpl({
+        harness: makeMockHarness(),
+        state: {
+          count: 0,
+        },
+      });
 
       const step = makeProvideStep(
         'provide-shared-state',
         async (_input, childCtx) => {
-          (childCtx.state as { count: number }).count = 42;
+          frameworkCast<{
+            count: number;
+          }>(childCtx.state).count = 42;
           return 'done';
         },
-        [makeLayer('l1', Slot.Steering)],
+        [
+          makeLayer('l1', Slot.Steering),
+        ],
       );
 
       await executeProvide(step, 'input', ctx, simpleExecute);
-      expect((ctx.state as { count: number }).count).toBe(42);
+      expect(
+        frameworkCast<{
+          count: number;
+        }>(ctx.state).count,
+      ).toBe(42);
     });
   });
 
   describe('layer merging (inheritance)', () => {
     it('nested provide: inner layers merge with outer', async () => {
-      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const ctx = new ContextImpl({
+        harness: makeMockHarness(),
+      });
       const outerLayer = makeLayer('outer', Slot.Steering);
       const innerLayer = makeLayer('inner', Slot.Working);
       let receivedLayers: MemoryLayer[] | undefined;
@@ -146,46 +199,25 @@ describe('executeProvide', () => {
           kind: 'run',
           id: 'capture',
           execute: async (_input, childCtx) => {
-            receivedLayers = (childCtx as Context<ContextMemory> & { layers?: MemoryLayer[] }).layers;
+            receivedLayers = getLayers(childCtx);
             return 'done';
           },
         },
-        memory: [innerLayer],
+        memory: [
+          innerLayer,
+        ],
       };
 
       const outerStep: StepProvide<ContextMemory, string, string> = {
         kind: 'provide',
         id: 'outer-provide',
         child: innerStep,
-        memory: [outerLayer],
+        memory: [
+          outerLayer,
+        ],
       };
 
-      // Need a recursive execute that handles provide
-      const recursiveExecute = async <TMemory, I, O>(
-        s: { kind: string; id: string; execute?: (input: I, ctx: Context<TMemory>) => Promise<O> },
-        input: I,
-        c: Context<TMemory>,
-      ): Promise<O> => {
-        if (s.kind === 'provide') {
-          return executeProvide(
-            s as unknown as StepProvide<TMemory, I, O>,
-            input,
-            c,
-            recursiveExecute as Parameters<typeof executeProvide>[3],
-          );
-        }
-        if (s.kind === 'run' && s.execute) {
-          return s.execute(input, c);
-        }
-        throw new Error(`Unsupported: ${s.kind}`);
-      };
-
-      await executeProvide(
-        outerStep,
-        'input',
-        ctx,
-        recursiveExecute as Parameters<typeof executeProvide>[3],
-      );
+      await executeProvide(outerStep, 'input', ctx, provideExecute());
 
       expect(receivedLayers).toBeDefined();
       expect(receivedLayers).toHaveLength(2);
@@ -195,7 +227,9 @@ describe('executeProvide', () => {
     });
 
     it('inner layer overrides outer layer with same id', async () => {
-      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const ctx = new ContextImpl({
+        harness: makeMockHarness(),
+      });
       const outerLayer = makeLayer('shared-id', Slot.Steering);
       const innerLayer = makeLayer('shared-id', Slot.Working);
       let receivedLayers: MemoryLayer[] | undefined;
@@ -207,45 +241,25 @@ describe('executeProvide', () => {
           kind: 'run',
           id: 'capture',
           execute: async (_input, childCtx) => {
-            receivedLayers = (childCtx as Context<ContextMemory> & { layers?: MemoryLayer[] }).layers;
+            receivedLayers = getLayers(childCtx);
             return 'done';
           },
         },
-        memory: [innerLayer],
+        memory: [
+          innerLayer,
+        ],
       };
 
       const outerStep: StepProvide<ContextMemory, string, string> = {
         kind: 'provide',
         id: 'outer-provide',
         child: innerStep,
-        memory: [outerLayer],
+        memory: [
+          outerLayer,
+        ],
       };
 
-      const recursiveExecute = async <TMemory, I, O>(
-        s: { kind: string; id: string; execute?: (input: I, ctx: Context<TMemory>) => Promise<O> },
-        input: I,
-        c: Context<TMemory>,
-      ): Promise<O> => {
-        if (s.kind === 'provide') {
-          return executeProvide(
-            s as unknown as StepProvide<TMemory, I, O>,
-            input,
-            c,
-            recursiveExecute as Parameters<typeof executeProvide>[3],
-          );
-        }
-        if (s.kind === 'run' && s.execute) {
-          return s.execute(input, c);
-        }
-        throw new Error(`Unsupported: ${s.kind}`);
-      };
-
-      await executeProvide(
-        outerStep,
-        'input',
-        ctx,
-        recursiveExecute as Parameters<typeof executeProvide>[3],
-      );
+      await executeProvide(outerStep, 'input', ctx, provideExecute());
 
       // Only one layer — inner overrode outer
       expect(receivedLayers).toHaveLength(1);
@@ -255,7 +269,9 @@ describe('executeProvide', () => {
 
   describe('MemoryConfig support', () => {
     it('resolves layers from MemoryConfig object', async () => {
-      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const ctx = new ContextImpl({
+        harness: makeMockHarness(),
+      });
       const layer = makeLayer('config-layer', Slot.Steering);
       let receivedLayers: MemoryLayer[] | undefined;
 
@@ -266,11 +282,15 @@ describe('executeProvide', () => {
           kind: 'run',
           id: 'capture',
           execute: async (_input, childCtx) => {
-            receivedLayers = (childCtx as Context<ContextMemory> & { layers?: MemoryLayer[] }).layers;
+            receivedLayers = getLayers(childCtx);
             return 'done';
           },
         },
-        memory: { layers: [layer] },
+        memory: {
+          layers: [
+            layer,
+          ],
+        },
       };
 
       await executeProvide(step, 'input', ctx, simpleExecute);
@@ -281,13 +301,13 @@ describe('executeProvide', () => {
 
   describe('output pass-through', () => {
     it('returns child output directly', async () => {
-      const ctx = new ContextImpl({ harness: makeMockHarness() });
+      const ctx = new ContextImpl({
+        harness: makeMockHarness(),
+      });
 
-      const step = makeProvideStep(
-        'provide-passthrough',
-        async () => 'result-value',
-        [makeLayer('l1', Slot.Steering)],
-      );
+      const step = makeProvideStep('provide-passthrough', async () => 'result-value', [
+        makeLayer('l1', Slot.Steering),
+      ]);
 
       const result = await executeProvide(step, 'input', ctx, simpleExecute);
       expect(result).toBe('result-value');

--- a/packages/core/test/runtime/harness-memory.test.ts
+++ b/packages/core/test/runtime/harness-memory.test.ts
@@ -26,9 +26,13 @@ describe('AgentHarness memory', () => {
       const layer = makeLayer('harness-layer', Slot.Steering);
       const harness = new AgentHarness({
         name: 'test',
-        memory: [layer],
+        memory: [
+          layer,
+        ],
         params: {},
-        _testCallModel: createScriptedCallModel([textOnlyResponse('ok')]),
+        _testCallModel: createScriptedCallModel([
+          textOnlyResponse('ok'),
+        ]),
       });
 
       const ctx = harness.createContext();
@@ -42,12 +46,20 @@ describe('AgentHarness memory', () => {
       const callLayer = makeLayer('call-layer', Slot.Working);
       const harness = new AgentHarness({
         name: 'test',
-        memory: [harnessLayer],
+        memory: [
+          harnessLayer,
+        ],
         params: {},
-        _testCallModel: createScriptedCallModel([textOnlyResponse('ok')]),
+        _testCallModel: createScriptedCallModel([
+          textOnlyResponse('ok'),
+        ]),
       });
 
-      const ctx = harness.createContext({ memory: [callLayer] });
+      const ctx = harness.createContext({
+        memory: [
+          callLayer,
+        ],
+      });
       expect(ctx.layers).toHaveLength(1);
       expect(ctx.layers![0].id).toBe('call-layer');
     });
@@ -56,7 +68,9 @@ describe('AgentHarness memory', () => {
       const harness = new AgentHarness({
         name: 'test',
         params: {},
-        _testCallModel: createScriptedCallModel([textOnlyResponse('ok')]),
+        _testCallModel: createScriptedCallModel([
+          textOnlyResponse('ok'),
+        ]),
       });
 
       const ctx = harness.createContext();
@@ -79,9 +93,13 @@ describe('AgentHarness memory', () => {
             return 'done';
           },
         },
-        memory: [layer],
+        memory: [
+          layer,
+        ],
         params: {},
-        _testCallModel: createScriptedCallModel([textOnlyResponse('ok')]),
+        _testCallModel: createScriptedCallModel([
+          textOnlyResponse('ok'),
+        ]),
       });
 
       await harness.execute('hello');

--- a/packages/core/test/runtime/harness-memory.test.ts
+++ b/packages/core/test/runtime/harness-memory.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'bun:test';
+import { AgentHarness } from '../../src/runtime/agent-harness';
+import type { MemoryLayer } from '../../src/types/memory';
+import { Slot } from '../../src/types/memory';
+import { createScriptedCallModel, textOnlyResponse } from '../_helpers';
+
+//#region Helper Functions
+
+function makeLayer(id: string, slot: number): MemoryLayer {
+  return {
+    id,
+    name: id,
+    slot,
+    scope: 'execution',
+    hooks: {},
+  };
+}
+
+//#endregion
+
+//#region Tests
+
+describe('AgentHarness memory', () => {
+  describe('createContext with harness-level memory', () => {
+    it('context inherits harness memory by default', () => {
+      const layer = makeLayer('harness-layer', Slot.Steering);
+      const harness = new AgentHarness({
+        name: 'test',
+        memory: [layer],
+        params: {},
+        _testCallModel: createScriptedCallModel([textOnlyResponse('ok')]),
+      });
+
+      const ctx = harness.createContext();
+      expect(ctx.layers).toBeDefined();
+      expect(ctx.layers).toHaveLength(1);
+      expect(ctx.layers![0].id).toBe('harness-layer');
+    });
+
+    it('per-call memory overrides harness memory', () => {
+      const harnessLayer = makeLayer('harness-layer', Slot.Steering);
+      const callLayer = makeLayer('call-layer', Slot.Working);
+      const harness = new AgentHarness({
+        name: 'test',
+        memory: [harnessLayer],
+        params: {},
+        _testCallModel: createScriptedCallModel([textOnlyResponse('ok')]),
+      });
+
+      const ctx = harness.createContext({ memory: [callLayer] });
+      expect(ctx.layers).toHaveLength(1);
+      expect(ctx.layers![0].id).toBe('call-layer');
+    });
+
+    it('no memory on harness or call produces undefined layers', () => {
+      const harness = new AgentHarness({
+        name: 'test',
+        params: {},
+        _testCallModel: createScriptedCallModel([textOnlyResponse('ok')]),
+      });
+
+      const ctx = harness.createContext();
+      expect(ctx.layers).toBeUndefined();
+    });
+  });
+
+  describe('execute with harness-level memory', () => {
+    it('execute passes harness memory to context', async () => {
+      const layer = makeLayer('exec-layer', Slot.Steering);
+      let contextLayers: MemoryLayer[] | undefined;
+
+      const harness = new AgentHarness({
+        name: 'test',
+        initialStep: {
+          kind: 'run',
+          id: 'capture',
+          execute: async (_input, ctx) => {
+            contextLayers = ctx.layers;
+            return 'done';
+          },
+        },
+        memory: [layer],
+        params: {},
+        _testCallModel: createScriptedCallModel([textOnlyResponse('ok')]),
+      });
+
+      await harness.execute('hello');
+      expect(contextLayers).toBeDefined();
+      expect(contextLayers).toHaveLength(1);
+      expect(contextLayers![0].id).toBe('exec-layer');
+    });
+  });
+});
+
+//#endregion

--- a/packages/web/content/docs/api/runtime-types.mdx
+++ b/packages/web/content/docs/api/runtime-types.mdx
@@ -12,7 +12,7 @@ interface AgentHarness<TParams extends Record<string, unknown> = Record<string, 
   readonly config: AgentConfig<TParams>;
   run<I, O>(step: Step<ContextMemory, I, O>, input: I, ctx: Context): Promise<O>;
   detachedSpawn<I, O>(step: Step<ContextMemory, I, O>, input: I, parentCtx: Context): DetachedHandle<O>;
-  createContext(opts?: CreateContextOpts): Context;
+  createContext(opts?: CreateContextOpts & { memory?: MemoryLayer[] }): Context;
   send<T>(channel: Channel<T>, value: T, ctx: Context): void;
   recv<T>(channel: Channel<T>, ctx: Context, opts?: { timeout?: number }): Promise<T>;
   tryRecv<T>(channel: Channel<T>, ctx: Context): T | null;
@@ -35,7 +35,7 @@ interface AgentHarness<TParams extends Record<string, unknown> = Record<string, 
 | `config` | The `AgentConfig<TParams>` the harness was constructed with |
 | `run(step, input, ctx)` | Run a step with the given input and context |
 | `detachedSpawn(step, input, parentCtx)` | Launch a step concurrently, returning a `DetachedHandle` |
-| `createContext(opts?)` | Create a new execution context |
+| `createContext(opts?)` | Create a new execution context. Accepts optional `memory` to override harness-level defaults. |
 | `send(channel, value, ctx)` | Send a value to a channel |
 | `recv(channel, ctx, opts?)` | Receive from a channel (blocking) |
 | `tryRecv(channel, ctx)` | Non-blocking receive |

--- a/packages/web/content/docs/api/step-types.mdx
+++ b/packages/web/content/docs/api/step-types.mdx
@@ -15,6 +15,7 @@ type Step<TMemory = ContextMemory, I = unknown, O = unknown> =
   | StepBranch<TMemory, I, O>
   | StepFork<TMemory, I, O>
   | StepSpawn<TMemory, I, O>
+  | StepProvide<TMemory, I, O>
   | StepLoop<TMemory, I, O>;
 ```
 
@@ -105,6 +106,17 @@ Fork has three mode variants, each a separate interface.
 | `paths` | `(input: I, ctx: Context<TMemory>) => Step<TMemory, I, O>[]` | yes | Path factory |
 | `merge` | `(results: SettleResult<O>[], ctx: Context<TMemory>) => O` | yes | Merge function |
 | `concurrency` | `number` | no | Max parallel paths |
+
+## StepProvide
+
+`StepProvide<TMemory, I, O>`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `kind` | `'provide'` | yes | Discriminant |
+| `id` | `string` | yes | Step identifier |
+| `child` | `Step<TMemory, I, O>` | yes | Child step to execute with the provided layers |
+| `memory` | `MemoryConfig \| MemoryLayer[]` | yes | Memory layers available to all descendant steps |
 
 ## StepSpawn
 

--- a/packages/web/content/docs/operators/meta.json
+++ b/packages/web/content/docs/operators/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Operators",
-  "pages": ["branch", "fork", "conditions", "spawn", "loop-and-until", "channels"]
+  "pages": ["branch", "fork", "conditions", "spawn", "provide", "loop-and-until", "channels"]
 }

--- a/packages/web/content/docs/operators/provide.mdx
+++ b/packages/web/content/docs/operators/provide.mdx
@@ -1,0 +1,67 @@
+---
+title: provide
+description: Attach memory layers to descendant steps without creating an isolated context.
+---
+
+## Quick Example
+
+```ts
+import { provide, step } from '@noetic/core';
+
+const withLayers = provide({
+  id: 'with-knowledge',
+  child: step.llm({
+    id: 'researcher',
+    model: 'gpt-4o',
+    system: 'Research the topic thoroughly.',
+  }),
+  memory: [knowledgeLayer, steeringLayer],
+});
+```
+
+## What It Does
+
+`provide` attaches memory layers to a subtree of steps without creating an isolated context. Like React's `Context.Provider`, layers become available to all descendant steps -- the child shares the parent's `ItemLog` and conversation history.
+
+This is the primitive for scoping memory layers to a section of your execution tree. Any `StepLLM` descendant will have access to the provided layers during recall, store, and steering hooks.
+
+`spawn` and `detachedSpawn` break the inheritance chain. If a descendant step spawns a child, the provided layers do not propagate into the spawn boundary.
+
+## API Reference
+
+| Property | Type | Required | Description |
+| --- | --- | --- | --- |
+| `id` | `string` | Yes | Unique step identifier |
+| `child` | `Step<TMemory, I, O>` | Yes | The step to execute with the provided layers |
+| `memory` | `MemoryConfig \| MemoryLayer[]` | Yes | Memory layers available to all descendant steps |
+
+## Example: Scoped Knowledge Layer
+
+Attach a knowledge base layer only to a specific subtree, without affecting sibling steps:
+
+```ts
+import { provide, step } from '@noetic/core';
+
+const researchPhase = provide({
+  id: 'research-with-knowledge',
+  child: {
+    kind: 'loop',
+    id: 'research-loop',
+    steps: [step.llm({
+      id: 'researcher-llm',
+      model: 'gpt-4o',
+      system: 'You are a research assistant.',
+      tools: [searchTool],
+    })],
+    until: until.noToolCalls(),
+    maxIterations: 10,
+  },
+  memory: [semanticMemory, steeringLayer],
+});
+```
+
+## Related
+
+- [spawn](/docs/operators/spawn) -- context isolation with spawn-local memory layers.
+- [Memory](/docs/memory) -- memory layer system overview.
+- [Overview](/docs/overview) -- how provide fits into the step primitives.

--- a/packages/web/content/docs/operators/spawn.mdx
+++ b/packages/web/content/docs/operators/spawn.mdx
@@ -275,8 +275,21 @@ The LLM sees both tools and their descriptions, then decides per-task:
 
 When a background agent finishes, its result arrives via the inbox channel as a developer message. The loop wakes, the LLM sees the result, and incorporates it.
 
+## provide vs spawn
+
+Use [`provide`](/docs/operators/provide) when you want to attach memory layers to a subtree without isolating the child context. The child shares the parent's `ItemLog` and conversation history -- layers simply become available to all descendant steps.
+
+Use `spawn` when you need full context isolation. The child starts with an empty `ItemLog`, and `onSpawn` / `onReturn` hooks control data flow across the boundary.
+
+| | `provide` | `spawn` |
+|---|---|---|
+| Child context | Shared with parent | Isolated (empty `ItemLog`) |
+| Memory layers | Inherited by descendants | Spawn-local only |
+| Use case | Attach layers to a subtree | Sub-agents, delegation, sandboxing |
+
 ## Related
 
+- [provide](/docs/operators/provide) -- attach memory layers without context isolation.
 - [fork](/docs/operators/fork) -- parallel execution without context isolation.
 - [Loop & Until](/docs/operators/loop-and-until) -- use a loop as a spawn child for iterative sub-agents.
 - [Overview](/docs/overview) -- how spawn fits into the seven primitives.

--- a/packages/web/content/docs/runtime.mdx
+++ b/packages/web/content/docs/runtime.mdx
@@ -42,6 +42,7 @@ const harness = new AgentHarness({
 | `name` | `string` | required | Agent name (populates `config.name`). |
 | `initialStep` | `Step<TMemory, string, string>` | `undefined` | The agent step to execute when calling `execute()`. `TMemory` defaults to `ContextMemory`. |
 | `params` | `TParams` | required | Arbitrary key-value parameters (populates `config.params`). |
+| `memory` | `MemoryLayer[]` | `undefined` | Default memory layers applied to every context created via `createContext()` / `execute()`. |
 | `storage` | `StorageAdapter` | `undefined` | Storage backend for memory persistence. |
 | `hooks` | `AgentHooks` | `undefined` | Before/after step hooks. |
 | `paramsSchema` | `ZodType` | `undefined` | Optional Zod schema to validate `params` at construction time. |
@@ -99,6 +100,7 @@ const result = await harness.run(myStep, input, ctx);
 | `state` | `unknown` | Initial mutable state. |
 | `threadId` | `string` | Conversation thread identifier. |
 | `resourceId` | `string` | Optional resource/tenant identifier. |
+| `memory` | `MemoryLayer[]` | Memory layers for this context. Overrides harness-level `memory` if provided. |
 
 ## Channel Methods
 

--- a/specs/01-step-type.md
+++ b/specs/01-step-type.md
@@ -7,17 +7,18 @@
 
 ## The `Step<I, O>` Discriminated Union
 
-`Step` is a single type with seven variants. The runtime pattern-matches on `kind`. Builder functions (`step.run(...)`, `fork(...)`, etc.) are constructors for the union variants.
+`Step` is a single type with eight variants. The runtime pattern-matches on `kind`. Builder functions (`step.run(...)`, `fork(...)`, etc.) are constructors for the union variants.
 
 ```typescript
 type Step<I, O> =
-  | { kind: 'run';    id: string; execute: (input: I, ctx: Context) => Promise<O>; retry?: RetryPolicy }
-  | { kind: 'llm';    id: string; model: string; system?: string; tools?: Tool[]; output?: ZodType<O>; params?: ModelParams }
-  | { kind: 'tool';   id: string; tool: Tool; args?: unknown }
-  | { kind: 'branch'; id: string; route: (input: I, ctx: Context) => Step<I, O> | null }
-  | { kind: 'fork';   id: string; mode: 'all' | 'race' | 'settle'; paths: (input: I, ctx: Context) => Step<I, O>[]; merge?: MergeFn<O>; concurrency?: number }
-  | { kind: 'spawn';  id: string; child: Step<I, O>; memory?: MemoryLayer[]; timeout?: number }
-  | { kind: 'loop';   id: string; body: Step<I, O>; until: Until; maxIterations?: number; maxHistorySize?: number; prepareNext?: (output: O, verdict: Verdict, ctx: Context) => I; onError?: (error: NoeticError, ctx: Context) => 'retry' | 'skip' | 'abort' }
+  | { kind: 'run';     id: string; execute: (input: I, ctx: Context) => Promise<O>; retry?: RetryPolicy }
+  | { kind: 'llm';     id: string; model: string; system?: string; tools?: Tool[]; output?: ZodType<O>; params?: ModelParams }
+  | { kind: 'tool';    id: string; tool: Tool; args?: unknown }
+  | { kind: 'branch';  id: string; route: (input: I, ctx: Context) => Step<I, O> | null }
+  | { kind: 'fork';    id: string; mode: 'all' | 'race' | 'settle'; paths: (input: I, ctx: Context) => Step<I, O>[]; merge?: MergeFn<O>; concurrency?: number }
+  | { kind: 'spawn';   id: string; child: Step<I, O>; memory?: MemoryLayer[]; timeout?: number }
+  | { kind: 'provide'; id: string; child: Step<I, O>; memory: MemoryConfig | MemoryLayer[] }
+  | { kind: 'loop';    id: string; body: Step<I, O>; until: Until; maxIterations?: number; maxHistorySize?: number; prepareNext?: (output: O, verdict: Verdict, ctx: Context) => I; onError?: (error: NoeticError, ctx: Context) => 'retry' | 'skip' | 'abort' }
 ```
 
 Each variant is specified in its own feature spec:
@@ -30,6 +31,7 @@ Each variant is specified in its own feature spec:
 | `branch` | `03-control-flow` | Conditional routing |
 | `fork` | `03-control-flow` | Parallel execution |
 | `spawn` | `04-spawn` | Child execution with context boundary |
+| `provide` | `02-step-variants` | Scoped memory layer injection |
 | `loop` | `05-loop-and-until` | Repeating execution with termination |
 
 ## The `execute()` Interpreter
@@ -39,18 +41,19 @@ The runtime is a single recursive interpreter:
 ```typescript
 async function execute<I, O>(step: Step<I, O>, input: I, ctx: Context): Promise<O> {
   switch (step.kind) {
-    case 'run':    return executeRun(step, input, ctx);
-    case 'llm':    return executeLLM(step, input, ctx);
-    case 'tool':   return executeTool(step, input, ctx);
-    case 'branch': return executeBranch(step, input, ctx);
-    case 'fork':   return executeFork(step, input, ctx);
-    case 'spawn':  return executeSpawn(step, input, ctx);
-    case 'loop':   return executeLoop(step, input, ctx);
+    case 'run':     return executeRun(step, input, ctx);
+    case 'llm':     return executeLLM(step, input, ctx);
+    case 'tool':    return executeTool(step, input, ctx);
+    case 'branch':  return executeBranch(step, input, ctx);
+    case 'fork':    return executeFork(step, input, ctx);
+    case 'spawn':   return executeSpawn(step, input, ctx);
+    case 'provide': return executeProvide(step, input, ctx);
+    case 'loop':    return executeLoop(step, input, ctx);
   }
 }
 ```
 
-This makes the "everything is a Step" claim true at the type level. The primitive count debate dissolves: one type, seven variants.
+This makes the "everything is a Step" claim true at the type level. The primitive count debate dissolves: one type, eight variants.
 
 ## The `O` Contract
 

--- a/specs/02-step-variants.md
+++ b/specs/02-step-variants.md
@@ -1,7 +1,7 @@
-# Step Variants: `run`, `llm`, `tool`
+# Step Variants: `run`, `llm`, `tool`, `provide`
 
-> **Depends On:** `01-step-type` (Step<I,O>, execute)
-> **Exports:** `step.run()`, `step.llm()`, `step.tool()`, `StepRunOpts`, `StepLLMOpts`, `StepToolOpts`, `Tool`, `RetryPolicy`, `ModelParams`
+> **Depends On:** `01-step-type` (Step<I,O>, execute), `11-memory-layer-system` (MemoryLayer, MemoryConfig)
+> **Exports:** `step.run()`, `step.llm()`, `step.tool()`, `step.provide()`, `StepRunOpts`, `StepLLMOpts`, `StepToolOpts`, `StepProvideOpts`, `Tool`, `RetryPolicy`, `ModelParams`
 
 ---
 
@@ -185,12 +185,50 @@ interface Tool<I extends ZodTypeAny = ZodTypeAny, O extends ZodTypeAny = ZodType
 
 ---
 
-## Why Three Execution Variants?
+## Variant: `provide` — Scoped Memory Layer Injection
+
+Attaches memory layers to a descendant step subtree without creating an isolated context. Analogous to React's `Context.Provider` — the layers are available to all descendant `llm` steps without the context boundary that `spawn` introduces.
+
+```typescript
+interface StepProvideOpts<TMemory, I, O> {
+  id: string;
+  child: Step<TMemory, I, O>;
+  memory: MemoryConfig | MemoryLayer[];
+}
+```
+
+```typescript
+const withMemory = step.provide({
+  id: 'inject-working-memory',
+  child: analyzeAndRespond,
+  memory: memory([workingMemory(), semanticRecall({ embedder })]),
+});
+```
+
+### Semantics
+
+1. **No context boundary.** Unlike `spawn`, the child step shares the parent's `Context` and `ItemLog`. There is no `onSpawn`/`onReturn` lifecycle.
+2. **Layer merging.** The provided layers are appended to whatever layers the parent already has. Descendant `llm` steps see the merged set.
+3. **Scoped lifetime.** Provided layers are initialized when `provide` begins and disposed when the child completes. They do not outlive the `provide` boundary.
+4. **Composable.** `provide` steps can nest. Inner `provide` layers merge with outer ones. Duplicate layer IDs follow the same resolution rules as top-level layer deduplication (see `11-memory-layer-system`).
+
+### When to Use `provide` vs `spawn`
+
+| Concern | `provide` | `spawn` |
+|---------|-----------|---------|
+| Context isolation | Shared — same ItemLog | Isolated — fresh ItemLog |
+| Memory layers | Merged with parent | Replaced or propagated via `onSpawn` |
+| Use case | "Add capabilities to this subtree" | "Run this work with a different context window" |
+
+---
+
+## Why Four Execution Variants?
 
 The agent harness needs to treat them differently:
 
 - **LLM steps** have cost implications, need model routing, produce telemetry with GenAI semantic conventions, and their output may contain tool calls that drive the next iteration.
 - **Tool steps** may have side effects, may need human approval before execution, and may need sandboxing.
 - **Run steps** are pure computation — the agent harness can retry freely, cache results, and doesn't need to track token usage.
+- **Provide steps** are structural — they configure the memory layer environment for a subtree without altering execution semantics or creating context boundaries.
 
 A single `step()` that inspects its arguments loses type safety and forces runtime introspection. Explicit variants mean the TypeScript compiler knows exactly what you're doing.

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -27,6 +27,7 @@ interface AgentHarness<TParams extends Record<string, unknown> = Record<string, 
     state?: unknown;
     threadId?: string;
     resourceId?: string;
+    memory?: MemoryLayer[];
   }): Context;
 
   // Channel operations (the agent harness owns the backing store)
@@ -98,6 +99,7 @@ interface DetachedHandle<O> {
 - **`beforeToolCall(layers, toolName, toolArgs, ctx)`** runs each layer's `beforeToolCall` hook sequentially in slot order before a tool is executed. Returns a `SteeringDecision` — `Allow` proceeds normally, `Deny` short-circuits and blocks the tool call, `Guide` returns guidance text to the model. Short-circuits on the first `Deny`. When multiple layers return `Guide`, their guidance is concatenated.
 - **`afterModelCall(layers, response, ctx)`** runs each layer's `afterModelCall` hook sequentially in slot order immediately after the LLM responds. Returns a `SteeringDecision` — `Allow` proceeds normally, `Deny` throws `steering_denied`, `Guide` injects guidance as a developer message and retries the model call (up to 3 times). Short-circuits on the first `Deny`.
 - **`config`** exposes the `AgentConfig<TParams>` that the harness was constructed with. Steps and tools access harness params via `ctx.harness.config.params`.
+- **`memory` on AgentConfig** are default memory layers applied to every context created via `createContext()`. When `createContext` is called with its own `memory` option, the per-call layers take precedence (full override, not merge). When neither is specified, the context has no default layers. This provides a convenient way to set up memory for the entire agent without passing layers to every call.
 - **`detachedSpawn`** launches a child step concurrently without blocking the caller. Creates a child `Context` with `parent: parentCtx`, starts execution, and returns a `DetachedHandle` immediately. The handle tracks status (`running` / `completed` / `failed`), exposes the result, and supports `await(timeout?)` for blocking on completion. Pairs with the loop inbox channel (see `05-loop-and-until`) for async sub-agent notification patterns.
 - **`checkpoint`/`restore`** enable durable execution. `AgentHarness` implements them as no-ops. `DurableAgentHarness` serializes state (including memory layer state) to its backing store.
 - **`cancel`** with propagation. The agent harness knows the execution tree (via parent/child context references) and walks it to cancel children. Cancelled executions still run `onComplete` and `dispose` on their memory layers.
@@ -121,10 +123,12 @@ interface DetachedHandle<O> {
 
 ```typescript
 import { setHarness, AgentHarness } from '@noetic/core';
+import { workingMemory, semanticRecall } from '@noetic/core';
 
 setHarness(new AgentHarness({
   name: 'my-agent',
   params: { model: 'anthropic/claude-sonnet-4-20250514' },
+  memory: [workingMemory(), semanticRecall({ embedder })],
 }));
 ```
 
@@ -211,6 +215,9 @@ interface AgentConfig<TParams extends Record<string, unknown> = Record<string, u
 
   /** Agent-level lifecycle hooks (separate from memory hooks). */
   hooks?: AgentHooks;
+
+  /** Default memory layers applied to every context created via createContext() / execute(). */
+  memory?: MemoryLayer[];
 
   /** Arbitrary key-value parameters accessible via ctx.harness.config.params. */
   params: TParams;


### PR DESCRIPTION
## Summary

- Adds `provide()` step operator that attaches memory layers to descendant steps **without context isolation** (like React's Context.Provider). Events stream through in real-time — no buffering like `spawn`.
- Adds `memory` option on `AgentHarness` constructor — default layers auto-applied to every `createContext()` / `execute()` call.
- Adds `memory` option on `createContext()` for per-call override of harness defaults.
- Updates the Claude Code agent guide to use `loop()` as `initialStep` with harness-level `memory` instead of wrapping in `spawn`.

## Test plan

- [x] 13 new tests for `executeProvide` (layer attachment, shared context, merging/inheritance, MemoryConfig support, output pass-through, error recovery)
- [x] 4 new tests for `AgentHarness` memory (harness-level layers, per-call override, execute passthrough)
- [x] Full test suite passes (576 tests, 0 failures)
- [x] Typecheck clean (no new src/ errors)
- [x] Biome lint clean
- [x] Specs, skills, and web docs updated