### PR TITLE
feat(core): unified tool set with per-step restriction

### DIFF
--- a/.claude/skills/noetic-agent-builder/references/api-reference.md
+++ b/.claude/skills/noetic-agent-builder/references/api-reference.md
@@ -23,12 +23,14 @@ step.llm<TMemory = ContextMemory, I = unknown, O = unknown>({
   id: string;
   model: string;
   instructions?: string;
-  tools?: Tool[];
+  tools?: Tool[];             // allowed tool subset (undefined = all, [] = none)
   output?: ZodType<O>;
   params?: ModelParams;
   emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
 }): StepLLM<TMemory, I, O>
 ```
+
+`tools` specifies which tools the model may invoke for this step. Before execution, the harness collects all tools from every LLM step in the tree into a unified set. Every LLM call sends the full set (preserving prompt cache), while `tools` narrows the allowed subset via `tool_choice: { type: "allowed_tools" }`. Omit `tools` to allow all; set `tools: []` to disable tools for the step.
 
 `emit` controls framework event emission (default `true`). Set `false` to suppress all, or pass a filter function.
 

--- a/packages/core/src/interpreter/collect-tools.ts
+++ b/packages/core/src/interpreter/collect-tools.ts
@@ -1,0 +1,81 @@
+import type { Tool } from '../types/common';
+import type { Step } from '../types/step';
+import { frameworkCast } from './framework-cast';
+
+/**
+ * Recursively walks a step tree and collects all Tool instances
+ * declared on LLM steps. Used to build the unified tool set
+ * that gets sent with every LLM call for prompt cache efficiency.
+ */
+export function collectAllTools<TMemory = unknown, I = unknown, O = unknown>(
+  step: Step<TMemory, I, O>,
+): Tool[] {
+  const tools: Tool[] = [];
+  // walkStep uses Step with defaults (unknown generics); the cast is safe because
+  // we only read the `.tools`, `.child`, `.steps`, `._optimizable` structural fields.
+  walkStep(frameworkCast<Step>(step), tools);
+  return deduplicateTools(tools);
+}
+
+/**
+ * Deduplicates tools by name, keeping the first occurrence.
+ */
+export function deduplicateTools(tools: ReadonlyArray<Tool>): Tool[] {
+  const seen = new Map<string, Tool>();
+  for (const tool of tools) {
+    if (!seen.has(tool.name)) {
+      seen.set(tool.name, tool);
+    }
+  }
+  return [
+    ...seen.values(),
+  ];
+}
+
+function walkStep(step: Step, out: Tool[]): void {
+  switch (step.kind) {
+    case 'llm':
+      if (step.tools) {
+        out.push(...step.tools);
+      }
+      return;
+
+    case 'run':
+    case 'tool':
+      return;
+
+    case 'branch':
+      if (step._optimizable) {
+        for (const child of step._optimizable) {
+          walkStep(child, out);
+        }
+      }
+      return;
+
+    case 'fork':
+      if (step._optimizable) {
+        for (const child of step._optimizable) {
+          walkStep(child, out);
+        }
+      }
+      return;
+
+    case 'provide':
+      walkStep(step.child, out);
+      return;
+
+    case 'spawn':
+      walkStep(step.child, out);
+      return;
+
+    case 'loop':
+      for (const child of step.steps) {
+        walkStep(child, out);
+      }
+      return;
+
+    default:
+      step satisfies never;
+      return;
+  }
+}

--- a/packages/core/src/interpreter/execute-llm.ts
+++ b/packages/core/src/interpreter/execute-llm.ts
@@ -13,20 +13,70 @@ import { isMutableContext } from './typeguards';
 
 const MAX_STEERING_RETRIES = 3;
 
-function mergeTools(
-  stepTools: Tool[] | undefined,
+//#region Tool Resolution
+
+interface ResolvedTools {
+  tools: Tool[] | undefined;
+  allowedToolNames: string[] | undefined;
+}
+
+/**
+ * Resolves which tools to send and what restrictions to apply.
+ *
+ * When a unified tool set exists on the context (collected before execution),
+ * every LLM call sends the full set and step.tools narrows via allowedToolNames.
+ *
+ * Semantics:
+ *   step.tools = undefined → unrestricted (all tools, no allowedToolNames)
+ *   step.tools = []        → no tools at all
+ *   step.tools = [a, b]    → full set sent, restrict to a and b
+ *
+ * Fallback: when no unified set exists (e.g. harness.run() called directly),
+ * merge step tools with layer tools as before.
+ */
+function resolveToolsAndRestrictions(
+  step: StepLLM,
   layers: MemoryLayer[] | undefined,
   ctx: Context,
-): Tool[] | undefined {
-  const layerTools = layers && layers.length > 0 ? resolveLayerTools(layers, ctx.harness, ctx) : [];
-  if (layerTools.length === 0) {
-    return stepTools;
+): ResolvedTools {
+  // step.tools = [] → explicit opt-out
+  if (step.tools && step.tools.length === 0) {
+    return {
+      tools: undefined,
+      allowedToolNames: undefined,
+    };
   }
-  return [
-    ...(stepTools ?? []),
+
+  const unified = ctx.unifiedTools;
+  if (unified && unified.length > 0) {
+    const allowedToolNames = step.tools ? step.tools.map((t) => t.name) : undefined;
+    return {
+      tools: [
+        ...unified,
+      ],
+      allowedToolNames,
+    };
+  }
+
+  // Fallback: no unified set (direct harness.run() path)
+  const layerTools = layers && layers.length > 0 ? resolveLayerTools(layers, ctx.harness, ctx) : [];
+  if (layerTools.length === 0 && !step.tools) {
+    return {
+      tools: undefined,
+      allowedToolNames: undefined,
+    };
+  }
+  const merged = [
+    ...(step.tools ?? []),
     ...layerTools,
   ];
+  return {
+    tools: merged.length > 0 ? merged : undefined,
+    allowedToolNames: undefined,
+  };
 }
+
+//#endregion
 
 export async function executeLLM<TMemory, I, O>(
   step: StepLLM<TMemory, I, O>,
@@ -40,21 +90,26 @@ export async function executeLLM<TMemory, I, O>(
     baseCtx.itemLog.append(createMessage(input, 'user'));
   }
 
-  const allTools = mergeTools(step.tools, layers, baseCtx);
+  const { tools: resolvedTools, allowedToolNames } = resolveToolsAndRestrictions(
+    step,
+    layers,
+    baseCtx,
+  );
   let retries = 0;
 
   while (retries <= MAX_STEERING_RETRIES) {
-    const request = allTools
+    const request = resolvedTools
       ? {
           model: step.model,
           items: baseCtx.itemLog.items,
           instructions: step.instructions,
-          tools: allTools,
+          tools: resolvedTools,
           params: step.params,
           outputSchema: step.output,
           emit: step.emit,
           ctx: baseCtx,
           layers,
+          allowedToolNames,
         }
       : {
           model: step.model,
@@ -63,7 +118,6 @@ export async function executeLLM<TMemory, I, O>(
           params: step.params,
           outputSchema: step.output,
           emit: step.emit,
-          ctx: baseCtx,
         };
     const response = await baseCtx.harness.callModel(request);
 

--- a/packages/core/src/interpreter/execute-provide.ts
+++ b/packages/core/src/interpreter/execute-provide.ts
@@ -1,6 +1,9 @@
+import { resolveLayerTools } from '../memory/layer-api';
+import type { Tool } from '../types/common';
 import type { Context } from '../types/context';
 import type { ContextMemory, MemoryConfig, MemoryLayer } from '../types/memory';
 import type { ExecuteStepFn, StepProvide } from '../types/step';
+import { deduplicateTools } from './collect-tools';
 import { frameworkCast } from './framework-cast';
 
 //#region Helper Functions
@@ -52,20 +55,34 @@ export async function executeProvide<TMemory, I, O>(
   const baseCtx = frameworkCast<
     Context<ContextMemory> & {
       layers?: MemoryLayer[];
+      unifiedTools?: ReadonlyArray<Tool>;
     }
   >(ctx);
   const previousLayers = baseCtx.layers;
+  const previousUnifiedTools = baseCtx.unifiedTools;
   const newLayers = resolveLayers(step);
   const mergedLayers = mergeLayers(previousLayers, newLayers);
 
   // Attach layers to the current context (no isolation)
   baseCtx.layers = mergedLayers;
 
+  // Merge new layer-provided tools into the unified tool set
+  if (baseCtx.unifiedTools && newLayers.length > 0) {
+    const layerTools = resolveLayerTools(newLayers, baseCtx.harness, baseCtx);
+    if (layerTools.length > 0) {
+      baseCtx.unifiedTools = deduplicateTools([
+        ...baseCtx.unifiedTools,
+        ...layerTools,
+      ]);
+    }
+  }
+
   try {
     return await executeStep<TMemory, I, O>(step.child, input, ctx);
   } finally {
-    // Restore previous layers so siblings are not affected
+    // Restore previous layers and unified tools so siblings are not affected
     baseCtx.layers = previousLayers;
+    baseCtx.unifiedTools = previousUnifiedTools;
   }
 }
 

--- a/packages/core/src/interpreter/execute-spawn.ts
+++ b/packages/core/src/interpreter/execute-spawn.ts
@@ -1,3 +1,4 @@
+import { resolveLayerTools } from '../memory/layer-api';
 import type { LayerStateStore } from '../memory/layer-lifecycle';
 import { returnLayers, spawnLayers } from '../memory/layer-lifecycle';
 import { ContextImpl } from '../runtime/context-impl';
@@ -6,6 +7,7 @@ import type { Item } from '../types/items';
 import type { ContextMemory, ExecutionContext, MemoryConfig, MemoryLayer } from '../types/memory';
 import type { ExecuteStepFn, StepSpawn } from '../types/step';
 import { cloneWithGuard } from './clone-guard';
+import { collectAllTools, deduplicateTools } from './collect-tools';
 import { frameworkCast } from './framework-cast';
 
 //#region Types
@@ -138,6 +140,15 @@ export async function executeSpawn<TMemory, I, O>(
     });
   }
 
+  // Build unified tool set for child from its step tree + layers
+  const childStepTools = collectAllTools(step.child);
+  const childLayerTools =
+    layers.length > 0 ? resolveLayerTools(layers, baseCtx.harness, baseCtx) : [];
+  const childUnifiedTools = deduplicateTools([
+    ...childStepTools,
+    ...childLayerTools,
+  ]);
+
   // Create child context — empty by default, layers provide items via onSpawn
   const childCtx = new ContextImpl({
     harness: baseCtx.harness,
@@ -147,6 +158,7 @@ export async function executeSpawn<TMemory, I, O>(
     threadId: baseCtx.threadId,
     resourceId: baseCtx.resourceId,
     layers: layers.length > 0 ? layers : undefined,
+    unifiedTools: childUnifiedTools.length > 0 ? childUnifiedTools : undefined,
   });
 
   try {

--- a/packages/core/src/runtime/agent-harness.ts
+++ b/packages/core/src/runtime/agent-harness.ts
@@ -10,7 +10,10 @@ import {
   responseToNoeticItems,
 } from '../adapters/openrouter';
 import { NoeticConfigError } from '../errors/noetic-config-error';
+import { collectAllTools, deduplicateTools } from '../interpreter/collect-tools';
 import { execute } from '../interpreter/execute';
+import { frameworkCast } from '../interpreter/framework-cast';
+import { resolveLayerTools } from '../memory/layer-api';
 import type { LayerStateStore } from '../memory/layer-lifecycle';
 import {
   afterModelCallLayers,
@@ -24,7 +27,7 @@ import {
 import { SpanImpl } from '../observability/span-impl';
 import { NoopExporter } from '../observability/trace-exporter';
 import type { Channel, ChannelHandle, ExternalChannel } from '../types/channel';
-import type { LLMResponse, LlmProviderConfig } from '../types/common';
+import type { LLMResponse, LlmProviderConfig, Tool } from '../types/common';
 import type { Context } from '../types/context';
 import type { DetachedHandle } from '../types/detached';
 import type { HarnessResult } from '../types/harness-result';
@@ -234,6 +237,22 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
     const conversationInput = itemsToInput(remaining);
     const textFormat = request.outputSchema ? buildTextFormat(request.outputSchema) : undefined;
 
+    // Build toolChoice for per-step restriction when allowedToolNames is set.
+    // The allowed_tools type is not yet in the OpenRouter SDK types, so we
+    // construct it as unknown and spread it into the call.
+    const allowedNames = request.tools ? request.allowedToolNames : undefined;
+    const toolChoiceOverride: Record<string, unknown> | undefined = allowedNames
+      ? {
+          toolChoice: {
+            type: 'allowed_tools',
+            tools: allowedNames.map((n: string) => ({
+              type: 'function',
+              name: n,
+            })),
+          },
+        }
+      : undefined;
+
     for (let round = 0; round < MAX_TOOL_ROUNDS; round++) {
       const callResult = this.client.callModel({
         model: request.model,
@@ -248,6 +267,7 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
               text: textFormat,
             }
           : {}),
+        ...toolChoiceOverride,
       });
 
       // The OpenRouter SDK internally tees the HTTP stream, so
@@ -378,6 +398,9 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
       );
     }
 
+    // Collect all tools from the step tree for unified tool set
+    const stepTools = collectAllTools(this.initialStep);
+
     const broadcaster = new EventBroadcaster();
 
     let executionPromise: Promise<string>;
@@ -388,6 +411,8 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
         ...options,
         _broadcaster: broadcaster,
       });
+      // Resolve layer tools now that ctx exists, then build unified set
+      this.setUnifiedTools(ctx, stepTools);
       executionPromise = this.run(this.initialStep, input, ctx);
     } else {
       const items = Array.isArray(input)
@@ -400,6 +425,7 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
         ...options,
         _broadcaster: broadcaster,
       });
+      this.setUnifiedTools(ctx, stepTools);
       executionPromise = this.run(this.initialStep, '', ctx);
     }
 
@@ -468,6 +494,24 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
 
   getChannelHandle<T>(channel: ExternalChannel<T>, executionId: string): ChannelHandle<T> {
     return this.channelStore.getHandle(channel, executionId);
+  }
+
+  /** Resolves layer-provided tools and merges with step tools into ctx.unifiedTools. */
+  private setUnifiedTools(ctx: Context, stepTools: Tool[]): void {
+    const layers = ctx.layers;
+    const layerTools = layers && layers.length > 0 ? resolveLayerTools(layers, this, ctx) : [];
+    const allTools = deduplicateTools([
+      ...stepTools,
+      ...layerTools,
+    ]);
+    if (allTools.length > 0) {
+      // Set unifiedTools after construction since resolveLayerTools requires a context reference.
+      // The Context interface is readonly but ContextImpl is mutable.
+      const impl = frameworkCast<{
+        unifiedTools: ReadonlyArray<Tool>;
+      }>(ctx);
+      impl.unifiedTools = allTools;
+    }
   }
 
   private toExecCtx(ctx: Context): ExecutionContext {

--- a/packages/core/src/runtime/context-impl.ts
+++ b/packages/core/src/runtime/context-impl.ts
@@ -1,6 +1,6 @@
 import { buildContextMemory } from '../memory/layer-api';
 import type { Channel } from '../types/channel';
-import type { StepMeta, TokenUsage } from '../types/common';
+import type { StepMeta, TokenUsage, Tool } from '../types/common';
 import type { Context, ItemLog } from '../types/context';
 import type { Item } from '../types/items';
 import type { ContextMemory, MemoryLayer } from '../types/memory';
@@ -40,6 +40,7 @@ export class ContextImpl implements Context<ContextMemory> {
   lastStepMeta: StepMeta | null = null;
   readonly harness: AgentHarnessContract;
   readonly layers?: MemoryLayer[];
+  unifiedTools?: ReadonlyArray<Tool>;
 
   /** @internal Event broadcaster for streaming — not part of public Context interface. */
   readonly _broadcaster?: EventBroadcaster;
@@ -64,6 +65,7 @@ export class ContextImpl implements Context<ContextMemory> {
     channelStore?: ChannelStore;
     checkpointFn?: () => Promise<void>;
     layers?: MemoryLayer[];
+    unifiedTools?: ReadonlyArray<Tool>;
     _broadcaster?: EventBroadcaster;
   }) {
     this.id = crypto.randomUUID();
@@ -78,6 +80,7 @@ export class ContextImpl implements Context<ContextMemory> {
     this.channelStore = opts.channelStore;
     this._checkpointFn = opts.checkpointFn;
     this.layers = opts.layers;
+    this.unifiedTools = opts.unifiedTools;
     this._broadcaster = opts._broadcaster;
 
     const log = new ItemLogImpl();

--- a/packages/core/src/types/context.ts
+++ b/packages/core/src/types/context.ts
@@ -1,5 +1,5 @@
 import type { Channel } from './channel';
-import type { StepMeta, TokenUsage } from './common';
+import type { StepMeta, TokenUsage, Tool } from './common';
 import type { Item } from './items';
 import type { ContextMemory, MemoryLayer } from './memory';
 import type { Span } from './observability';
@@ -30,6 +30,8 @@ export interface Context<TMemory = ContextMemory, TState = unknown> {
   readonly layers?: MemoryLayer[];
   /** Layer provides keyed by layer ID. Access data/functions via `ctx.memory['layerId'].prop`. */
   readonly memory: TMemory;
+  /** Unified tool set collected from all LLM steps in the step tree before execution. */
+  readonly unifiedTools?: ReadonlyArray<Tool>;
   recv<T>(
     channel: Channel<T>,
     opts?: {

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -41,6 +41,8 @@ interface CallModelRequestWithTools extends CallModelRequestBase {
   tools: Tool[];
   ctx: Context;
   layers?: MemoryLayer[];
+  /** When set, restricts which tools the model may invoke for this call. */
+  allowedToolNames?: string[];
 }
 
 /** @public Request shape when no tools are provided — ctx is only needed for tool

--- a/packages/core/test/interpreter/collect-tools.test.ts
+++ b/packages/core/test/interpreter/collect-tools.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+import { collectAllTools, deduplicateTools } from '../../src/interpreter/collect-tools';
+import type { Tool } from '../../src/types/common';
+import type { Step } from '../../src/types/step';
+import { makeTestTool } from '../_helpers';
+
+//#region Test Helpers
+
+function makeTool(name: string): Tool {
+  return makeTestTool({
+    name,
+  });
+}
+
+function llmStep(id: string, tools?: Tool[]): Step {
+  return {
+    kind: 'llm',
+    id,
+    model: 'test/model',
+    tools,
+  };
+}
+
+function runStep(id: string): Step {
+  return {
+    kind: 'run',
+    id,
+    execute: async (i: unknown) => i,
+  };
+}
+
+function toolStep(id: string): Step {
+  return {
+    kind: 'tool',
+    id,
+    tool: {
+      name: 'direct-tool',
+      description: 'direct',
+      input: z.object({
+        query: z.string(),
+      }),
+      output: z.object({
+        result: z.string(),
+      }),
+      execute: async () => ({
+        result: 'ok',
+      }),
+    },
+  };
+}
+
+//#endregion
+
+//#region deduplicateTools
+
+describe('deduplicateTools', () => {
+  test('returns empty array for empty input', () => {
+    expect(deduplicateTools([])).toEqual([]);
+  });
+
+  test('keeps unique tools', () => {
+    const a = makeTool('a');
+    const b = makeTool('b');
+    expect(
+      deduplicateTools([
+        a,
+        b,
+      ]),
+    ).toEqual([
+      a,
+      b,
+    ]);
+  });
+
+  test('deduplicates by name (first-wins)', () => {
+    const a1 = makeTool('a');
+    const a2 = makeTool('a');
+    const b = makeTool('b');
+    const result = deduplicateTools([
+      a1,
+      b,
+      a2,
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(a1);
+    expect(result[1]).toBe(b);
+  });
+});
+
+//#endregion
+
+//#region collectAllTools
+
+describe('collectAllTools', () => {
+  test('collects tools from a single LLM step', () => {
+    const t = makeTool('search');
+    const result = collectAllTools(
+      llmStep('s1', [
+        t,
+      ]),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('search');
+  });
+
+  test('returns empty for LLM step with no tools', () => {
+    expect(collectAllTools(llmStep('s1'))).toEqual([]);
+  });
+
+  test('returns empty for LLM step with empty tools', () => {
+    expect(collectAllTools(llmStep('s1', []))).toEqual([]);
+  });
+
+  test('returns empty for run step', () => {
+    expect(collectAllTools(runStep('r1'))).toEqual([]);
+  });
+
+  test('returns empty for tool step', () => {
+    expect(collectAllTools(toolStep('t1'))).toEqual([]);
+  });
+
+  test('collects from loop steps', () => {
+    const t1 = makeTool('search');
+    const t2 = makeTool('calc');
+    const loop: Step = {
+      kind: 'loop',
+      id: 'loop1',
+      steps: [
+        llmStep('s1', [
+          t1,
+        ]),
+        runStep('r1'),
+        llmStep('s2', [
+          t2,
+        ]),
+      ],
+      until: () => ({
+        stop: true,
+      }),
+    };
+    const result = collectAllTools(loop);
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.name)).toEqual([
+      'search',
+      'calc',
+    ]);
+  });
+
+  test('collects from provide step child', () => {
+    const t = makeTool('search');
+    const provide: Step = {
+      kind: 'provide',
+      id: 'p1',
+      child: llmStep('s1', [
+        t,
+      ]),
+      memory: [],
+    };
+    const result = collectAllTools(provide);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('search');
+  });
+
+  test('collects from spawn step child', () => {
+    const t = makeTool('search');
+    const spawn: Step = {
+      kind: 'spawn',
+      id: 'sp1',
+      child: llmStep('s1', [
+        t,
+      ]),
+    };
+    const result = collectAllTools(spawn);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('search');
+  });
+
+  test('collects from branch _optimizable', () => {
+    const t1 = makeTool('search');
+    const t2 = makeTool('calc');
+    const branch: Step = {
+      kind: 'branch',
+      id: 'b1',
+      route: () => null,
+      _optimizable: [
+        llmStep('s1', [
+          t1,
+        ]),
+        llmStep('s2', [
+          t2,
+        ]),
+      ],
+    };
+    const result = collectAllTools(branch);
+    expect(result).toHaveLength(2);
+  });
+
+  test('returns empty for branch without _optimizable', () => {
+    const branch: Step = {
+      kind: 'branch',
+      id: 'b1',
+      route: () => null,
+    };
+    expect(collectAllTools(branch)).toEqual([]);
+  });
+
+  test('collects from fork _optimizable', () => {
+    const t = makeTool('search');
+    const fork: Step = {
+      kind: 'fork',
+      id: 'f1',
+      mode: 'race',
+      paths: () => [],
+      _optimizable: [
+        llmStep('s1', [
+          t,
+        ]),
+      ],
+    };
+    const result = collectAllTools(fork);
+    expect(result).toHaveLength(1);
+  });
+
+  test('deduplicates across nested steps', () => {
+    const t1 = makeTool('search');
+    const t2 = makeTool('search');
+    const t3 = makeTool('calc');
+    const loop: Step = {
+      kind: 'loop',
+      id: 'loop1',
+      steps: [
+        llmStep('s1', [
+          t1,
+          t3,
+        ]),
+        llmStep('s2', [
+          t2,
+        ]),
+      ],
+      until: () => ({
+        stop: true,
+      }),
+    };
+    const result = collectAllTools(loop);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(t1);
+    expect(result[1]).toBe(t3);
+  });
+
+  test('deep nesting: loop > provide > branch > llm', () => {
+    const t1 = makeTool('search');
+    const t2 = makeTool('calc');
+    const t3 = makeTool('write');
+
+    const step: Step = {
+      kind: 'loop',
+      id: 'loop1',
+      steps: [
+        {
+          kind: 'provide',
+          id: 'p1',
+          child: {
+            kind: 'branch',
+            id: 'b1',
+            route: () => null,
+            _optimizable: [
+              llmStep('s1', [
+                t1,
+                t2,
+              ]),
+              llmStep('s2', [
+                t3,
+              ]),
+            ],
+          },
+          memory: [],
+        },
+      ],
+      until: () => ({
+        stop: true,
+      }),
+    };
+    const result = collectAllTools(step);
+    expect(result).toHaveLength(3);
+    expect(result.map((t) => t.name)).toEqual([
+      'search',
+      'calc',
+      'write',
+    ]);
+  });
+});
+
+//#endregion

--- a/packages/web/content/docs/api/step-types.mdx
+++ b/packages/web/content/docs/api/step-types.mdx
@@ -40,7 +40,7 @@ type Step<TMemory = ContextMemory, I = unknown, O = unknown> =
 | `id` | `string` | yes | Step identifier |
 | `model` | `string` | yes | Model identifier |
 | `instructions` | `string` | no | System prompt / instructions for the model |
-| `tools` | `Tool[]` | no | Available tools |
+| `tools` | `Tool[]` | no | Allowed tool subset (`undefined` = all, `[]` = none) |
 | `output` | `ZodType<O>` | no | Structured output schema |
 | `params` | `ModelParams` | no | Sampling parameters |
 

--- a/packages/web/content/docs/steps/llm.mdx
+++ b/packages/web/content/docs/steps/llm.mdx
@@ -28,7 +28,7 @@ const chat = step.llm({
 | `id` | `string` | Yes | Unique step identifier |
 | `model` | `string` | Yes | Model identifier (e.g. `'gpt-4o'`, `'claude-sonnet-4-20250514'`) |
 | `instructions` | `string` | No | System prompt prepended to the conversation |
-| `tools` | `Tool[]` | No | Tools the model may call |
+| `tools` | `Tool[]` | No | Allowed tool subset (`undefined` = all, `[]` = none) |
 | `output` | `ZodType<O>` | No | Zod schema for structured output |
 | `params` | `ModelParams` | No | Generation parameters |
 
@@ -99,9 +99,17 @@ const researcher = step.llm({
 
 When the model emits a tool call, the runtime executes the tool and feeds the result back. To loop until the model stops calling tools, wrap the LLM step in a [loop](/docs/operators/loop-and-until) with `until.noToolCalls()`.
 
+### Unified Tool Set
+
+Before execution, the harness collects all tools from every LLM step in the step tree plus layer-provided tools into a single unified set. Every LLM call sends the full set (preserving prompt cache), while `tools` on each step narrows which tools the model may actually invoke.
+
+- **`tools: undefined`** (or omitted) -- the model may call any tool in the unified set.
+- **`tools: [searchTool]`** -- the model may only call `searchTool`.
+- **`tools: []`** -- no tools are available for this step.
+
 ### Auto-Injected Layer Tools
 
-In addition to explicitly provided tools, functions declared in a memory layer's `provides` field are automatically injected as tools for every `step.llm` call. These tools are namespaced as `layerId/fnName` (e.g., `working-memory/update`). You do not need to pass them in the `tools` array -- the runtime resolves them from the active memory layers.
+Functions declared in a memory layer's `provides` field are automatically included in the unified tool set. These tools are namespaced as `layerId/fnName` (e.g., `working-memory/update`). You do not need to pass them in the `tools` array -- the runtime resolves them from the active memory layers.
 
 ## Tuning Generation
 

--- a/specs/02-step-variants.md
+++ b/specs/02-step-variants.md
@@ -45,7 +45,7 @@ interface StepLLMOpts<O> {
   id: string;
   model: string;              // e.g. 'anthropic/claude-sonnet-4-20250514'
   instructions?: string;
-  tools?: Tool[];             // tools available for THIS call
+  tools?: Tool[];             // allowed tool subset (undefined = all, [] = none)
   output?: ZodType<O>;        // structured output schema
   params?: ModelParams;       // temperature, topP, etc.
   emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
@@ -93,15 +93,28 @@ const harness = new AgentHarness({
 });
 ```
 
+### Unified Tool Set
+
+Before execution begins, the agent harness walks the entire step tree and collects all `Tool` instances declared on LLM steps, plus tools provided by memory layers. These are deduplicated by name (first-wins) into a **unified tool set** stored on the execution context.
+
+Every LLM call receives the full unified tool set, preserving prompt cache across calls with different tool restrictions. Individual steps restrict which tools the model may invoke via the `tools` field on `StepLLMOpts`:
+
+- `tools: undefined` (or omitted) — unrestricted, model may call any tool
+- `tools: [searchTool, readFileTool]` — model may only call these tools
+- `tools: []` — no tools available for this step
+
+The restriction is communicated to the provider via `tool_choice: { type: "allowed_tools", tools: [...] }` in the API call.
+
 ### OpenRouter Integration
 
 The agent harness delegates LLM calls to the `@openrouter/sdk` internally. It:
 
 1. Merges `StepLLM.instructions` (from the step definition) with any system-role messages extracted from `items`, joined by `\n\n`. If only one source is present, that one is used. If neither is present, `instructions` is `undefined`.
 2. Converts Noetic `Item[]` to OpenResponses input format.
-3. Wraps Noetic `Tool[]` into SDK tool objects, binding `ctx` into each `execute` closure.
-4. Calls the SDK's `callModel()` — the SDK handles the tool call loop internally.
-5. Converts the SDK response back to Noetic `Item[]` and `LLMResponse`.
+3. Wraps the unified `Tool[]` into SDK tool objects, binding `ctx` into each `execute` closure.
+4. Passes `tool_choice` with allowed subset when the step restricts tools.
+5. Calls the SDK's `callModel()` — the SDK handles the tool call loop internally.
+6. Converts the SDK response back to Noetic `Item[]` and `LLMResponse`.
 
 ### Tool Call Execution
 

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -96,7 +96,7 @@ interface DetachedHandle<O> {
 
 ## HarnessResult
 
-`execute()` returns a `HarnessResult` synchronously. Execution starts eagerly in the background. The result provides six accessors for consuming output in different modes.
+`execute()` returns a `HarnessResult` synchronously. Before execution starts, the harness walks the step tree to collect all tools from all LLM steps, merges them with layer-provided tools, and deduplicates by name. This **unified tool set** is stored on the execution context and sent with every LLM call for prompt cache efficiency. Individual steps restrict the model to a subset via the Open Responses `tool_choice: { type: "allowed_tools" }` parameter. Execution then starts eagerly in the background. The result provides six accessors for consuming output in different modes.
 
 ```typescript
 interface HarnessResult {


### PR DESCRIPTION
## Summary

- Collects all tools from every LLM step in the step tree + layer-provided tools into a deduplicated unified set before execution begins
- Every LLM API call sends the full unified tool set, preserving prompt cache across calls with different tool restrictions
- Individual steps restrict which tools the model may invoke via `tool_choice: { type: "allowed_tools" }` — `step.tools` semantics shift from "provided tools" to "allowed subset"

## Key changes

- **New**: `collect-tools.ts` — recursive step tree walker with `collectAllTools()` and `deduplicateTools()`
- **`AgentHarness.execute()`** — collects unified tool set and stores on context before execution
- **`executeLLM()`** — uses unified set as `tools`, computes `allowedToolNames` from `step.tools`
- **`AgentHarness.callModel()`** — passes `toolChoice: { type: "allowed_tools" }` to the SDK
- **`executeProvide`/`executeSpawn`** — propagate unified tools through provide (save/restore) and spawn (fresh set)
- **Types**: `allowedToolNames` on `CallModelRequest`, `unifiedTools` on `Context`

## Tool semantics

| `step.tools` | Behavior |
|---|---|
| `undefined` (omitted) | Unrestricted — model may call any tool |
| `[searchTool, readTool]` | Restricted — model may only call these |
| `[]` | No tools — step gets no tools at all |

## Test plan

- [x] 16 new unit tests for `collectAllTools` (all step kinds, deduplication, deep nesting)
- [x] All 621 existing tests pass (backward compatible)
- [x] `tsc --noEmit` — 0 source errors
- [x] `biome check` — clean