### PR TITLE
docs(cli): add Ink compatibility note to theme system

### DIFF
--- a/packages/cli/src/tui/components/theme.tsx
+++ b/packages/cli/src/tui/components/theme.tsx
@@ -1,3 +1,8 @@
+/**
+ * Theme system for the TUI. This is pure React context code that works with Ink.
+ * No framework-specific dependencies - just React context patterns.
+ */
+
 export interface Theme {
   /** Whether this is a dark theme */
   isDark: boolean;


### PR DESCRIPTION
## Summary
- Added documentation comment to `packages/cli/src/tui/components/theme.tsx` noting that the theme system is pure React context code that works with Ink
- Verified the file has no Gridland imports or framework-specific dependencies
- Part of the Gridland to Ink migration (Unit 3: Theme System)

## Test plan
- [x] CLI package typecheck passes (`bun run typecheck`)
- [x] No tests needed - documentation-only change to existing pure React code