### PR TITLE
feat(chat-sdk): @noetic/chat-sdk adapter for chat-sdk.dev

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,19 @@
         "@biomejs/biome": "^2.3.11",
       },
     },
+    "packages/chat-sdk": {
+      "name": "@noetic/chat-sdk",
+      "version": "0.1.0",
+      "dependencies": {
+        "@noetic/core": "workspace:*",
+        "chat": "4.23.0",
+        "typescript": "5.9.3",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "bun-types": "latest",
+      },
+    },
     "packages/cli": {
       "name": "@noetic/cli",
       "version": "0.1.0",
@@ -279,6 +292,8 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.1.6", "", { "os": "win32", "cpu": "x64" }, "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A=="],
 
+    "@noetic/chat-sdk": ["@noetic/chat-sdk@workspace:packages/chat-sdk"],
+
     "@noetic/cli": ["@noetic/cli@workspace:packages/cli"],
 
     "@noetic/core": ["@noetic/core@workspace:packages/core"],
@@ -449,6 +464,8 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
+    "@workflow/serde": ["@workflow/serde@4.1.0-beta.2", "", {}, "sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
@@ -480,6 +497,8 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "chat": ["chat@4.23.0", "", { "dependencies": { "@workflow/serde": "4.1.0-beta.2", "mdast-util-to-string": "^4.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "remend": "^1.2.1", "unified": "^11.0.5" } }, "sha512-Gmw8yyDrrH9Vxs+TfxF7FoTENrCzJV4T0FiAh7APGcQPhMMYAhrpq66PKj8azhkUSEyaen8ujbneogoJWiY8vg=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
@@ -848,6 +867,8 @@
     "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
+    "remend": ["remend@1.3.0", "", {}, "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw=="],
 
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 

--- a/packages/chat-sdk/package.json
+++ b/packages/chat-sdk/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@noetic/chat-sdk",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@noetic/core": "workspace:*",
+    "chat": "4.23.0",
+    "typescript": "5.9.3",
+    "zod": "4.3.6"
+  },
+  "devDependencies": {
+    "bun-types": "latest"
+  },
+  "scripts": {
+    "test": "bun test",
+    "test:coverage": "bun test --coverage --coverage-reporter=text --coverage-reporter=json",
+    "test:ci": "bun test --coverage --coverage-reporter=json",
+    "typecheck": "bunx tsc --noEmit",
+    "lint": "bunx biome check .",
+    "lint:fix": "bunx biome check --fix .",
+    "format": "bunx biome format --write .",
+    "format:check": "bunx biome format ."
+  }
+}

--- a/packages/chat-sdk/src/chat-stream.ts
+++ b/packages/chat-sdk/src/chat-stream.ts
@@ -1,0 +1,53 @@
+import type { HarnessResult, StreamEvent } from '@noetic/core';
+
+//#region Helper
+
+function isTextDelta(event: StreamEvent): boolean {
+  return event.source === 'sdk' && event.type === 'response.output_text.delta';
+}
+
+function isToolRoundCompleted(event: StreamEvent): boolean {
+  return event.source === 'framework' && event.type.endsWith(':tool_round_completed');
+}
+
+//#endregion
+
+//#region Public API
+
+/**
+ * Convert a Noetic HarnessResult into an AsyncIterable<string> suitable for
+ * chat-sdk's `thread.post()`. Equivalent to AI SDK's `fullStream` —
+ * yields text deltas and injects paragraph breaks between tool rounds.
+ *
+ * @param result - The HarnessResult from harness.execute()
+ * @returns AsyncIterable<string> compatible with thread.post()
+ *
+ * @public
+ */
+export async function* chatStream(result: HarnessResult): AsyncIterable<string> {
+  let hasEmittedText = false;
+
+  for await (const event of result.getFullStream()) {
+    if (isToolRoundCompleted(event)) {
+      if (hasEmittedText) {
+        yield '\n\n';
+        hasEmittedText = false;
+      }
+      continue;
+    }
+
+    if (!isTextDelta(event)) {
+      continue;
+    }
+
+    const delta = event.data.delta;
+    if (typeof delta !== 'string') {
+      continue;
+    }
+
+    hasEmittedText = true;
+    yield delta;
+  }
+}
+
+//#endregion

--- a/packages/chat-sdk/src/chat-tool.ts
+++ b/packages/chat-sdk/src/chat-tool.ts
@@ -1,0 +1,82 @@
+import type { Tool, ToolExecutionContext } from '@noetic/core';
+import type { ZodTypeAny, z } from 'zod';
+
+import type { ChatTool, ChatToolRenderable } from './types';
+
+//#region Types
+
+/** @public Configuration for creating a ChatTool. */
+export interface ChatToolConfig<I extends ZodTypeAny, O extends ZodTypeAny> {
+  /** Unique tool name used by the LLM for selection. */
+  name: string;
+  /** Human-readable description shown to the LLM. */
+  description: string;
+  /** Zod schema validating tool input arguments. */
+  input: I;
+  /** Zod schema validating tool return value. */
+  output: O;
+  /** Async function that performs the tool's work. */
+  execute: (args: z.infer<I>, toolCtx: ToolExecutionContext) => Promise<z.infer<O>>;
+  /** When true, execution pauses for human approval before running. */
+  needsApproval?: boolean;
+  /** Render tool output as a chat-sdk card or string for posting after execution. */
+  render?: (output: unknown) => ChatToolRenderable;
+}
+
+//#endregion
+
+//#region Registry
+
+const chatToolRegistry = new Map<string, ChatTool>();
+
+/** @internal Look up a ChatTool's render function by tool name. */
+export function getChatToolRender(
+  toolName: string,
+): ((output: unknown) => ChatToolRenderable) | undefined {
+  return chatToolRegistry.get(toolName)?.render;
+}
+
+/** @internal Clear the registry (for testing). */
+export function clearChatToolRegistry(): void {
+  chatToolRegistry.clear();
+}
+
+//#endregion
+
+//#region Public API
+
+/**
+ * Create a Noetic Tool with an optional chat-sdk card render function.
+ *
+ * The returned tool is a standard Noetic Tool usable in `step.llm({ tools: [...] })`.
+ * The `render` function is stored in a registry and used by NoeticChat to post
+ * rich cards after tool execution completes.
+ *
+ * @param config - Tool configuration including optional render function
+ * @returns A ChatTool (extends Tool) with render capability
+ *
+ * @public
+ */
+export function chatTool<I extends ZodTypeAny, O extends ZodTypeAny>(
+  config: ChatToolConfig<I, O>,
+): ChatTool<I, O> {
+  const baseTool: Tool<I, O> = {
+    name: config.name,
+    description: config.description,
+    input: config.input,
+    output: config.output,
+    execute: config.execute,
+    needsApproval: config.needsApproval,
+  };
+
+  const ct: ChatTool<I, O> = {
+    ...baseTool,
+    render: config.render,
+  };
+
+  chatToolRegistry.set(config.name, ct);
+
+  return ct;
+}
+
+//#endregion

--- a/packages/chat-sdk/src/index.ts
+++ b/packages/chat-sdk/src/index.ts
@@ -1,0 +1,22 @@
+// Re-export everything from chat-sdk.
+// Note: chat-sdk exports its own StreamEvent type; users needing Noetic's
+// StreamEvent should import it from @noetic/core directly.
+export * from 'chat';
+
+// Noetic adapter exports
+export { chatStream } from './chat-stream';
+export type { ChatToolConfig } from './chat-tool';
+export { chatTool, clearChatToolRegistry, getChatToolRender } from './chat-tool';
+export { toNoeticItems } from './messages';
+export type { ModalSubmitValues } from './modals';
+export { modalToNoeticInput } from './modals';
+export { NoeticChat } from './noetic-chat';
+export type {
+  ChatTool,
+  ChatToolRenderable,
+  ModalInputOptions,
+  NoeticChatConfig,
+  NoeticMentionHandler,
+  NoeticSubscribedHandler,
+} from './types';
+export { ModalInputMode } from './types';

--- a/packages/chat-sdk/src/messages.ts
+++ b/packages/chat-sdk/src/messages.ts
@@ -1,0 +1,63 @@
+import type { Item, MessageItem } from '@noetic/core';
+import type { Message } from 'chat';
+
+//#region Helper
+
+function mapRole(message: Message): 'user' | 'assistant' {
+  // isBot is typed boolean | 'unknown'; strict equality excludes the 'unknown' string value
+  if (message.author.isMe || message.author.isBot === true) {
+    return 'assistant';
+  }
+  return 'user';
+}
+
+function mapContentType(role: 'user' | 'assistant'): 'input_text' | 'output_text' {
+  return role === 'user' ? 'input_text' : 'output_text';
+}
+
+//#endregion
+
+//#region Public API
+
+/**
+ * Convert chat-sdk Messages to Noetic Items for use as conversation context.
+ * Parallel to chat-sdk's `toAiMessages()` but produces Noetic Items.
+ *
+ * - Bot/self messages become assistant role with output_text
+ * - User messages become user role with input_text
+ * - Empty messages are filtered out
+ *
+ * @param messages - Array of chat-sdk Message objects
+ * @returns Array of Noetic MessageItem objects
+ *
+ * @public
+ */
+export function toNoeticItems(messages: ReadonlyArray<Message>): Item[] {
+  const items: MessageItem[] = [];
+
+  for (const msg of messages) {
+    if (!msg.text || msg.text.trim() === '') {
+      continue;
+    }
+
+    const role = mapRole(msg);
+    const contentType = mapContentType(role);
+
+    items.push({
+      id: msg.id,
+      status: 'completed',
+      type: 'message',
+      role,
+      content: [
+        {
+          type: contentType,
+          text: msg.text,
+        },
+      ],
+    });
+  }
+
+  return items;
+}
+
+//#endregion

--- a/packages/chat-sdk/src/modals.ts
+++ b/packages/chat-sdk/src/modals.ts
@@ -1,0 +1,78 @@
+import type { ExecuteInput, Item } from '@noetic/core';
+
+import type { ModalInputOptions } from './types';
+import { ModalInputMode } from './types';
+
+//#region Types
+
+/** Minimal shape of a modal submit event needed for conversion. */
+export interface ModalSubmitValues {
+  values: Record<string, string>;
+  callbackId: string;
+}
+
+//#endregion
+
+//#region Helper
+
+function valuesToUserMessage(values: Record<string, string>): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(values)) {
+    parts.push(`${key}: ${value}`);
+  }
+  return parts.join('\n');
+}
+
+function valuesToItems(values: Record<string, string>): Item[] {
+  return [
+    {
+      id: crypto.randomUUID(),
+      status: 'completed',
+      type: 'message',
+      role: 'user',
+      content: [
+        {
+          type: 'input_text',
+          text: valuesToUserMessage(values),
+        },
+      ],
+    },
+  ];
+}
+
+//#endregion
+
+//#region Public API
+
+/**
+ * Convert a chat-sdk modal form submission to Noetic execution input.
+ *
+ * Three modes:
+ * 1. **message** (default): Serializes values as a readable user message string
+ * 2. **structured**: Returns Item[] with the values as a user message
+ * 3. **custom mapper**: Uses the provided mapper function to convert values
+ *
+ * @param event - The modal submit event from chat-sdk
+ * @param opts - Conversion options (mode or custom mapper)
+ * @returns ExecuteInput suitable for harness.execute()
+ *
+ * @public
+ */
+export function modalToNoeticInput(
+  event: ModalSubmitValues,
+  opts?: ModalInputOptions,
+): ExecuteInput {
+  if (opts?.mapper) {
+    return opts.mapper(event.values, event);
+  }
+
+  const mode = opts?.mode ?? ModalInputMode.Message;
+
+  if (mode === ModalInputMode.Structured) {
+    return valuesToItems(event.values);
+  }
+
+  return valuesToUserMessage(event.values);
+}
+
+//#endregion

--- a/packages/chat-sdk/src/noetic-chat.ts
+++ b/packages/chat-sdk/src/noetic-chat.ts
@@ -1,0 +1,301 @@
+import type { ExecuteInput, HarnessResult } from '@noetic/core';
+import type {
+  ActionHandler,
+  Adapter,
+  AppHomeOpenedHandler,
+  AssistantContextChangedHandler,
+  AssistantThreadStartedHandler,
+  Author,
+  Channel,
+  DirectMessageHandler,
+  MemberJoinedChannelHandler,
+  Message,
+  MessageHandler,
+  ModalCloseHandler,
+  ModalSubmitHandler,
+  ReactionHandler,
+  SlashCommandHandler,
+  Thread,
+} from 'chat';
+import { Chat } from 'chat';
+
+import { chatStream } from './chat-stream';
+import { getChatToolRender } from './chat-tool';
+import { toNoeticItems } from './messages';
+import type { NoeticChatConfig, NoeticMentionHandler, NoeticSubscribedHandler } from './types';
+
+//#region Constants
+
+const DEFAULT_MAX_HISTORY = 20;
+
+//#endregion
+
+//#region Helper
+
+async function collectMessages(thread: Thread, maxMessages: number): Promise<Message[]> {
+  const messages: Message[] = [];
+  for await (const msg of thread.allMessages) {
+    messages.push(msg);
+    if (messages.length >= maxMessages) {
+      break;
+    }
+  }
+  return messages;
+}
+
+async function postToolCards(thread: Thread, result: HarnessResult): Promise<void> {
+  const response = await result.getResponse();
+  for (const item of response.items) {
+    if (item.type !== 'function_call_output') {
+      continue;
+    }
+    const render = getChatToolRender(findToolNameForCallId(response.items, item.callId));
+    if (!render) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(item.output);
+    } catch {
+      parsed = item.output;
+    }
+    const card = render(parsed);
+    if (card !== null && card !== undefined) {
+      await thread.post(card);
+    }
+  }
+}
+
+function findToolNameForCallId(
+  items: ReadonlyArray<{
+    type: string;
+    name?: string;
+    callId?: string;
+  }>,
+  callId: string,
+): string {
+  for (const item of items) {
+    if (item.type === 'function_call' && item.callId === callId) {
+      return item.name ?? '';
+    }
+  }
+  return '';
+}
+
+//#endregion
+
+//#region NoeticChat
+
+/**
+ * Composed wrapper around chat-sdk's Chat class with Noetic agent execution baked in.
+ *
+ * - Auto-executes a Noetic step on mentions and subscribed messages by default
+ * - Streams responses via chatStream() (paragraph breaks between tool rounds)
+ * - Posts tool result cards when chatTool render functions are registered
+ * - Supports override handlers that receive an execute convenience function
+ *
+ * @public
+ */
+export class NoeticChat<TAdapters extends Record<string, Adapter> = Record<string, Adapter>> {
+  private readonly chat: Chat<TAdapters>;
+  private readonly config: NoeticChatConfig<TAdapters>;
+  private customMentionHandler?: NoeticMentionHandler;
+  private customSubscribedHandler?: NoeticSubscribedHandler;
+
+  constructor(config: NoeticChatConfig<TAdapters>) {
+    this.config = config;
+    const { harness, autoSubscribe, singleTurn, maxHistoryMessages, tools, ...chatConfig } = config;
+    this.chat = new Chat(chatConfig);
+
+    this.chat.onNewMention(async (thread, message) => {
+      await this.handleMention(thread, message);
+    });
+
+    this.chat.onSubscribedMessage(async (thread, message) => {
+      await this.handleSubscribed(thread, message);
+    });
+  }
+
+  //#region Event Handlers (with Noetic override support)
+
+  /** Override the default mention handler. Receives an execute convenience function. */
+  onNewMention(handler: NoeticMentionHandler): void {
+    this.customMentionHandler = handler;
+  }
+
+  /** Override the default subscribed message handler. Receives an execute convenience function. */
+  onSubscribedMessage(handler: NoeticSubscribedHandler): void {
+    this.customSubscribedHandler = handler;
+  }
+
+  //#endregion
+
+  //#region Delegated Event Handlers
+
+  onDirectMessage(handler: DirectMessageHandler): void {
+    this.chat.onDirectMessage(handler);
+  }
+
+  onNewMessage(pattern: RegExp, handler: MessageHandler): void {
+    this.chat.onNewMessage(pattern, handler);
+  }
+
+  onReaction(handlerOrEmoji: ReactionHandler | Array<string>, handler?: ReactionHandler): void {
+    if (!Array.isArray(handlerOrEmoji)) {
+      this.chat.onReaction(handlerOrEmoji);
+      return;
+    }
+    if (!handler) {
+      return;
+    }
+    this.chat.onReaction(handlerOrEmoji, handler);
+  }
+
+  onAction(handlerOrIds: ActionHandler | string[] | string, handler?: ActionHandler): void {
+    if (typeof handlerOrIds === 'function') {
+      this.chat.onAction(handlerOrIds);
+      return;
+    }
+    if (!handler) {
+      return;
+    }
+    this.chat.onAction(handlerOrIds, handler);
+  }
+
+  onModalSubmit(
+    handlerOrIds: ModalSubmitHandler | string[] | string,
+    handler?: ModalSubmitHandler,
+  ): void {
+    if (typeof handlerOrIds === 'function') {
+      this.chat.onModalSubmit(handlerOrIds);
+      return;
+    }
+    if (!handler) {
+      return;
+    }
+    this.chat.onModalSubmit(handlerOrIds, handler);
+  }
+
+  onModalClose(
+    handlerOrIds: ModalCloseHandler | string[] | string,
+    handler?: ModalCloseHandler,
+  ): void {
+    if (typeof handlerOrIds === 'function') {
+      this.chat.onModalClose(handlerOrIds);
+      return;
+    }
+    if (!handler) {
+      return;
+    }
+    this.chat.onModalClose(handlerOrIds, handler);
+  }
+
+  onSlashCommand(
+    handlerOrCommands: SlashCommandHandler | string[] | string,
+    handler?: SlashCommandHandler,
+  ): void {
+    if (typeof handlerOrCommands === 'function') {
+      this.chat.onSlashCommand(handlerOrCommands);
+      return;
+    }
+    if (!handler) {
+      return;
+    }
+    this.chat.onSlashCommand(handlerOrCommands, handler);
+  }
+
+  onAssistantThreadStarted(handler: AssistantThreadStartedHandler): void {
+    this.chat.onAssistantThreadStarted(handler);
+  }
+
+  onAssistantContextChanged(handler: AssistantContextChangedHandler): void {
+    this.chat.onAssistantContextChanged(handler);
+  }
+
+  onAppHomeOpened(handler: AppHomeOpenedHandler): void {
+    this.chat.onAppHomeOpened(handler);
+  }
+
+  onMemberJoinedChannel(handler: MemberJoinedChannelHandler): void {
+    this.chat.onMemberJoinedChannel(handler);
+  }
+
+  //#endregion
+
+  //#region Delegated Methods
+
+  get webhooks(): Chat<TAdapters>['webhooks'] {
+    return this.chat.webhooks;
+  }
+
+  getAdapter<K extends keyof TAdapters>(name: K): TAdapters[K] {
+    return this.chat.getAdapter(name);
+  }
+
+  async openDM(user: string | Author): Promise<Thread> {
+    return this.chat.openDM(user);
+  }
+
+  channel(channelId: string): Channel {
+    return this.chat.channel(channelId);
+  }
+
+  async initialize(): Promise<void> {
+    return this.chat.initialize();
+  }
+
+  async shutdown(): Promise<void> {
+    return this.chat.shutdown();
+  }
+
+  reviver(): (key: string, value: unknown) => unknown {
+    return this.chat.reviver();
+  }
+
+  //#endregion
+
+  //#region Internal Handlers
+
+  private async handleMention(thread: Thread, message: Message): Promise<void> {
+    if (this.customMentionHandler) {
+      const executeFn = (input?: ExecuteInput): HarnessResult =>
+        this.config.harness.execute(input ?? '');
+      await this.customMentionHandler(thread, message, executeFn);
+      return;
+    }
+
+    await this.autoExecute(thread);
+  }
+
+  private async handleSubscribed(thread: Thread, message: Message): Promise<void> {
+    if (this.customSubscribedHandler) {
+      const executeFn = (input?: ExecuteInput): HarnessResult =>
+        this.config.harness.execute(input ?? '');
+      await this.customSubscribedHandler(thread, message, executeFn);
+      return;
+    }
+
+    await this.autoExecute(thread);
+  }
+
+  private async autoExecute(thread: Thread): Promise<void> {
+    const shouldSubscribe = !this.config.singleTurn && this.config.autoSubscribe !== false;
+
+    if (shouldSubscribe) {
+      await thread.subscribe();
+    }
+
+    const maxHistory = this.config.maxHistoryMessages ?? DEFAULT_MAX_HISTORY;
+    const historyMessages = await collectMessages(thread, maxHistory);
+    const items = toNoeticItems(historyMessages);
+
+    const result = this.config.harness.execute(items);
+
+    await thread.post(chatStream(result));
+    await postToolCards(thread, result);
+  }
+
+  //#endregion
+}
+
+//#endregion

--- a/packages/chat-sdk/src/types.ts
+++ b/packages/chat-sdk/src/types.ts
@@ -1,0 +1,75 @@
+import type { AgentHarness, ExecuteInput, HarnessResult, Tool } from '@noetic/core';
+import type { Adapter, ChatConfig, ChatElement, Message, Thread } from 'chat';
+import type { ZodTypeAny } from 'zod';
+
+/** @public Accepted return types from a chatTool render function. */
+export type ChatToolRenderable = string | ChatElement | null | undefined;
+
+//#region ChatTool Types
+
+/** @public A Noetic Tool extended with a chat-sdk card render function. */
+export interface ChatTool<I extends ZodTypeAny = ZodTypeAny, O extends ZodTypeAny = ZodTypeAny>
+  extends Tool<I, O> {
+  /** Render tool output as a chat-sdk card or string for posting. */
+  render?: (output: unknown) => ChatToolRenderable;
+}
+
+//#endregion
+
+//#region NoeticChat Config
+
+/** @public Handler that receives an execute convenience function alongside thread and message. */
+export type NoeticMentionHandler = (
+  thread: Thread,
+  message: Message,
+  execute: (input?: ExecuteInput) => HarnessResult,
+) => void | Promise<void>;
+
+/** @public Handler for subscribed thread messages with execute convenience. */
+export type NoeticSubscribedHandler = (
+  thread: Thread,
+  message: Message,
+  execute: (input?: ExecuteInput) => HarnessResult,
+) => void | Promise<void>;
+
+/** @public Mode for converting modal form values to Noetic input. */
+export const ModalInputMode = {
+  /** Serialize values as a readable user message string. */
+  Message: 'message',
+  /** Pass values object directly as structured input. */
+  Structured: 'structured',
+} as const;
+
+export type ModalInputMode = (typeof ModalInputMode)[keyof typeof ModalInputMode];
+
+/** @public Options for modal-to-Noetic input conversion. */
+export interface ModalInputOptions {
+  /** Conversion mode. Defaults to 'message'. */
+  mode?: ModalInputMode;
+  /** Custom mapper function. When provided, mode is ignored. */
+  mapper?: (
+    values: Record<string, string>,
+    event: {
+      values: Record<string, string>;
+      callbackId: string;
+    },
+  ) => ExecuteInput;
+}
+
+/** @public Configuration for NoeticChat, extending ChatConfig with Noetic-specific options. */
+export interface NoeticChatConfig<
+  TAdapters extends Record<string, Adapter> = Record<string, Adapter>,
+> extends ChatConfig<TAdapters> {
+  /** Noetic AgentHarness instance (must have initialStep configured). */
+  harness: AgentHarness;
+  /** Auto-subscribe threads on first mention. Defaults to true. */
+  autoSubscribe?: boolean;
+  /** Disable auto-subscribe entirely. Defaults to false. */
+  singleTurn?: boolean;
+  /** Maximum number of thread messages to load as conversation context. Defaults to 20. */
+  maxHistoryMessages?: number;
+  /** Chat tools with optional card render functions. Used by auto-execute to post cards after tool calls. */
+  tools?: ChatTool[];
+}
+
+//#endregion

--- a/packages/chat-sdk/test/chat-stream.test.ts
+++ b/packages/chat-sdk/test/chat-stream.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { HarnessResult, StreamEvent } from '@noetic/core';
+
+import { chatStream } from '../src/chat-stream';
+
+//#region Helpers
+
+function emptyAsyncIterable<T>(): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+      return {
+        async next(): Promise<IteratorResult<T>> {
+          return {
+            done: true,
+            value: undefined,
+          };
+        },
+      };
+    },
+  };
+}
+
+function createMockResult(events: StreamEvent[]): HarnessResult {
+  const fullStream: AsyncIterable<StreamEvent> = {
+    [Symbol.asyncIterator](): AsyncIterator<StreamEvent> {
+      let index = 0;
+      return {
+        async next(): Promise<IteratorResult<StreamEvent>> {
+          if (index >= events.length) {
+            return {
+              done: true,
+              value: undefined,
+            };
+          }
+          const value = events[index];
+          index++;
+          return {
+            done: false,
+            value,
+          };
+        },
+      };
+    },
+  };
+
+  return {
+    getText: () => Promise.resolve(''),
+    getResponse: () =>
+      Promise.resolve({
+        items: [],
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+        },
+        cost: 0,
+        text: '',
+      }),
+    getTextStream: () => emptyAsyncIterable<string>(),
+    getReasoningStream: () => emptyAsyncIterable<string>(),
+    getItemStream: () => emptyAsyncIterable(),
+    getFullStream: () => fullStream,
+  };
+}
+
+function textDelta(delta: string): StreamEvent {
+  return {
+    source: 'sdk',
+    type: 'response.output_text.delta',
+    data: {
+      delta,
+    },
+  };
+}
+
+function toolRoundCompleted(agentName: string): StreamEvent {
+  return {
+    source: 'framework',
+    type: `${agentName}:tool_round_completed`,
+    data: {
+      round: 1,
+      toolCount: 1,
+    },
+  };
+}
+
+function reasoningDelta(delta: string): StreamEvent {
+  return {
+    source: 'sdk',
+    type: 'response.reasoning.delta',
+    data: {
+      delta,
+    },
+  };
+}
+
+async function collectStream(stream: AsyncIterable<string>): Promise<string[]> {
+  const chunks: string[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+//#endregion
+
+describe('chatStream', () => {
+  test('yields text deltas', async () => {
+    const result = createMockResult([
+      textDelta('Hello'),
+      textDelta(' world'),
+    ]);
+
+    const chunks = await collectStream(chatStream(result));
+
+    expect(chunks).toEqual([
+      'Hello',
+      ' world',
+    ]);
+  });
+
+  test('injects paragraph break on tool_round_completed', async () => {
+    const result = createMockResult([
+      textDelta('Step 1'),
+      toolRoundCompleted('myagent'),
+      textDelta('Step 2'),
+    ]);
+
+    const chunks = await collectStream(chatStream(result));
+
+    expect(chunks).toEqual([
+      'Step 1',
+      '\n\n',
+      'Step 2',
+    ]);
+  });
+
+  test('no leading separator when first event is tool_round_completed', async () => {
+    const result = createMockResult([
+      toolRoundCompleted('myagent'),
+      textDelta('Hello'),
+    ]);
+
+    const chunks = await collectStream(chatStream(result));
+
+    expect(chunks).toEqual([
+      'Hello',
+    ]);
+  });
+
+  test('no duplicate separators for consecutive tool rounds without text', async () => {
+    const result = createMockResult([
+      textDelta('Start'),
+      toolRoundCompleted('myagent'),
+      toolRoundCompleted('myagent'),
+      textDelta('End'),
+    ]);
+
+    const chunks = await collectStream(chatStream(result));
+
+    expect(chunks).toEqual([
+      'Start',
+      '\n\n',
+      'End',
+    ]);
+  });
+
+  test('ignores non-text SDK events', async () => {
+    const result = createMockResult([
+      reasoningDelta('thinking...'),
+      textDelta('Hello'),
+    ]);
+
+    const chunks = await collectStream(chatStream(result));
+
+    expect(chunks).toEqual([
+      'Hello',
+    ]);
+  });
+
+  test('ignores framework events other than tool_round_completed', async () => {
+    const stepStarted: StreamEvent = {
+      source: 'framework',
+      type: 'myagent:step_started',
+      data: {},
+    };
+    const result = createMockResult([
+      textDelta('Hello'),
+      stepStarted,
+      textDelta(' world'),
+    ]);
+
+    const chunks = await collectStream(chatStream(result));
+
+    expect(chunks).toEqual([
+      'Hello',
+      ' world',
+    ]);
+  });
+
+  test('handles empty stream', async () => {
+    const result = createMockResult([]);
+
+    const chunks = await collectStream(chatStream(result));
+
+    expect(chunks).toEqual([]);
+  });
+
+  test('ignores non-string delta values', async () => {
+    const badDelta: StreamEvent = {
+      source: 'sdk',
+      type: 'response.output_text.delta',
+      data: {
+        delta: 42,
+      },
+    };
+    const result = createMockResult([
+      badDelta,
+      textDelta('ok'),
+    ]);
+
+    const chunks = await collectStream(chatStream(result));
+
+    expect(chunks).toEqual([
+      'ok',
+    ]);
+  });
+
+  test('works with any agent name prefix', async () => {
+    const result = createMockResult([
+      textDelta('A'),
+      toolRoundCompleted('custom-agent-v2'),
+      textDelta('B'),
+    ]);
+
+    const chunks = await collectStream(chatStream(result));
+
+    expect(chunks).toEqual([
+      'A',
+      '\n\n',
+      'B',
+    ]);
+  });
+});

--- a/packages/chat-sdk/test/chat-tool.test.ts
+++ b/packages/chat-sdk/test/chat-tool.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { chatTool, clearChatToolRegistry, getChatToolRender } from '../src/chat-tool';
+
+describe('chatTool', () => {
+  test('creates a tool with name, description, input, output, execute', () => {
+    clearChatToolRegistry();
+
+    const t = chatTool({
+      name: 'greet',
+      description: 'Greet someone',
+      input: z.object({
+        name: z.string(),
+      }),
+      output: z.string(),
+      execute: async (args) => `Hello, ${args.name}!`,
+    });
+
+    expect(t.name).toBe('greet');
+    expect(t.description).toBe('Greet someone');
+  });
+
+  test('registers render function in registry', () => {
+    clearChatToolRegistry();
+
+    chatTool({
+      name: 'search',
+      description: 'Search',
+      input: z.object({
+        query: z.string(),
+      }),
+      output: z.string(),
+      execute: async () => 'result',
+      render: (output) => `Card: ${output}`,
+    });
+
+    const render = getChatToolRender('search');
+    expect(render).toBeDefined();
+    if (!render) {
+      throw new Error('Expected render to be defined');
+    }
+    expect(render('test')).toBe('Card: test');
+  });
+
+  test('returns undefined render for unregistered tool', () => {
+    clearChatToolRegistry();
+
+    const render = getChatToolRender('nonexistent');
+    expect(render).toBeUndefined();
+  });
+
+  test('tool without render has undefined render', () => {
+    clearChatToolRegistry();
+
+    chatTool({
+      name: 'plain',
+      description: 'Plain tool',
+      input: z.object({
+        x: z.number(),
+      }),
+      output: z.number(),
+      execute: async (args) => args.x * 2,
+    });
+
+    const render = getChatToolRender('plain');
+    expect(render).toBeUndefined();
+  });
+
+  test('clearChatToolRegistry removes all entries', () => {
+    chatTool({
+      name: 'temp',
+      description: 'Temp',
+      input: z.string(),
+      output: z.string(),
+      execute: async (x) => x,
+      render: () => 'card',
+    });
+
+    expect(getChatToolRender('temp')).toBeDefined();
+
+    clearChatToolRegistry();
+
+    expect(getChatToolRender('temp')).toBeUndefined();
+  });
+
+  test('render can return null to skip posting', () => {
+    clearChatToolRegistry();
+
+    chatTool({
+      name: 'maybe',
+      description: 'Maybe render',
+      input: z.string(),
+      output: z.string(),
+      execute: async (x) => x,
+      render: () => null,
+    });
+
+    const render = getChatToolRender('maybe');
+    if (!render) {
+      throw new Error('Expected render to be defined');
+    }
+    expect(render('anything')).toBeNull();
+  });
+
+  test('preserves needsApproval flag', () => {
+    clearChatToolRegistry();
+
+    const t = chatTool({
+      name: 'dangerous',
+      description: 'Needs approval',
+      input: z.string(),
+      output: z.string(),
+      execute: async (x) => x,
+      needsApproval: true,
+    });
+
+    expect(t.needsApproval).toBe(true);
+  });
+});

--- a/packages/chat-sdk/test/messages.test.ts
+++ b/packages/chat-sdk/test/messages.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Item, MessageItem } from '@noetic/core';
+import { Message, parseMarkdown } from 'chat';
+
+import { toNoeticItems } from '../src/messages';
+
+//#region Helpers
+
+function createMessage(overrides: {
+  id?: string;
+  text?: string;
+  isBot?: boolean | 'unknown';
+  isMe?: boolean;
+}): Message {
+  return new Message({
+    id: overrides.id ?? crypto.randomUUID(),
+    threadId: 'thread-1',
+    text: overrides.text ?? 'Hello',
+    formatted: parseMarkdown(overrides.text ?? 'Hello'),
+    raw: {},
+    author: {
+      userId: 'u1',
+      userName: 'testuser',
+      fullName: 'Test User',
+      isBot: overrides.isBot ?? false,
+      isMe: overrides.isMe ?? false,
+    },
+    metadata: {
+      dateSent: new Date(),
+      edited: false,
+    },
+    attachments: [],
+  });
+}
+
+function isMessageItem(item: Item): item is MessageItem {
+  return item.type === 'message';
+}
+
+function getMessageItem(items: Item[], index: number): MessageItem {
+  const item = items[index];
+  if (!isMessageItem(item)) {
+    throw new Error(`Expected MessageItem at index ${index}, got ${item.type}`);
+  }
+  return item;
+}
+
+//#endregion
+
+describe('toNoeticItems', () => {
+  test('converts user message to user role with input_text', () => {
+    const msg = createMessage({
+      id: 'msg-1',
+      text: 'Hi there',
+    });
+
+    const items = toNoeticItems([
+      msg,
+    ]);
+
+    expect(items).toHaveLength(1);
+    const item = getMessageItem(items, 0);
+    expect(item.type).toBe('message');
+    expect(item.role).toBe('user');
+    expect(item.id).toBe('msg-1');
+    expect(item.status).toBe('completed');
+    expect(item.content).toEqual([
+      {
+        type: 'input_text',
+        text: 'Hi there',
+      },
+    ]);
+  });
+
+  test('converts bot message to assistant role with output_text', () => {
+    const msg = createMessage({
+      text: 'Bot response',
+      isBot: true,
+    });
+
+    const items = toNoeticItems([
+      msg,
+    ]);
+
+    expect(items).toHaveLength(1);
+    const item = getMessageItem(items, 0);
+    expect(item.role).toBe('assistant');
+    expect(item.content).toEqual([
+      {
+        type: 'output_text',
+        text: 'Bot response',
+      },
+    ]);
+  });
+
+  test('converts isMe message to assistant role', () => {
+    const msg = createMessage({
+      text: 'My message',
+      isMe: true,
+    });
+
+    const items = toNoeticItems([
+      msg,
+    ]);
+
+    const item = getMessageItem(items, 0);
+    expect(item.role).toBe('assistant');
+  });
+
+  test('filters out empty messages', () => {
+    const messages = [
+      createMessage({
+        text: '',
+      }),
+      createMessage({
+        text: '  ',
+      }),
+      createMessage({
+        text: 'Valid',
+      }),
+    ];
+
+    const items = toNoeticItems(messages);
+
+    expect(items).toHaveLength(1);
+    const item = getMessageItem(items, 0);
+    const part = item.content[0];
+    expect(part.type).toBe('input_text');
+    if (part.type === 'refusal') {
+      throw new Error('Unexpected refusal');
+    }
+    expect(part.text).toBe('Valid');
+  });
+
+  test('preserves message order', () => {
+    const messages = [
+      createMessage({
+        text: 'First',
+        id: 'a',
+      }),
+      createMessage({
+        text: 'Second',
+        id: 'b',
+      }),
+      createMessage({
+        text: 'Third',
+        id: 'c',
+      }),
+    ];
+
+    const items = toNoeticItems(messages);
+
+    expect(items).toHaveLength(3);
+    expect(items[0].id).toBe('a');
+    expect(items[1].id).toBe('b');
+    expect(items[2].id).toBe('c');
+  });
+
+  test('handles empty array', () => {
+    const items = toNoeticItems([]);
+    expect(items).toEqual([]);
+  });
+
+  test('treats isBot "unknown" as user', () => {
+    const msg = createMessage({
+      text: 'Unknown bot',
+      isBot: 'unknown',
+    });
+
+    const items = toNoeticItems([
+      msg,
+    ]);
+
+    const item = getMessageItem(items, 0);
+    expect(item.role).toBe('user');
+  });
+
+  test('isMe takes precedence over isBot false', () => {
+    const msg = createMessage({
+      text: 'Self',
+      isMe: true,
+      isBot: false,
+    });
+
+    const items = toNoeticItems([
+      msg,
+    ]);
+
+    const item = getMessageItem(items, 0);
+    expect(item.role).toBe('assistant');
+  });
+});

--- a/packages/chat-sdk/test/modals.test.ts
+++ b/packages/chat-sdk/test/modals.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { Item, MessageItem } from '@noetic/core';
+
+import type { ModalSubmitValues } from '../src/modals';
+import { modalToNoeticInput } from '../src/modals';
+import { ModalInputMode } from '../src/types';
+
+//#region Helpers
+
+function isMessageItem(item: Item): item is MessageItem {
+  return item.type === 'message';
+}
+
+function isItemArray(value: unknown): value is ReadonlyArray<Item> {
+  return Array.isArray(value);
+}
+
+function createModalEvent(values: Record<string, string>): ModalSubmitValues {
+  return {
+    callbackId: 'test-modal',
+    values,
+  };
+}
+
+//#endregion
+
+describe('modalToNoeticInput', () => {
+  test('default mode returns user message string', () => {
+    const event = createModalEvent({
+      name: 'John',
+      email: 'john@example.com',
+    });
+
+    const result = modalToNoeticInput(event);
+
+    expect(typeof result).toBe('string');
+    expect(result).toContain('name: John');
+    expect(result).toContain('email: john@example.com');
+  });
+
+  test('structured mode returns Item array', () => {
+    const event = createModalEvent({
+      feedback: 'Great product',
+    });
+
+    const result = modalToNoeticInput(event, {
+      mode: ModalInputMode.Structured,
+    });
+
+    expect(Array.isArray(result)).toBe(true);
+    if (!isItemArray(result)) {
+      throw new Error('Expected Item array');
+    }
+    expect(result).toHaveLength(1);
+    const item = result[0];
+    if (!isMessageItem(item)) {
+      throw new Error('Expected MessageItem');
+    }
+    expect(item.role).toBe('user');
+    const part = item.content[0];
+    if (part.type === 'refusal') {
+      throw new Error('Unexpected refusal');
+    }
+    expect(part.text).toContain('feedback: Great product');
+  });
+
+  test('custom mapper overrides mode', () => {
+    const event = createModalEvent({
+      query: 'search term',
+    });
+
+    const result = modalToNoeticInput(event, {
+      mode: ModalInputMode.Structured,
+      mapper: (values) => `Custom: ${values.query}`,
+    });
+
+    expect(result).toBe('Custom: search term');
+  });
+
+  test('custom mapper receives event', () => {
+    const event = createModalEvent({
+      x: 'y',
+    });
+
+    let receivedCallbackId = '';
+    modalToNoeticInput(event, {
+      mapper: (_values, evt) => {
+        receivedCallbackId = evt.callbackId;
+        return 'ok';
+      },
+    });
+
+    expect(receivedCallbackId).toBe('test-modal');
+  });
+
+  test('message mode with empty values returns empty string', () => {
+    const event = createModalEvent({});
+
+    const result = modalToNoeticInput(event);
+
+    expect(result).toBe('');
+  });
+
+  test('structured mode generates unique item IDs', () => {
+    const event = createModalEvent({
+      a: '1',
+    });
+
+    const result1 = modalToNoeticInput(event, {
+      mode: ModalInputMode.Structured,
+    });
+    const result2 = modalToNoeticInput(event, {
+      mode: ModalInputMode.Structured,
+    });
+
+    if (!isItemArray(result1) || !isItemArray(result2)) {
+      throw new Error('Expected Item arrays');
+    }
+    expect(result1[0].id).not.toBe(result2[0].id);
+  });
+});

--- a/packages/chat-sdk/tsconfig.json
+++ b/packages/chat-sdk/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "jsxImportSource": "chat",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- New `@noetic/chat-sdk` package bridging Noetic agent execution with [chat-sdk.dev](https://chat-sdk.dev) (Slack, Teams, Discord, Google Chat, WhatsApp)
- Re-exports everything from `chat` so users import from one place
- Adds `chatStream()` — `AsyncIterable<string>` with `\n\n` between tool rounds (equivalent to AI SDK's `fullStream`)
- Adds `toNoeticItems()` — converts chat-sdk Messages to Noetic Items for multi-turn context
- Adds `chatTool()` — wraps Noetic Tool with card render function for rich platform output
- Adds `modalToNoeticInput()` — bidirectional modal integration (message, structured, or custom mapper)
- Adds `NoeticChat` class — composed wrapper around Chat with auto-execute, auto-subscribe, configurable history depth

## Test plan

- [x] 30 tests across 4 files (chat-stream, chat-tool, messages, modals)
- [x] Typecheck clean (0 errors)
- [x] Biome lint clean (0 issues)
- [x] Core tests unaffected (603 pass, 5 skip, 0 fail)
- [ ] Spec, docs, and skill updates (follow-up PR)
- [ ] NoeticChat integration tests (follow-up PR)