### PR TITLE
fix: resolve CI lint and typecheck failures on main

### DIFF
--- a/examples/skippy/src/bot.tsx
+++ b/examples/skippy/src/bot.tsx
@@ -34,7 +34,7 @@ function createBot(env: Env): NoeticChat<SkippyAdapters> {
     initialStep: step.llm({
       id: 'respond',
       model: 'anthropic/claude-sonnet-4-5',
-      system: [
+      instructions: [
         'You are Skippy, a helpful and friendly Discord bot.',
         'Keep responses concise and conversational — this is chat, not an essay.',
         'Use markdown formatting when it helps readability.',

--- a/packages/chat-sdk/src/messages.ts
+++ b/packages/chat-sdk/src/messages.ts
@@ -1,18 +1,41 @@
-import type { Item, MessageItem } from '@noetic/core';
+import type { InputMessageItem, Item, MessageItem } from '@noetic/core';
 import type { Message } from 'chat';
 
 //#region Helper
 
-function mapRole(message: Message): 'user' | 'assistant' {
-  // isBot is typed boolean | 'unknown'; strict equality excludes the 'unknown' string value
-  if (message.author.isMe || message.author.isBot === true) {
-    return 'assistant';
-  }
-  return 'user';
+function isAssistant(message: Message): boolean {
+  return message.author.isMe || message.author.isBot === true;
 }
 
-function mapContentType(role: 'user' | 'assistant'): 'input_text' | 'output_text' {
-  return role === 'user' ? 'input_text' : 'output_text';
+function toAssistantItem(msg: Message): MessageItem {
+  return {
+    id: msg.id,
+    status: 'completed',
+    type: 'message',
+    role: 'assistant',
+    content: [
+      {
+        type: 'output_text',
+        text: msg.text,
+        annotations: [],
+      },
+    ],
+  };
+}
+
+function toUserItem(msg: Message): InputMessageItem {
+  return {
+    id: msg.id,
+    status: 'completed',
+    type: 'message',
+    role: 'user',
+    content: [
+      {
+        type: 'input_text',
+        text: msg.text,
+      },
+    ],
+  };
 }
 
 //#endregion
@@ -21,40 +44,18 @@ function mapContentType(role: 'user' | 'assistant'): 'input_text' | 'output_text
 
 /**
  * Convert chat-sdk Messages to Noetic Items for use as conversation context.
- * Parallel to chat-sdk's `toAiMessages()` but produces Noetic Items.
- *
- * - Bot/self messages become assistant role with output_text
- * - User messages become user role with input_text
- * - Empty messages are filtered out
- *
- * @param messages - Array of chat-sdk Message objects
- * @returns Array of Noetic MessageItem objects
  *
  * @public
  */
 export function toNoeticItems(messages: ReadonlyArray<Message>): Item[] {
-  const items: MessageItem[] = [];
+  const items: Item[] = [];
 
   for (const msg of messages) {
     if (!msg.text || msg.text.trim() === '') {
       continue;
     }
 
-    const role = mapRole(msg);
-    const contentType = mapContentType(role);
-
-    items.push({
-      id: msg.id,
-      status: 'completed',
-      type: 'message',
-      role,
-      content: [
-        {
-          type: contentType,
-          text: msg.text,
-        },
-      ],
-    });
+    items.push(isAssistant(msg) ? toAssistantItem(msg) : toUserItem(msg));
   }
 
   return items;

--- a/packages/chat-sdk/test/messages.test.ts
+++ b/packages/chat-sdk/test/messages.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import type { Item, MessageItem } from '@noetic/core';
+import type { InputMessageItem, Item, MessageItem } from '@noetic/core';
 import { Message, parseMarkdown } from 'chat';
 
 import { toNoeticItems } from '../src/messages';
@@ -34,14 +34,26 @@ function createMessage(overrides: {
   });
 }
 
-function isMessageItem(item: Item): item is MessageItem {
-  return item.type === 'message';
+function isAssistantItem(item: Item): item is MessageItem {
+  return item.type === 'message' && 'role' in item && item.role === 'assistant';
 }
 
-function getMessageItem(items: Item[], index: number): MessageItem {
+function isUserItem(item: Item): item is InputMessageItem {
+  return item.type === 'message' && 'role' in item && item.role === 'user';
+}
+
+function getAssistantItem(items: Item[], index: number): MessageItem {
   const item = items[index];
-  if (!isMessageItem(item)) {
-    throw new Error(`Expected MessageItem at index ${index}, got ${item.type}`);
+  if (!isAssistantItem(item)) {
+    throw new Error(`Expected assistant MessageItem at index ${index}`);
+  }
+  return item;
+}
+
+function getUserItem(items: Item[], index: number): InputMessageItem {
+  const item = items[index];
+  if (!isUserItem(item)) {
+    throw new Error(`Expected user InputMessageItem at index ${index}`);
   }
   return item;
 }
@@ -60,7 +72,7 @@ describe('toNoeticItems', () => {
     ]);
 
     expect(items).toHaveLength(1);
-    const item = getMessageItem(items, 0);
+    const item = getUserItem(items, 0);
     expect(item.type).toBe('message');
     expect(item.role).toBe('user');
     expect(item.id).toBe('msg-1');
@@ -84,12 +96,13 @@ describe('toNoeticItems', () => {
     ]);
 
     expect(items).toHaveLength(1);
-    const item = getMessageItem(items, 0);
+    const item = getAssistantItem(items, 0);
     expect(item.role).toBe('assistant');
     expect(item.content).toEqual([
       {
         type: 'output_text',
         text: 'Bot response',
+        annotations: [],
       },
     ]);
   });
@@ -104,7 +117,7 @@ describe('toNoeticItems', () => {
       msg,
     ]);
 
-    const item = getMessageItem(items, 0);
+    const item = getAssistantItem(items, 0);
     expect(item.role).toBe('assistant');
   });
 
@@ -124,13 +137,9 @@ describe('toNoeticItems', () => {
     const items = toNoeticItems(messages);
 
     expect(items).toHaveLength(1);
-    const item = getMessageItem(items, 0);
-    const part = item.content[0];
-    expect(part.type).toBe('input_text');
-    if (part.type === 'refusal') {
-      throw new Error('Unexpected refusal');
-    }
-    expect(part.text).toBe('Valid');
+    const item = getUserItem(items, 0);
+    expect(item.content[0].type).toBe('input_text');
+    expect(item.content[0].text).toBe('Valid');
   });
 
   test('preserves message order', () => {
@@ -172,7 +181,7 @@ describe('toNoeticItems', () => {
       msg,
     ]);
 
-    const item = getMessageItem(items, 0);
+    const item = getUserItem(items, 0);
     expect(item.role).toBe('user');
   });
 
@@ -187,7 +196,7 @@ describe('toNoeticItems', () => {
       msg,
     ]);
 
-    const item = getMessageItem(items, 0);
+    const item = getAssistantItem(items, 0);
     expect(item.role).toBe('assistant');
   });
 });

--- a/packages/chat-sdk/test/modals.test.ts
+++ b/packages/chat-sdk/test/modals.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
-import type { Item, MessageItem } from '@noetic/core';
+import type { InputMessageItem, Item } from '@noetic/core';
 
 import type { ModalSubmitValues } from '../src/modals';
 import { modalToNoeticInput } from '../src/modals';
@@ -8,8 +8,8 @@ import { ModalInputMode } from '../src/types';
 
 //#region Helpers
 
-function isMessageItem(item: Item): item is MessageItem {
-  return item.type === 'message';
+function isInputMessageItem(item: Item): item is InputMessageItem {
+  return item.type === 'message' && 'role' in item && item.role === 'user';
 }
 
 function isItemArray(value: unknown): value is ReadonlyArray<Item> {
@@ -54,15 +54,11 @@ describe('modalToNoeticInput', () => {
     }
     expect(result).toHaveLength(1);
     const item = result[0];
-    if (!isMessageItem(item)) {
-      throw new Error('Expected MessageItem');
+    if (!isInputMessageItem(item)) {
+      throw new Error('Expected InputMessageItem');
     }
     expect(item.role).toBe('user');
-    const part = item.content[0];
-    if (part.type === 'refusal') {
-      throw new Error('Unexpected refusal');
-    }
-    expect(part.text).toContain('feedback: Great product');
+    expect(item.content[0].text).toContain('feedback: Great product');
   });
 
   test('custom mapper overrides mode', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,8 @@ export type { DurableTaskState, DurableTaskStateConfig } from './memory/layers/d
 /** @public */
 export { durableTaskState } from './memory/layers/durable-task-state';
 /** @public */
+export { fileReference } from './memory/layers/file-reference';
+/** @public */
 export type {
   ObservationalMemoryConfig,
   ObservationalState,
@@ -88,8 +90,6 @@ export { toolMemoryLayer } from './memory/layers/tool-memory-layer';
 export type { WorkingMemoryConfig, WorkingMemoryState } from './memory/layers/working-memory';
 /** @public */
 export { workingMemory } from './memory/layers/working-memory';
-/** @public */
-export { fileReference } from './memory/layers/file-reference';
 
 //#endregion
 

--- a/packages/core/src/interpreter/execute-llm.ts
+++ b/packages/core/src/interpreter/execute-llm.ts
@@ -94,7 +94,9 @@ export async function executeLLM<TMemory, I, O>(
       // Run through pipeline — layers can filter/transform
       const { items: finalItems, rerenderRequests } = await baseCtx.harness.runAppendPipeline(
         layers,
-        [userItem],
+        [
+          userItem,
+        ],
         baseCtx,
       );
 
@@ -107,7 +109,13 @@ export async function executeLLM<TMemory, I, O>(
       const immediateRequests = rerenderRequests.filter((r) => r.timing === 'immediate');
       if (immediateRequests.length > 0) {
         const userQuery = typeof input === 'string' ? input : '';
-        await baseCtx.harness.executeRerender(immediateRequests, layers, baseCtx, new Map(), userQuery);
+        await baseCtx.harness.executeRerender(
+          immediateRequests,
+          layers,
+          baseCtx,
+          new Map(),
+          userQuery,
+        );
       }
     } else {
       // No layers, append directly

--- a/packages/core/src/memory/layers/file-reference.ts
+++ b/packages/core/src/memory/layers/file-reference.ts
@@ -53,18 +53,50 @@ const DEFAULT_MAX_FILE_SIZE = 1024 * 1024;
 
 /** Default allowed extensions */
 const DEFAULT_ALLOWED_EXTENSIONS = [
-  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
-  '.json', '.yaml', '.yml', '.toml',
-  '.md', '.mdx', '.txt', '.csv',
-  '.html', '.css', '.scss', '.less',
-  '.py', '.rb', '.go', '.rs', '.java', '.kt', '.swift',
-  '.c', '.cpp', '.h', '.hpp',
-  '.sh', '.bash', '.zsh',
-  '.sql', '.graphql',
-  '.xml', '.svg',
-  '.env', '.env.local', '.env.example',
-  '.gitignore', '.dockerignore',
-  'Dockerfile', 'Makefile', 'Taskfile',
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.toml',
+  '.md',
+  '.mdx',
+  '.txt',
+  '.csv',
+  '.html',
+  '.css',
+  '.scss',
+  '.less',
+  '.py',
+  '.rb',
+  '.go',
+  '.rs',
+  '.java',
+  '.kt',
+  '.swift',
+  '.c',
+  '.cpp',
+  '.h',
+  '.hpp',
+  '.sh',
+  '.bash',
+  '.zsh',
+  '.sql',
+  '.graphql',
+  '.xml',
+  '.svg',
+  '.env',
+  '.env.local',
+  '.env.example',
+  '.gitignore',
+  '.dockerignore',
+  'Dockerfile',
+  'Makefile',
+  'Taskfile',
 ];
 
 //#endregion
@@ -88,12 +120,15 @@ function transformReferencesToAnchors(text: string): string {
 
 function extractFileReferences(text: string): string[] {
   const refs: string[] = [];
-  let match: RegExpExecArray | null;
   const pattern = new RegExp(FILE_REF_PATTERN);
-  while ((match = pattern.exec(text)) !== null) {
+  let match = pattern.exec(text);
+  while (match !== null) {
     refs.push(match[1]);
+    match = pattern.exec(text);
   }
-  return [...new Set(refs)]; // Dedupe
+  return [
+    ...new Set(refs),
+  ]; // Dedupe
 }
 
 function simpleHash(content: string): string {
@@ -113,12 +148,16 @@ function isInputMessage(item: Item): item is InputMessageItem {
     'role' in item &&
     'content' in item &&
     Array.isArray(item.content) &&
-    item.content.every((c) => 'type' in c && c.type === 'input_text')
+    item.content.every(
+      (c: unknown) => typeof c === 'object' && c !== null && 'type' in c && c.type === 'input_text',
+    )
   );
 }
 
 function extractTextFromItem(item: Item): string {
-  if (!isInputMessage(item)) return '';
+  if (!isInputMessage(item)) {
+    return '';
+  }
   return item.content.map((c) => c.text).join('\n');
 }
 
@@ -143,8 +182,15 @@ async function readFileContent(
     // Security: Validate path stays within baseDir (prevent path traversal)
     const normalizedBase = path.resolve(opts.baseDir);
     const normalizedPath = path.resolve(absolutePath);
-    if (!normalizedPath.startsWith(normalizedBase + path.sep) && normalizedPath !== normalizedBase) {
-      return { content: null, deleted: false, error: 'PATH_TRAVERSAL: File outside allowed directory' };
+    if (
+      !normalizedPath.startsWith(normalizedBase + path.sep) &&
+      normalizedPath !== normalizedBase
+    ) {
+      return {
+        content: null,
+        deleted: false,
+        error: 'PATH_TRAVERSAL: File outside allowed directory',
+      };
     }
 
     // Security: Check file extension
@@ -154,13 +200,21 @@ async function readFileContent(
       (allowed) => ext === allowed.toLowerCase() || basename === allowed,
     );
     if (!isAllowedExt && opts.allowedExtensions.length > 0) {
-      return { content: null, deleted: false, error: `DISALLOWED_EXTENSION: ${ext || 'no extension'}` };
+      return {
+        content: null,
+        deleted: false,
+        error: `DISALLOWED_EXTENSION: ${ext || 'no extension'}`,
+      };
     }
 
     // Security: Check for symlinks if not allowed
     const stats = await fs.lstat(absolutePath);
     if (stats.isSymbolicLink() && !opts.followSymlinks) {
-      return { content: null, deleted: false, error: 'SYMLINK: Symlinks not allowed' };
+      return {
+        content: null,
+        deleted: false,
+        error: 'SYMLINK: Symlinks not allowed',
+      };
     }
 
     // Security: Check file size
@@ -174,13 +228,23 @@ async function readFileContent(
     }
 
     const content = await fs.readFile(absolutePath, 'utf-8');
-    return { content, deleted: false };
+    return {
+      content,
+      deleted: false,
+    };
   } catch (e) {
     if (isNodeError(e) && e.code === 'ENOENT') {
-      return { content: null, deleted: true };
+      return {
+        content: null,
+        deleted: true,
+      };
     }
     if (isNodeError(e) && e.code === 'EACCES') {
-      return { content: null, deleted: false, error: 'PERMISSION_DENIED: Cannot read file' };
+      return {
+        content: null,
+        deleted: false,
+        error: 'PERMISSION_DENIED: Cannot read file',
+      };
     }
     throw e;
   }
@@ -193,8 +257,12 @@ function isNodeError(e: unknown): e is NodeJS.ErrnoException {
 function extractResponseText(items: Item[]): string {
   const texts: string[] = [];
   for (const item of items) {
-    if (item.type !== 'message') continue;
-    if (!('content' in item) || !Array.isArray(item.content)) continue;
+    if (item.type !== 'message') {
+      continue;
+    }
+    if (!('content' in item) || !Array.isArray(item.content)) {
+      continue;
+    }
     for (const part of item.content) {
       if ('text' in part && typeof part.text === 'string') {
         texts.push(part.text);
@@ -204,15 +272,18 @@ function extractResponseText(items: Item[]): string {
   return texts.join('').trim();
 }
 
-async function scoreFileRelevance(
-  filePath: string,
-  fileContent: string,
-  userQuery: string,
-  ctx: ExecutionContext,
-  model: string,
-): Promise<number> {
+interface ScoreFileRelevanceParams {
+  filePath: string;
+  fileContent: string;
+  userQuery: string;
+  ctx: ExecutionContext;
+  model: string;
+}
+
+async function scoreFileRelevance(params: ScoreFileRelevanceParams): Promise<number> {
+  const { filePath, fileContent, userQuery, ctx, model } = params;
+
   if (!ctx.callModel) {
-    // No LLM available, use simple heuristic (filename match)
     const queryLower = userQuery.toLowerCase();
     const pathLower = filePath.toLowerCase();
     if (pathLower.includes(queryLower) || queryLower.includes(path.basename(pathLower))) {
@@ -241,7 +312,9 @@ Score:`;
   try {
     const response = await ctx.callModel({
       model,
-      items: [createMessage(scoringPrompt, 'user')],
+      items: [
+        createMessage(scoringPrompt, 'user'),
+      ],
       instructions: 'You are a relevance scorer. Respond with only a number 0-100.',
     });
 
@@ -249,11 +322,11 @@ Score:`;
 
     const score = Number.parseInt(responseText, 10);
     if (Number.isNaN(score) || score < 0 || score > 100) {
-      return 50; // Default on parse failure
+      return 50;
     }
     return score;
   } catch {
-    return 50; // Default on error
+    return 50;
   }
 }
 
@@ -315,7 +388,10 @@ export function fileReference(opts?: FileReferenceOptions): MemoryLayer<FileRefe
         let userQuery = '';
 
         // Update readOpts with current state's baseDir
-        const currentReadOpts: ReadFileOptions = { ...readOpts, baseDir: state.baseDir };
+        const currentReadOpts: ReadFileOptions = {
+          ...readOpts,
+          baseDir: state.baseDir,
+        };
 
         // Process each item
         const transformedItems: Item[] = [];
@@ -358,7 +434,13 @@ export function fileReference(opts?: FileReferenceOptions): MemoryLayer<FileRefe
               const result = await readFileContent(absolutePath, currentReadOpts);
 
               const priority = result.content
-                ? await scoreFileRelevance(ref, result.content, userQuery, ctx, scoringModel)
+                ? await scoreFileRelevance({
+                    filePath: ref,
+                    fileContent: result.content,
+                    userQuery,
+                    ctx,
+                    model: scoringModel,
+                  })
                 : 0;
 
               newFiles.set(ref, {
@@ -385,7 +467,10 @@ export function fileReference(opts?: FileReferenceOptions): MemoryLayer<FileRefe
               };
               return part;
             });
-            const transformedItem: InputMessageItem = { ...item, content: transformedContent };
+            const transformedItem: InputMessageItem = {
+              ...item,
+              content: transformedContent,
+            };
             transformedItems.push(transformedItem);
           } else {
             transformedItems.push(item);
@@ -395,24 +480,40 @@ export function fileReference(opts?: FileReferenceOptions): MemoryLayer<FileRefe
         // Check existing files for changes
         for (const [ref, tracked] of newFiles) {
           // Skip files with errors - they won't change
-          if (tracked.error) continue;
+          if (tracked.error) {
+            continue;
+          }
 
           const result = await readFileContent(tracked.absolutePath, currentReadOpts);
 
           if (result.deleted && !tracked.deleted) {
             // File was deleted
-            newFiles.set(ref, { ...tracked, content: null, deleted: true });
+            newFiles.set(ref, {
+              ...tracked,
+              content: null,
+              deleted: true,
+            });
             hasChanges = true;
           } else if (result.error && !tracked.error) {
             // File now has error (e.g., permission changed)
-            newFiles.set(ref, { ...tracked, content: null, error: result.error });
+            newFiles.set(ref, {
+              ...tracked,
+              content: null,
+              error: result.error,
+            });
             hasChanges = true;
           } else if (!result.deleted && result.content) {
             const newHash = simpleHash(result.content);
             if (newHash !== tracked.contentHash) {
               // File content changed
               const priority = userQuery
-                ? await scoreFileRelevance(ref, result.content, userQuery, ctx, scoringModel)
+                ? await scoreFileRelevance({
+                    filePath: ref,
+                    fileContent: result.content,
+                    userQuery,
+                    ctx,
+                    model: scoringModel,
+                  })
                 : tracked.priority;
 
               newFiles.set(ref, {
@@ -431,7 +532,10 @@ export function fileReference(opts?: FileReferenceOptions): MemoryLayer<FileRefe
 
         return {
           items: transformedItems,
-          state: { ...state, files: newFiles },
+          state: {
+            ...state,
+            files: newFiles,
+          },
           rerender: hasChanges,
           timing: 'immediate',
           scope: 'self',
@@ -440,11 +544,16 @@ export function fileReference(opts?: FileReferenceOptions): MemoryLayer<FileRefe
 
       async recall({ state, budget }) {
         if (state.files.size === 0) {
-          return { items: [], tokenCount: 0 };
+          return {
+            items: [],
+            tokenCount: 0,
+          };
         }
 
         // Sort files by priority (highest first)
-        const sortedFiles = [...state.files.values()].sort((a, b) => b.priority - a.priority);
+        const sortedFiles = [
+          ...state.files.values(),
+        ].sort((a, b) => b.priority - a.priority);
 
         // Build content blocks within budget
         const blocks: string[] = [];
@@ -473,7 +582,9 @@ export function fileReference(opts?: FileReferenceOptions): MemoryLayer<FileRefe
             continue;
           }
 
-          if (!file.content) continue;
+          if (!file.content) {
+            continue;
+          }
 
           const header = `## ${file.referencePath}`;
           const headerTokens = estimateTokens(header);
@@ -508,13 +619,18 @@ export function fileReference(opts?: FileReferenceOptions): MemoryLayer<FileRefe
         }
 
         if (blocks.length === 0) {
-          return { items: [], tokenCount: 0 };
+          return {
+            items: [],
+            tokenCount: 0,
+          };
         }
 
         const content = `# Referenced Files\n\n${blocks.join('\n\n')}`;
 
         return {
-          items: [createMessage(content, 'developer')],
+          items: [
+            createMessage(content, 'developer'),
+          ],
           tokenCount: estimateTokens(content),
         };
       },

--- a/packages/core/src/runtime/agent-harness.ts
+++ b/packages/core/src/runtime/agent-harness.ts
@@ -634,7 +634,10 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
   }> {
     const hasHook = layers.some((l) => l.hooks.onItemAppend);
     if (!hasHook) {
-      return { items, rerenderRequests: [] };
+      return {
+        items,
+        rerenderRequests: [],
+      };
     }
     return runAppendPipeline({
       layers,

--- a/packages/core/test/memory/file-reference.test.ts
+++ b/packages/core/test/memory/file-reference.test.ts
@@ -9,7 +9,15 @@ import {
 } from '../../src/memory/layer-lifecycle';
 import { fileReference } from '../../src/memory/layers/file-reference';
 import type { InputMessageItem, Item } from '../../src/types/items';
+import type { MemoryLayer, RecallParams } from '../../src/types/memory';
 import { makeCtx, makeItemLog, makeStorage } from '../_helpers';
+
+function callRecall(
+  layer: MemoryLayer,
+  params: RecallParams<unknown>,
+): ReturnType<NonNullable<MemoryLayer['hooks']['recall']>> {
+  return layer.hooks.recall!(params);
+}
 
 describe('fileReference', () => {
   let tempDir: string;
@@ -47,7 +55,10 @@ describe('fileReference', () => {
       item.role === 'user' &&
       'content' in item &&
       Array.isArray(item.content) &&
-      item.content.every((c) => 'type' in c && c.type === 'input_text')
+      item.content.every(
+        (c: unknown) =>
+          typeof c === 'object' && c !== null && 'type' in c && c.type === 'input_text',
+      )
     );
   }
 
@@ -494,8 +505,8 @@ describe('fileReference', () => {
       }
 
       // Call recall - use getRecallContent helper for type safety
-      const recallResult = await layer.hooks.recall!({
-        state: state as never,
+      const recallResult = await callRecall(layer, {
+        state,
         budget: 10000,
         query: '',
         ctx,
@@ -550,8 +561,8 @@ describe('fileReference', () => {
       const state = store.get<TestFileRefState>('exec-errors', 'file-reference');
 
       // Call recall
-      const recallResult = await layer.hooks.recall!({
-        state: state as never,
+      const recallResult = await callRecall(layer, {
+        state,
         budget: 10000,
         query: '',
         ctx,
@@ -605,8 +616,8 @@ describe('fileReference', () => {
       const state = store.get<TestFileRefState>('exec-truncate', 'file-reference');
 
       // Call recall with very small budget
-      const recallResult = await layer.hooks.recall!({
-        state: state as never,
+      const recallResult = await callRecall(layer, {
+        state,
         budget: 100, // Very small budget
         query: '',
         ctx,
@@ -672,8 +683,8 @@ describe('fileReference', () => {
       const state = store.get<TestFileRefState>('exec-del-recall', 'file-reference');
 
       // Call recall
-      const recallResult = await layer.hooks.recall!({
-        state: state as never,
+      const recallResult = await callRecall(layer, {
+        state,
         budget: 10000,
         query: '',
         ctx,
@@ -705,8 +716,8 @@ describe('fileReference', () => {
 
       const state = store.get<TestFileRefState>('exec-empty', 'file-reference');
 
-      const recallResult = await layer.hooks.recall!({
-        state: state as never,
+      const recallResult = await callRecall(layer, {
+        state,
         budget: 10000,
         query: '',
         ctx,

--- a/packages/core/test/memory/layer-lifecycle.test.ts
+++ b/packages/core/test/memory/layer-lifecycle.test.ts
@@ -689,7 +689,12 @@ describe('runAppendPipeline', () => {
       type: 'message',
       role: 'user',
       status: 'completed',
-      content: [{ type: 'input_text', text }],
+      content: [
+        {
+          type: 'input_text',
+          text,
+        },
+      ],
     };
   }
 
@@ -704,8 +709,12 @@ describe('runAppendPipeline', () => {
         hooks: {},
       },
     ];
-    const ctx = makeCtx({ executionId: 'exec-no-hook' });
-    const items = [makeUserMessage('hello')];
+    const ctx = makeCtx({
+      executionId: 'exec-no-hook',
+    });
+    const items = [
+      makeUserMessage('hello'),
+    ];
 
     const result = await runAppendPipeline({
       layers,
@@ -732,7 +741,9 @@ describe('runAppendPipeline', () => {
         hooks: {
           onItemAppend: async ({ items }) => {
             order.push('high');
-            return { items };
+            return {
+              items,
+            };
           },
         },
       },
@@ -744,14 +755,20 @@ describe('runAppendPipeline', () => {
         hooks: {
           onItemAppend: async ({ items }) => {
             order.push('low');
-            return { items };
+            return {
+              items,
+            };
           },
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-order' });
-    const items = [makeUserMessage('hello')];
+    const ctx = makeCtx({
+      executionId: 'exec-order',
+    });
+    const items = [
+      makeUserMessage('hello'),
+    ];
 
     await runAppendPipeline({
       layers,
@@ -761,7 +778,10 @@ describe('runAppendPipeline', () => {
       store,
     });
 
-    expect(order).toEqual(['low', 'high']);
+    expect(order).toEqual([
+      'low',
+      'high',
+    ]);
   });
 
   it('filters items when layer returns empty array', async () => {
@@ -773,13 +793,19 @@ describe('runAppendPipeline', () => {
         slot: 100,
         scope: 'execution',
         hooks: {
-          onItemAppend: async () => ({ items: [] }),
+          onItemAppend: async () => ({
+            items: [],
+          }),
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-filter' });
-    const items = [makeUserMessage('hello')];
+    const ctx = makeCtx({
+      executionId: 'exec-filter',
+    });
+    const items = [
+      makeUserMessage('hello'),
+    ];
 
     const result = await runAppendPipeline({
       layers,
@@ -806,14 +832,20 @@ describe('runAppendPipeline', () => {
               ...item,
               id: `transformed-${item.id}`,
             }));
-            return { items: transformed };
+            return {
+              items: transformed,
+            };
           },
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-transform' });
-    const items = [makeUserMessage('hello')];
+    const ctx = makeCtx({
+      executionId: 'exec-transform',
+    });
+    const items = [
+      makeUserMessage('hello'),
+    ];
 
     const result = await runAppendPipeline({
       layers,
@@ -838,14 +870,23 @@ describe('runAppendPipeline', () => {
         hooks: {
           onItemAppend: async ({ items }) => {
             const extra = makeUserMessage('injected');
-            return { items: [...items, extra] };
+            return {
+              items: [
+                ...items,
+                extra,
+              ],
+            };
           },
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-inject' });
-    const items = [makeUserMessage('original')];
+    const ctx = makeCtx({
+      executionId: 'exec-inject',
+    });
+    const items = [
+      makeUserMessage('original'),
+    ];
 
     const result = await runAppendPipeline({
       layers,
@@ -860,23 +901,33 @@ describe('runAppendPipeline', () => {
 
   it('updates layer state', async () => {
     const store = createLayerStateStore();
-    const layers: MemoryLayer<{ count: number }>[] = [
+    const layers: MemoryLayer<{
+      count: number;
+    }>[] = [
       {
         id: 'stateful',
         name: 'Stateful',
         slot: 100,
         scope: 'execution',
         hooks: {
-          init: async () => ({ state: { count: 0 } }),
+          init: async () => ({
+            state: {
+              count: 0,
+            },
+          }),
           onItemAppend: async ({ items, state }) => ({
             items,
-            state: { count: state.count + items.length },
+            state: {
+              count: state.count + items.length,
+            },
           }),
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-stateful' });
+    const ctx = makeCtx({
+      executionId: 'exec-stateful',
+    });
     await initLayers({
       layers,
       ctx,
@@ -884,7 +935,9 @@ describe('runAppendPipeline', () => {
       store,
     });
 
-    const items = [makeUserMessage('hello')];
+    const items = [
+      makeUserMessage('hello'),
+    ];
     await runAppendPipeline({
       layers,
       items,
@@ -893,7 +946,9 @@ describe('runAppendPipeline', () => {
       store,
     });
 
-    const state = store.get<{ count: number }>('exec-stateful', 'stateful');
+    const state = store.get<{
+      count: number;
+    }>('exec-stateful', 'stateful');
     expect(state?.count).toBe(1);
   });
 
@@ -915,8 +970,12 @@ describe('runAppendPipeline', () => {
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-rerender' });
-    const items = [makeUserMessage('hello')];
+    const ctx = makeCtx({
+      executionId: 'exec-rerender',
+    });
+    const items = [
+      makeUserMessage('hello'),
+    ];
 
     const result = await runAppendPipeline({
       layers,
@@ -949,8 +1008,12 @@ describe('runAppendPipeline', () => {
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-timing' });
-    const items = [makeUserMessage('hello')];
+    const ctx = makeCtx({
+      executionId: 'exec-timing',
+    });
+    const items = [
+      makeUserMessage('hello'),
+    ];
 
     const result = await runAppendPipeline({
       layers,
@@ -974,7 +1037,9 @@ describe('runAppendPipeline', () => {
         slot: 100,
         scope: 'execution',
         hooks: {
-          onItemAppend: async () => ({ items: [] }),
+          onItemAppend: async () => ({
+            items: [],
+          }),
         },
       },
       {
@@ -985,14 +1050,20 @@ describe('runAppendPipeline', () => {
         hooks: {
           onItemAppend: async ({ items }) => {
             secondCalled = true;
-            return { items };
+            return {
+              items,
+            };
           },
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-stop' });
-    const items = [makeUserMessage('hello')];
+    const ctx = makeCtx({
+      executionId: 'exec-stop',
+    });
+    const items = [
+      makeUserMessage('hello'),
+    ];
 
     await runAppendPipeline({
       layers,
@@ -1006,9 +1077,15 @@ describe('runAppendPipeline', () => {
   });
 
   it('handles errors gracefully and passes items through', async () => {
-    const errors: { layerId: string; hook: string }[] = [];
+    const errors: {
+      layerId: string;
+      hook: string;
+    }[] = [];
     const store = createLayerStateStore((layerId, hook) => {
-      errors.push({ layerId, hook });
+      errors.push({
+        layerId,
+        hook,
+      });
     });
 
     const layers: MemoryLayer[] = [
@@ -1025,8 +1102,12 @@ describe('runAppendPipeline', () => {
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-error' });
-    const items = [makeUserMessage('hello')];
+    const ctx = makeCtx({
+      executionId: 'exec-error',
+    });
+    const items = [
+      makeUserMessage('hello'),
+    ];
 
     const result = await runAppendPipeline({
       layers,
@@ -1058,13 +1139,17 @@ describe('runAppendPipeline', () => {
           },
           onItemAppend: async ({ items }) => {
             hookCalled = true;
-            return { items };
+            return {
+              items,
+            };
           },
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-disabled' });
+    const ctx = makeCtx({
+      executionId: 'exec-disabled',
+    });
     await initLayers({
       layers,
       ctx,
@@ -1072,7 +1157,9 @@ describe('runAppendPipeline', () => {
       store,
     });
 
-    const items = [makeUserMessage('hello')];
+    const items = [
+      makeUserMessage('hello'),
+    ];
     await runAppendPipeline({
       layers,
       items,
@@ -1085,9 +1172,15 @@ describe('runAppendPipeline', () => {
   });
 
   it('times out slow onItemAppend hooks', async () => {
-    const errors: { layerId: string; hook: string }[] = [];
+    const errors: {
+      layerId: string;
+      hook: string;
+    }[] = [];
     const store = createLayerStateStore((layerId, hook) => {
-      errors.push({ layerId, hook });
+      errors.push({
+        layerId,
+        hook,
+      });
     });
 
     const layers: MemoryLayer[] = [
@@ -1103,14 +1196,20 @@ describe('runAppendPipeline', () => {
           onItemAppend: async ({ items }) => {
             // This will take longer than the timeout
             await new Promise((r) => setTimeout(r, 200));
-            return { items };
+            return {
+              items,
+            };
           },
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-timeout' });
-    const items = [makeUserMessage('hello')];
+    const ctx = makeCtx({
+      executionId: 'exec-timeout',
+    });
+    const items = [
+      makeUserMessage('hello'),
+    ];
 
     const result = await runAppendPipeline({
       layers,
@@ -1131,7 +1230,9 @@ describe('runAppendPipeline', () => {
 describe('executeRerender', () => {
   it('returns empty array when no requests', async () => {
     const store = createLayerStateStore();
-    const ctx = makeCtx({ executionId: 'exec-empty' });
+    const ctx = makeCtx({
+      executionId: 'exec-empty',
+    });
 
     const result = await executeRerender({
       requests: [],
@@ -1156,10 +1257,15 @@ describe('executeRerender', () => {
         slot: 100,
         scope: 'execution',
         hooks: {
-          init: async () => ({ state: {} }),
+          init: async () => ({
+            state: {},
+          }),
           recall: async () => {
             recallOrder.push('target');
-            return { items: [], tokenCount: 0 };
+            return {
+              items: [],
+              tokenCount: 0,
+            };
           },
         },
       },
@@ -1169,16 +1275,23 @@ describe('executeRerender', () => {
         slot: 200,
         scope: 'execution',
         hooks: {
-          init: async () => ({ state: {} }),
+          init: async () => ({
+            state: {},
+          }),
           recall: async () => {
             recallOrder.push('other');
-            return { items: [], tokenCount: 0 };
+            return {
+              items: [],
+              tokenCount: 0,
+            };
           },
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-self' });
+    const ctx = makeCtx({
+      executionId: 'exec-self',
+    });
     await initLayers({
       layers,
       ctx,
@@ -1188,16 +1301,32 @@ describe('executeRerender', () => {
 
     await executeRerender({
       requests: [
-        { layerId: 'target', slot: 100, timing: 'immediate', scope: 'self' },
+        {
+          layerId: 'target',
+          slot: 100,
+          timing: 'immediate',
+          scope: 'self',
+        },
       ],
       layers,
       ctx,
       log: makeItemLog(),
-      budgets: new Map([['target', 1e3], ['other', 1e3]]),
+      budgets: new Map([
+        [
+          'target',
+          1e3,
+        ],
+        [
+          'other',
+          1e3,
+        ],
+      ]),
       store,
     });
 
-    expect(recallOrder).toEqual(['target']);
+    expect(recallOrder).toEqual([
+      'target',
+    ]);
   });
 
   it('re-recalls slot-after scope', async () => {
@@ -1211,10 +1340,15 @@ describe('executeRerender', () => {
         slot: 50,
         scope: 'execution',
         hooks: {
-          init: async () => ({ state: {} }),
+          init: async () => ({
+            state: {},
+          }),
           recall: async () => {
             recallOrder.push('before');
-            return { items: [], tokenCount: 0 };
+            return {
+              items: [],
+              tokenCount: 0,
+            };
           },
         },
       },
@@ -1224,10 +1358,15 @@ describe('executeRerender', () => {
         slot: 100,
         scope: 'execution',
         hooks: {
-          init: async () => ({ state: {} }),
+          init: async () => ({
+            state: {},
+          }),
           recall: async () => {
             recallOrder.push('target');
-            return { items: [], tokenCount: 0 };
+            return {
+              items: [],
+              tokenCount: 0,
+            };
           },
         },
       },
@@ -1237,16 +1376,23 @@ describe('executeRerender', () => {
         slot: 200,
         scope: 'execution',
         hooks: {
-          init: async () => ({ state: {} }),
+          init: async () => ({
+            state: {},
+          }),
           recall: async () => {
             recallOrder.push('after');
-            return { items: [], tokenCount: 0 };
+            return {
+              items: [],
+              tokenCount: 0,
+            };
           },
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-slot-after' });
+    const ctx = makeCtx({
+      executionId: 'exec-slot-after',
+    });
     await initLayers({
       layers,
       ctx,
@@ -1256,17 +1402,38 @@ describe('executeRerender', () => {
 
     await executeRerender({
       requests: [
-        { layerId: 'target', slot: 100, timing: 'immediate', scope: 'slot-after' },
+        {
+          layerId: 'target',
+          slot: 100,
+          timing: 'immediate',
+          scope: 'slot-after',
+        },
       ],
       layers,
       ctx,
       log: makeItemLog(),
-      budgets: new Map([['before', 1e3], ['target', 1e3], ['after', 1e3]]),
+      budgets: new Map([
+        [
+          'before',
+          1e3,
+        ],
+        [
+          'target',
+          1e3,
+        ],
+        [
+          'after',
+          1e3,
+        ],
+      ]),
       store,
     });
 
     // Should include target and after, not before
-    expect(recallOrder).toEqual(['target', 'after']);
+    expect(recallOrder).toEqual([
+      'target',
+      'after',
+    ]);
   });
 
   it('re-recalls all scope', async () => {
@@ -1280,10 +1447,15 @@ describe('executeRerender', () => {
         slot: 50,
         scope: 'execution',
         hooks: {
-          init: async () => ({ state: {} }),
+          init: async () => ({
+            state: {},
+          }),
           recall: async () => {
             recallOrder.push('first');
-            return { items: [], tokenCount: 0 };
+            return {
+              items: [],
+              tokenCount: 0,
+            };
           },
         },
       },
@@ -1293,16 +1465,23 @@ describe('executeRerender', () => {
         slot: 150,
         scope: 'execution',
         hooks: {
-          init: async () => ({ state: {} }),
+          init: async () => ({
+            state: {},
+          }),
           recall: async () => {
             recallOrder.push('second');
-            return { items: [], tokenCount: 0 };
+            return {
+              items: [],
+              tokenCount: 0,
+            };
           },
         },
       },
     ];
 
-    const ctx = makeCtx({ executionId: 'exec-all' });
+    const ctx = makeCtx({
+      executionId: 'exec-all',
+    });
     await initLayers({
       layers,
       ctx,
@@ -1312,16 +1491,33 @@ describe('executeRerender', () => {
 
     await executeRerender({
       requests: [
-        { layerId: 'second', slot: 150, timing: 'immediate', scope: 'all' },
+        {
+          layerId: 'second',
+          slot: 150,
+          timing: 'immediate',
+          scope: 'all',
+        },
       ],
       layers,
       ctx,
       log: makeItemLog(),
-      budgets: new Map([['first', 1e3], ['second', 1e3]]),
+      budgets: new Map([
+        [
+          'first',
+          1e3,
+        ],
+        [
+          'second',
+          1e3,
+        ],
+      ]),
       store,
     });
 
     // Should recall all in slot order
-    expect(recallOrder).toEqual(['first', 'second']);
+    expect(recallOrder).toEqual([
+      'first',
+      'second',
+    ]);
   });
 });

--- a/packages/core/test/memory/steering.test.ts
+++ b/packages/core/test/memory/steering.test.ts
@@ -435,7 +435,9 @@ describe('steering layer', () => {
       assert(result.items[0].type === 'message');
       const text = result.items[0].content
         .filter(
-          (c: { type: string }): c is {
+          (c: {
+            type: string;
+          }): c is {
             type: 'input_text';
             text: string;
           } => c.type === 'input_text' && 'text' in c,

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -116,6 +116,37 @@
   grid-column: span 2;
 }
 
+.side-by-side-sections {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+}
+
+.side-by-side-sections > * {
+  flex: 1;
+  min-width: 0;
+}
+
+.side-by-side-sections section {
+  max-width: 100%;
+}
+
+.section-split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 64px;
+  align-items: center;
+}
+
+.section-split > * {
+  min-width: 0;
+}
+
+/* Memory section: swap order on desktop so SVG appears on left */
+.section-split > .memory-visual {
+  order: -1;
+}
+
 .landing-section + .landing-section,
 .side-by-side-sections + .landing-section,
 .landing-section + .side-by-side-sections {
@@ -191,72 +222,7 @@
   .tui-scanlines::after {
     display: none;
   }
-}
 
-.side-by-side-sections {
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-}
-
-.side-by-side-sections > * {
-  flex: 1;
-  min-width: 0;
-}
-
-.side-by-side-sections section {
-  max-width: 100%;
-}
-
-.section-split {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 64px;
-  align-items: center;
-}
-
-.section-split > * {
-  min-width: 0;
-}
-
-/* Memory section: swap order on desktop so SVG appears on left */
-.section-split > .memory-visual {
-  order: -1;
-}
-
-@media (max-width: 1024px) {
-  .side-by-side-sections {
-    flex-direction: column;
-  }
-
-  .section-split {
-    grid-template-columns: 1fr;
-  }
-
-  .section-split > :last-child {
-    order: 2;
-    margin-top: 32px;
-  }
-
-  /* Reset memory section order for single column (content first, then SVG) */
-  .section-split > .memory-visual {
-    order: 0;
-  }
-}
-
-@media (max-width: 480px) {
-  .section-split > :last-child {
-    margin-top: 24px;
-  }
-}
-
-@media (min-width: 1025px) {
-  main section {
-    max-width: 1280px;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
   svg * {
     animation-play-state: paused;
   }

--- a/packages/web/components/landing/svgs/patterns-isometric.tsx
+++ b/packages/web/components/landing/svgs/patterns-isometric.tsx
@@ -221,10 +221,6 @@ export function PatternsIsometricSvg(): ReactNode {
     x: llmPos.x,
     y: llmPos.y + NODE_H / 2,
   };
-  const llmTop = {
-    x: llmPos.x + NODE_W / 2,
-    y: llmPos.y,
-  };
   const llmBottom = {
     x: llmPos.x + NODE_W / 2,
     y: llmPos.y + NODE_H,
@@ -244,10 +240,6 @@ export function PatternsIsometricSvg(): ReactNode {
   const memTop = {
     x: memX + memW / 2,
     y: memY,
-  };
-  const memBottom = {
-    x: memX + memW / 2,
-    y: memY + memH,
   };
   const memRight = {
     x: memX + memW,


### PR DESCRIPTION
## Summary
- Fix biome lint errors: CSS specificity ordering, unused variables, import ordering, formatting violations, assignment-in-expression
- Fix TypeScript errors: `system` → `instructions` in skippy bot, type-safe `Item` union in chat-sdk messages, implicit `any` parameters
- Refactor `scoreFileRelevance` to use object params (>3-param biome rule)
- Remove duplicate CSS media query blocks in global.css
- Update chat-sdk tests to use proper `InputMessageItem`/`MessageItem` type guards

## Test plan
- [ ] CI lint (`bunx biome check .`) passes
- [ ] Core typecheck passes
- [ ] Skippy typecheck passes
- [ ] Chat-sdk typecheck passes
- [ ] Core tests pass
- [ ] Chat-sdk tests pass