### PR TITLE
feat(cli): add slash command system

### DIFF
--- a/packages/cli/src/commands/builtins/clear.ts
+++ b/packages/cli/src/commands/builtins/clear.ts
@@ -1,0 +1,29 @@
+/**
+ * /clear command - Clears the conversation history.
+ */
+
+import type { Command, LocalCommandCall } from '../types.js';
+
+//#region Implementation
+
+const call: LocalCommandCall = async (_args, ctx) => {
+  ctx.clearEntries();
+  return {
+    type: 'skip',
+  };
+};
+
+//#endregion
+
+//#region Command Definition
+
+export const clear: Command = {
+  type: 'local',
+  name: 'clear',
+  description: 'Clear conversation history',
+  load: async () => ({
+    call,
+  }),
+};
+
+//#endregion

--- a/packages/cli/src/commands/builtins/context.tsx
+++ b/packages/cli/src/commands/builtins/context.tsx
@@ -1,0 +1,131 @@
+/**
+ * /context command - Shows current context usage.
+ */
+
+import { Box, Text } from 'ink';
+import type { ReactNode } from 'react';
+
+import type { ConversationEntry } from '../../tui/item-utils.js';
+import type { Command, LocalJsxCommandCall, LocalJsxCommandOnDone } from '../types.js';
+
+//#region Types
+
+interface ContextDisplayProps {
+  model: string;
+  entries: ReadonlyArray<ConversationEntry>;
+  onDone: LocalJsxCommandOnDone;
+}
+
+interface StatRowProps {
+  label: string;
+  value: string | number;
+  color?: string;
+}
+
+//#endregion
+
+//#region Helpers
+
+function countByType(entries: ReadonlyArray<ConversationEntry>): {
+  userMessages: number;
+  assistantMessages: number;
+  toolCalls: number;
+  errors: number;
+} {
+  let userMessages = 0;
+  let assistantMessages = 0;
+  let toolCalls = 0;
+  let errors = 0;
+
+  for (const entry of entries) {
+    if ('role' in entry && entry.role === 'user') {
+      userMessages++;
+      continue;
+    }
+    if ('type' in entry) {
+      if (entry.type === 'error') {
+        errors++;
+        continue;
+      }
+      if (entry.type === 'message') {
+        assistantMessages++;
+        continue;
+      }
+      if (entry.type === 'function_call' || entry.type === 'function_call_output') {
+        toolCalls++;
+      }
+    }
+  }
+
+  return {
+    userMessages,
+    assistantMessages,
+    toolCalls,
+    errors,
+  };
+}
+
+//#endregion
+
+//#region Components
+
+function StatRow({ label, value, color = 'white' }: StatRowProps): ReactNode {
+  return (
+    <Box>
+      <Box width={20}>
+        <Text dimColor>{label}</Text>
+      </Box>
+      <Text color={color}>{String(value)}</Text>
+    </Box>
+  );
+}
+
+function ContextDisplay({ model, entries, onDone }: ContextDisplayProps): ReactNode {
+  const counts = countByType(entries);
+  const totalMessages = counts.userMessages + counts.assistantMessages;
+
+  // Auto-dismiss after render
+  setTimeout(() => onDone(), 0);
+
+  return (
+    <Box flexDirection="column" marginY={1}>
+      <Text bold>Context Status</Text>
+      <Box height={1} />
+
+      <Box flexDirection="column" marginLeft={2}>
+        <StatRow label="Model" value={model} color="cyan" />
+        <StatRow label="Total Messages" value={totalMessages} color="green" />
+        <StatRow label="  User" value={counts.userMessages} />
+        <StatRow label="  Assistant" value={counts.assistantMessages} />
+        <StatRow label="Tool Calls" value={counts.toolCalls} color="yellow" />
+        {counts.errors > 0 && <StatRow label="Errors" value={counts.errors} color="red" />}
+      </Box>
+
+      <Box height={1} />
+      <Text dimColor>Note: Token usage tracking coming soon.</Text>
+    </Box>
+  );
+}
+
+//#endregion
+
+//#region Implementation
+
+const call: LocalJsxCommandCall = async (onDone, ctx, _args) => {
+  return <ContextDisplay model={ctx.config.model} entries={ctx.entries} onDone={onDone} />;
+};
+
+//#endregion
+
+//#region Command Definition
+
+export const context: Command = {
+  type: 'local-jsx',
+  name: 'context',
+  description: 'Show current context usage',
+  load: async () => ({
+    call,
+  }),
+};
+
+//#endregion

--- a/packages/cli/src/commands/builtins/index.ts
+++ b/packages/cli/src/commands/builtins/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Built-in commands index.
+ */
+
+import type { Command } from '../types.js';
+
+import { clear } from './clear.js';
+import { context } from './context.js';
+import { skills } from './skills.js';
+
+/**
+ * All built-in commands.
+ */
+export const BUILTIN_COMMANDS: ReadonlyArray<Command> = [
+  clear,
+  context,
+  skills,
+];
+
+export { clear, context, skills };

--- a/packages/cli/src/commands/builtins/skills.tsx
+++ b/packages/cli/src/commands/builtins/skills.tsx
@@ -1,0 +1,107 @@
+/**
+ * /skills command - Lists available skills.
+ */
+
+import { Box, Text } from 'ink';
+import type { ReactNode } from 'react';
+import type { SkillDefinition } from '../../skills/types.js';
+import { SkillSource } from '../../skills/types.js';
+import type { Command, LocalJsxCommandCall, LocalJsxCommandOnDone } from '../types.js';
+
+//#region Types
+
+interface SkillsListProps {
+  skills: ReadonlyArray<SkillDefinition>;
+  activatedSkills: ReadonlySet<string>;
+  onDone: LocalJsxCommandOnDone;
+}
+
+interface SkillGroupProps {
+  title: string;
+  skills: ReadonlyArray<SkillDefinition>;
+  activatedSkills: ReadonlySet<string>;
+}
+
+//#endregion
+
+//#region Components
+
+function SkillGroup({ title, skills, activatedSkills }: SkillGroupProps): ReactNode {
+  if (skills.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box flexDirection="column" marginBottom={1}>
+      <Text bold color="cyan">
+        {title} ({skills.length})
+      </Text>
+      {skills.map((skill) => {
+        const isActive = activatedSkills.has(skill.name);
+        return (
+          <Box key={skill.name} marginLeft={2}>
+            {isActive && <Text color="yellow">[active] </Text>}
+            <Text color={isActive ? 'yellow' : 'green'}>/{skill.name}</Text>
+            {skill.description && <Text dimColor> — {skill.description}</Text>}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+function SkillsList({ skills, activatedSkills, onDone }: SkillsListProps): ReactNode {
+  // Group skills by source
+  const projectSkills = skills.filter((s) => s.source === SkillSource.Project);
+  const userSkills = skills.filter((s) => s.source === SkillSource.User);
+  const pluginSkills = skills.filter((s) => s.source === SkillSource.Plugin);
+
+  const totalCount = skills.length;
+  const activeCount = activatedSkills.size;
+
+  // Auto-dismiss after render (skills list is informational)
+  setTimeout(() => onDone(), 0);
+
+  if (totalCount === 0) {
+    return (
+      <Box flexDirection="column" marginY={1}>
+        <Text dimColor>No skills available.</Text>
+        <Text dimColor>Add skills to .noetic/skills/ or ~/.noetic/skills/</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" marginY={1}>
+      <Text bold>Available Skills ({totalCount})</Text>
+      {activeCount > 0 && <Text dimColor>{activeCount} active in this conversation</Text>}
+      <Box height={1} />
+      <SkillGroup title="Project Skills" skills={projectSkills} activatedSkills={activatedSkills} />
+      <SkillGroup title="User Skills" skills={userSkills} activatedSkills={activatedSkills} />
+      <SkillGroup title="Plugin Skills" skills={pluginSkills} activatedSkills={activatedSkills} />
+    </Box>
+  );
+}
+
+//#endregion
+
+//#region Implementation
+
+const call: LocalJsxCommandCall = async (onDone, ctx, _args) => {
+  return <SkillsList skills={ctx.skills} activatedSkills={ctx.activatedSkills} onDone={onDone} />;
+};
+
+//#endregion
+
+//#region Command Definition
+
+export const skills: Command = {
+  type: 'local-jsx',
+  name: 'skills',
+  description: 'List available skills',
+  load: async () => ({
+    call,
+  }),
+};
+
+//#endregion

--- a/packages/cli/src/commands/execute.ts
+++ b/packages/cli/src/commands/execute.ts
@@ -1,0 +1,63 @@
+/**
+ * Command execution.
+ *
+ * Dispatches command execution based on command type.
+ */
+
+import type { Command, CommandContext, CommandExecutionResult } from './types.js';
+
+//#region Execute
+
+/**
+ * Execute a command and return the result.
+ */
+export async function executeCommand(
+  command: Command,
+  args: string,
+  ctx: CommandContext,
+): Promise<CommandExecutionResult> {
+  // Check if command is enabled
+  if (command.isEnabled && !command.isEnabled()) {
+    return {
+      type: 'text',
+      value: `Command /${command.name} is not currently available.`,
+    };
+  }
+
+  if (command.type === 'local') {
+    const mod = await command.load();
+    const result = await mod.call(args, ctx);
+    return result;
+  }
+
+  if (command.type === 'local-jsx') {
+    const mod = await command.load();
+    // For JSX commands, we return a special result that the caller handles
+    return new Promise((resolve) => {
+      const onDone = (result?: string): void => {
+        if (result) {
+          resolve({
+            type: 'text',
+            value: result,
+          });
+        } else {
+          resolve({
+            type: 'skip',
+          });
+        }
+      };
+      mod.call(onDone, ctx, args).then((node) => {
+        resolve({
+          type: 'jsx',
+          node,
+        });
+      });
+    });
+  }
+
+  // Exhaustive check - should never reach here
+  const _exhaustive: never = command;
+  return _exhaustive;
+}
+
+//#endregion

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Commands module - Slash command system for the CLI.
+ */
+
+// Built-in commands
+export { BUILTIN_COMMANDS, clear, context, skills } from './builtins/index.js';
+// Execute
+export { executeCommand } from './execute.js';
+export type { ParsedSlashCommand } from './parse.js';
+// Parse
+export { isSlashCommand, parseSlashCommand } from './parse.js';
+// Registry
+export { findCommand, getEnabledCommands, getVisibleCommands, hasCommand } from './registry.js';
+
+// Suggestions
+export { commandsToPromptSuggestions, generateCommandSuggestions } from './suggestions.js';
+// Types
+export type {
+  Command,
+  CommandBase,
+  CommandContext,
+  CommandExecutionResult,
+  LocalCommand,
+  LocalCommandCall,
+  LocalCommandModule,
+  LocalCommandResult,
+  LocalJsxCommand,
+  LocalJsxCommandCall,
+  LocalJsxCommandModule,
+  LocalJsxCommandOnDone,
+} from './types.js';

--- a/packages/cli/src/commands/parse.ts
+++ b/packages/cli/src/commands/parse.ts
@@ -1,0 +1,55 @@
+/**
+ * Slash command parsing.
+ */
+
+//#region Types
+
+interface ParsedSlashCommand {
+  /** Command name (without leading slash) */
+  commandName: string;
+  /** Arguments after the command name */
+  args: string;
+}
+
+//#endregion
+
+//#region Parser
+
+/**
+ * Parse user input as a slash command.
+ * Returns null if input doesn't start with '/'.
+ */
+export function parseSlashCommand(input: string): ParsedSlashCommand | null {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith('/')) {
+    return null;
+  }
+
+  // Remove leading slash and split on first whitespace
+  const withoutSlash = trimmed.slice(1);
+  const spaceIndex = withoutSlash.search(/\s/);
+
+  if (spaceIndex === -1) {
+    // No arguments
+    return {
+      commandName: withoutSlash,
+      args: '',
+    };
+  }
+
+  return {
+    commandName: withoutSlash.slice(0, spaceIndex),
+    args: withoutSlash.slice(spaceIndex + 1).trim(),
+  };
+}
+
+/**
+ * Check if input looks like a slash command.
+ */
+export function isSlashCommand(input: string): boolean {
+  return input.trim().startsWith('/');
+}
+
+//#endregion
+
+export type { ParsedSlashCommand };

--- a/packages/cli/src/commands/registry.ts
+++ b/packages/cli/src/commands/registry.ts
@@ -1,0 +1,52 @@
+/**
+ * Command registry and discovery.
+ *
+ * Provides lookup utilities for commands.
+ */
+
+import type { Command } from './types.js';
+
+//#region Lookup Utilities
+
+/**
+ * Find a command by name or alias.
+ */
+export function findCommand(name: string, commands: ReadonlyArray<Command>): Command | undefined {
+  const lowerName = name.toLowerCase();
+  for (const cmd of commands) {
+    if (cmd.name.toLowerCase() === lowerName) {
+      return cmd;
+    }
+    if (cmd.aliases?.some((a) => a.toLowerCase() === lowerName)) {
+      return cmd;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Check if a command exists by name or alias.
+ */
+export function hasCommand(name: string, commands: ReadonlyArray<Command>): boolean {
+  return findCommand(name, commands) !== undefined;
+}
+
+/**
+ * Get enabled commands only.
+ */
+export function getEnabledCommands(commands: ReadonlyArray<Command>): Command[] {
+  return commands.filter((cmd) => cmd.isEnabled?.() ?? true);
+}
+
+/**
+ * Get commands visible in help/autocomplete (enabled and not hidden).
+ */
+export function getVisibleCommands(commands: ReadonlyArray<Command>): Command[] {
+  return commands.filter((cmd) => {
+    const isEnabled = cmd.isEnabled?.() ?? true;
+    const isHidden = cmd.isHidden ?? false;
+    return isEnabled && !isHidden;
+  });
+}
+
+//#endregion

--- a/packages/cli/src/commands/suggestions.ts
+++ b/packages/cli/src/commands/suggestions.ts
@@ -1,0 +1,171 @@
+/**
+ * Command suggestion generation for autocomplete.
+ *
+ * Provides fuzzy matching and ranking for slash command suggestions,
+ * inspired by Claude Code's command suggestion system.
+ */
+
+import type { Command } from './types.js';
+
+//#region Types
+
+interface CommandSuggestion {
+  /** Display text (e.g. "/clear") */
+  text: string;
+  /** Description shown after the command */
+  desc?: string;
+  /** The underlying command object */
+  command: Command;
+  /** Match score (lower is better) */
+  score: number;
+}
+
+//#endregion
+
+//#region Matching Helpers
+
+/**
+ * Calculate a simple match score for a command against a query.
+ * Lower score = better match.
+ */
+function getMatchScore(commandName: string, query: string): number {
+  const lowerName = commandName.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+
+  // Exact match
+  if (lowerName === lowerQuery) {
+    return 0;
+  }
+
+  // Prefix match
+  if (lowerName.startsWith(lowerQuery)) {
+    // Shorter names rank higher for prefix matches
+    return 1 + lowerName.length / 100;
+  }
+
+  // Contains match
+  if (lowerName.includes(lowerQuery)) {
+    return 2 + lowerName.indexOf(lowerQuery) / 100;
+  }
+
+  // No match
+  return Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Check if a command matches a query (by name or alias).
+ */
+function commandMatches(cmd: Command, query: string): boolean {
+  if (query === '') {
+    return true;
+  }
+
+  const lowerQuery = query.toLowerCase();
+
+  // Check main name
+  if (cmd.name.toLowerCase().includes(lowerQuery)) {
+    return true;
+  }
+
+  // Check aliases
+  if (cmd.aliases?.some((a) => a.toLowerCase().includes(lowerQuery))) {
+    return true;
+  }
+
+  return false;
+}
+
+//#endregion
+
+//#region Public API
+
+/**
+ * Generate command suggestions based on input.
+ *
+ * @param input - User input (should start with '/')
+ * @param commands - Available commands
+ * @returns Sorted suggestions, best match first
+ */
+export function generateCommandSuggestions(
+  input: string,
+  commands: ReadonlyArray<Command>,
+): CommandSuggestion[] {
+  // Only process command input
+  if (!input.startsWith('/')) {
+    return [];
+  }
+
+  const query = input.slice(1).trim();
+
+  // Filter and score commands
+  const suggestions: CommandSuggestion[] = [];
+
+  for (const cmd of commands) {
+    // Skip hidden or disabled commands
+    if (cmd.isHidden) {
+      continue;
+    }
+    if (cmd.isEnabled && !cmd.isEnabled()) {
+      continue;
+    }
+
+    if (!commandMatches(cmd, query)) {
+      continue;
+    }
+
+    // Calculate score (best match on name or alias)
+    let score = getMatchScore(cmd.name, query);
+
+    // Check aliases for better match
+    if (cmd.aliases) {
+      for (const alias of cmd.aliases) {
+        const aliasScore = getMatchScore(alias, query);
+        if (aliasScore < score) {
+          score = aliasScore;
+        }
+      }
+    }
+
+    suggestions.push({
+      text: `/${cmd.name}`,
+      desc: cmd.description,
+      command: cmd,
+      score,
+    });
+  }
+
+  // Sort by score (lower is better), then alphabetically
+  suggestions.sort((a, b) => {
+    if (a.score !== b.score) {
+      return a.score - b.score;
+    }
+    return a.command.name.localeCompare(b.command.name);
+  });
+
+  return suggestions;
+}
+
+/**
+ * Convert commands to the simple format expected by PromptInput.
+ */
+export function commandsToPromptSuggestions(commands: ReadonlyArray<Command>): Array<{
+  cmd: string;
+  desc?: string;
+}> {
+  return commands
+    .filter((cmd) => {
+      if (cmd.isHidden) {
+        return false;
+      }
+      if (cmd.isEnabled && !cmd.isEnabled()) {
+        return false;
+      }
+      return true;
+    })
+    .map((cmd) => ({
+      cmd: `/${cmd.name}`,
+      desc: cmd.description,
+    }));
+}
+
+//#endregion

--- a/packages/cli/src/commands/types.ts
+++ b/packages/cli/src/commands/types.ts
@@ -1,0 +1,161 @@
+/**
+ * Type definitions for the slash command system.
+ *
+ * Commands are user-invocable actions that execute locally in the CLI,
+ * distinct from skills which are instruction prompts for the model.
+ */
+
+import type { ReactNode } from 'react';
+
+import type { SkillDefinition } from '../skills/types.js';
+import type { ConversationEntry } from '../tui/item-utils.js';
+import type { AgentConfig } from '../types/config.js';
+
+//#region Command Context
+
+/**
+ * Context passed to command handlers during execution.
+ */
+interface CommandContext {
+  /** Current agent configuration */
+  config: AgentConfig;
+  /** Current working directory */
+  cwd: string;
+  /** Current conversation history */
+  entries: ReadonlyArray<ConversationEntry>;
+  /** All discovered skills */
+  skills: ReadonlyArray<SkillDefinition>;
+  /** Names of currently activated skills (from conversation history) */
+  activatedSkills: ReadonlySet<string>;
+  /** All available commands */
+  commands: ReadonlyArray<Command>;
+  /** Clear conversation history */
+  clearEntries: () => void;
+}
+
+//#endregion
+
+//#region Command Results
+
+/**
+ * Result from a local (non-JSX) command.
+ */
+type LocalCommandResult =
+  | {
+      type: 'text';
+      value: string;
+    }
+  | {
+      type: 'skip';
+    };
+
+/**
+ * Callback when a JSX command completes.
+ */
+type LocalJsxCommandOnDone = (result?: string) => void;
+
+/**
+ * Call signature for a local command implementation.
+ */
+type LocalCommandCall = (args: string, ctx: CommandContext) => Promise<LocalCommandResult>;
+
+/**
+ * Module shape returned by load() for lazy-loaded local commands.
+ */
+interface LocalCommandModule {
+  call: LocalCommandCall;
+}
+
+/**
+ * Call signature for a local JSX command implementation.
+ */
+type LocalJsxCommandCall = (
+  onDone: LocalJsxCommandOnDone,
+  ctx: CommandContext,
+  args: string,
+) => Promise<ReactNode>;
+
+/**
+ * Module shape returned by load() for lazy-loaded JSX commands.
+ */
+interface LocalJsxCommandModule {
+  call: LocalJsxCommandCall;
+}
+
+//#endregion
+
+//#region Command Types
+
+/**
+ * A local command that returns text or skips output.
+ */
+type LocalCommand = {
+  type: 'local';
+  load: () => Promise<LocalCommandModule>;
+};
+
+/**
+ * A local command that renders React/Ink UI.
+ */
+type LocalJsxCommand = {
+  type: 'local-jsx';
+  load: () => Promise<LocalJsxCommandModule>;
+};
+
+/**
+ * Base properties shared by all commands.
+ */
+interface CommandBase {
+  /** Unique command name (without leading slash) */
+  name: string;
+  /** Alternative names for this command */
+  aliases?: ReadonlyArray<string>;
+  /** Brief description shown in help */
+  description: string;
+  /** Whether command is currently enabled */
+  isEnabled?: () => boolean;
+  /** Whether to hide from autocomplete/help */
+  isHidden?: boolean;
+}
+
+/**
+ * A slash command definition.
+ */
+type Command = CommandBase & (LocalCommand | LocalJsxCommand);
+
+//#endregion
+
+//#region Execution Result
+
+/**
+ * Result of executing a command.
+ */
+type CommandExecutionResult =
+  | {
+      type: 'text';
+      value: string;
+    }
+  | {
+      type: 'skip';
+    }
+  | {
+      type: 'jsx';
+      node: ReactNode;
+    };
+
+//#endregion
+
+export type {
+  Command,
+  CommandBase,
+  CommandContext,
+  CommandExecutionResult,
+  LocalCommand,
+  LocalCommandCall,
+  LocalCommandModule,
+  LocalCommandResult,
+  LocalJsxCommand,
+  LocalJsxCommandCall,
+  LocalJsxCommandModule,
+  LocalJsxCommandOnDone,
+};

--- a/packages/cli/src/harness/factory.ts
+++ b/packages/cli/src/harness/factory.ts
@@ -4,9 +4,8 @@ import { AgentHarness, step } from '@noetic/core';
 import { buildSystemPrompt } from '../ai/system-prompt.js';
 import { skillsLayer } from '../memory/skills-layer.js';
 import type { NoeticPlugin } from '../plugins/types.js';
-import { discoverSkills } from '../skills/discovery.js';
+import { buildSkillCatalog } from '../skills/catalog.js';
 import type { SkillDefinition } from '../skills/types.js';
-import { SkillSource } from '../skills/types.js';
 import { createActivateSkillTool, createCodingTools } from '../tools/index.js';
 import type { AgentConfig } from '../types/config.js';
 
@@ -36,26 +35,6 @@ async function collectPluginMemory(plugins: ReadonlyArray<NoeticPlugin>): Promis
   return layers;
 }
 
-async function collectPluginSkills(
-  plugins: ReadonlyArray<NoeticPlugin>,
-): Promise<SkillDefinition[]> {
-  const skills: SkillDefinition[] = [];
-  for (const plugin of plugins) {
-    const pluginSkills = await plugin.skills?.();
-    if (!pluginSkills) {
-      continue;
-    }
-    skills.push(
-      ...pluginSkills.map((s) => ({
-        ...s,
-        source: SkillSource.Plugin,
-        filePath: s.filePath ?? null,
-      })),
-    );
-  }
-  return skills;
-}
-
 function filterTools(allTools: Tool[], config: AgentConfig): Tool[] {
   const includes = new Set(config.tools?.include ?? []);
   const excludes = new Set(config.tools?.exclude ?? []);
@@ -75,29 +54,23 @@ function filterTools(allTools: Tool[], config: AgentConfig): Tool[] {
 
 //#region Public API
 
+export interface HarnessWithSkills {
+  harness: AgentHarness<{
+    model: string;
+  }>;
+  skills: ReadonlyArray<SkillDefinition>;
+}
+
+/**
+ * Create the agent harness with all tools, memory layers, and skills.
+ * Returns both the harness and the canonical skill catalog for UI use.
+ */
 export async function createAgentHarness(
   config: AgentConfig,
   plugins: ReadonlyArray<NoeticPlugin>,
-): Promise<
-  AgentHarness<{
-    model: string;
-  }>
-> {
-  // Discover skills from filesystem and plugins
-  const filesystemSkills = await discoverSkills(config.cwd);
-  const pluginSkills = await collectPluginSkills(plugins);
-
-  // Merge skills (filesystem skills have priority, they're already deduplicated)
-  const skillsByName = new Map<string, SkillDefinition>();
-  for (const skill of [
-    ...pluginSkills,
-    ...filesystemSkills,
-  ]) {
-    skillsByName.set(skill.name, skill);
-  }
-  const allSkills = [
-    ...skillsByName.values(),
-  ];
+): Promise<HarnessWithSkills> {
+  // Build canonical skill catalog (single source of truth)
+  const allSkills = await buildSkillCatalog(config.cwd, plugins);
 
   // Build tools including skill activation
   const builtinTools = createCodingTools(config.cwd);
@@ -130,7 +103,7 @@ export async function createAgentHarness(
       : []),
   ];
 
-  return new AgentHarness({
+  const harness = new AgentHarness({
     name: 'noetic-cli',
     params: {
       model: config.model,
@@ -147,6 +120,11 @@ export async function createAgentHarness(
       apiKey: config.apiKey,
     },
   });
+
+  return {
+    harness,
+    skills: allSkills,
+  };
 }
 
 //#endregion

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@
 
 export { buildSystemPrompt } from './ai/system-prompt.js';
 export { discoverConfig, resolvePluginBaseDir } from './config/discovery.js';
-export { createAgentHarness } from './harness/factory.js';
+export { createAgentHarness, type HarnessWithSkills } from './harness/factory.js';
 export { disposePlugins, loadPlugins } from './plugins/loader.js';
 export type { NoeticPlugin } from './plugins/types.js';
 export { createCodingTools, createReadOnlyTools } from './tools/index.js';

--- a/packages/cli/src/skills/catalog.ts
+++ b/packages/cli/src/skills/catalog.ts
@@ -1,0 +1,67 @@
+/**
+ * Shared skill catalog builder.
+ *
+ * Provides a single source of truth for discovered skills,
+ * used by both the harness and the UI.
+ */
+
+import type { NoeticPlugin } from '../plugins/types.js';
+
+import { discoverSkills } from './discovery.js';
+import type { SkillDefinition } from './types.js';
+import { SkillSource } from './types.js';
+
+//#region Plugin Skills
+
+async function collectPluginSkills(
+  plugins: ReadonlyArray<NoeticPlugin>,
+): Promise<SkillDefinition[]> {
+  const skills: SkillDefinition[] = [];
+  for (const plugin of plugins) {
+    const pluginSkills = await plugin.skills?.();
+    if (!pluginSkills) {
+      continue;
+    }
+    skills.push(
+      ...pluginSkills.map((s) => ({
+        ...s,
+        source: SkillSource.Plugin,
+        filePath: s.filePath ?? null,
+      })),
+    );
+  }
+  return skills;
+}
+
+//#endregion
+
+//#region Public API
+
+/**
+ * Build the canonical skill catalog from filesystem and plugins.
+ *
+ * This is the single source of truth for skill discovery.
+ * Filesystem skills have priority over plugin skills with the same name.
+ */
+export async function buildSkillCatalog(
+  cwd: string,
+  plugins: ReadonlyArray<NoeticPlugin>,
+): Promise<SkillDefinition[]> {
+  const filesystemSkills = await discoverSkills(cwd);
+  const pluginSkills = await collectPluginSkills(plugins);
+
+  // Merge skills (filesystem skills have priority, they're already deduplicated)
+  const skillsByName = new Map<string, SkillDefinition>();
+  for (const skill of [
+    ...pluginSkills,
+    ...filesystemSkills,
+  ]) {
+    skillsByName.set(skill.name, skill);
+  }
+
+  return [
+    ...skillsByName.values(),
+  ];
+}
+
+//#endregion

--- a/packages/cli/src/skills/index.ts
+++ b/packages/cli/src/skills/index.ts
@@ -2,6 +2,7 @@
  * Skills system exports.
  */
 
+export { buildSkillCatalog } from './catalog.js';
 export { discoverSkills, loadSkillFromFile } from './discovery.js';
 export { processSkillContent } from './processor.js';
 export type {

--- a/packages/cli/src/tui/app.tsx
+++ b/packages/cli/src/tui/app.tsx
@@ -5,15 +5,30 @@
 import type { AgentHarness, InputMessageItem, Item } from '@noetic/core';
 import { render } from 'ink';
 import type { ReactNode } from 'react';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
+import {
+  BUILTIN_COMMANDS,
+  commandsToPromptSuggestions,
+  executeCommand,
+  findCommand,
+  isSlashCommand,
+  parseSlashCommand,
+} from '../commands/index.js';
+import type { Command, CommandContext } from '../commands/types.js';
 import { createAgentHarness } from '../harness/factory.js';
 import type { NoeticPlugin } from '../plugins/types.js';
+import type { SkillDefinition } from '../skills/types.js';
 import type { AgentConfig } from '../types/config.js';
 import type { ChatStatus } from './components/index.js';
 import { InkProvider, ResponsesChat } from './components/index.js';
-import type { ConversationEntry, ErrorEntry, UserEntry } from './item-utils.js';
-import { appendOrUpdateEntry, isErrorEntry, isUserEntry } from './item-utils.js';
+import type { ConversationEntry, ErrorEntry, SystemEntry, UserEntry } from './item-utils.js';
+import {
+  appendOrUpdateEntry,
+  extractActivatedSkills,
+  isErrorEntry,
+  isUserEntry,
+} from './item-utils.js';
 
 //#region Helpers
 
@@ -69,26 +84,6 @@ function entriesToItems(entries: ConversationEntry[]): Item[] {
   return items;
 }
 
-/**
- * Get or create the harness, retrying on failure.
- * Stores the harness directly to avoid race conditions where a rejected
- * promise would cause all subsequent awaits to fail.
- */
-async function getOrCreateHarness(
-  harnessRef: {
-    current: AgentHarness | null;
-  },
-  config: AgentConfig,
-  plugins: ReadonlyArray<NoeticPlugin>,
-): Promise<AgentHarness> {
-  if (harnessRef.current !== null) {
-    return harnessRef.current;
-  }
-  const harness = await createAgentHarness(config, plugins);
-  harnessRef.current = harness;
-  return harness;
-}
-
 //#endregion
 
 //#region Types
@@ -105,6 +100,8 @@ interface AppProps {
 function App({ config, plugins }: AppProps): ReactNode {
   const [entries, setEntries] = useState<ConversationEntry[]>([]);
   const [status, setStatus] = useState<ChatStatus>('ready');
+  const [skills, setSkills] = useState<ReadonlyArray<SkillDefinition>>([]);
+  const [commandOutput, setCommandOutput] = useState<ReactNode | null>(null);
 
   const harnessRef = useRef<AgentHarness | null>(null);
 
@@ -113,8 +110,104 @@ function App({ config, plugins }: AppProps): ReactNode {
   const entriesRef = useRef(entries);
   entriesRef.current = entries;
 
+  // Built-in commands only - skills are not slash commands
+  const commands = useMemo<Command[]>(
+    () => [
+      ...BUILTIN_COMMANDS,
+    ],
+    [],
+  );
+
+  // Convert commands to PromptInput format
+  const commandSuggestions = useMemo(
+    () => commandsToPromptSuggestions(commands),
+    [
+      commands,
+    ],
+  );
+
+  // Clear entries callback for /clear command
+  const clearEntries = useCallback(() => {
+    setEntries([]);
+  }, []);
+
+  /**
+   * Get or create the harness, storing the canonical skill catalog.
+   */
+  const getOrCreateHarness = useCallback(async (): Promise<AgentHarness> => {
+    if (harnessRef.current !== null) {
+      return harnessRef.current;
+    }
+    const { harness, skills: resolvedSkills } = await createAgentHarness(config, plugins);
+    harnessRef.current = harness;
+    setSkills(resolvedSkills);
+    return harness;
+  }, [
+    config,
+    plugins,
+  ]);
+
   const handleSubmit = useCallback(
     async (text: string): Promise<void> => {
+      // Check if this is a slash command
+      if (isSlashCommand(text)) {
+        const parsed = parseSlashCommand(text);
+        if (parsed) {
+          const cmd = findCommand(parsed.commandName, commands);
+          if (cmd) {
+            // Build command context with activated skills from conversation
+            const activatedSkills = extractActivatedSkills(entriesRef.current);
+            const ctx: CommandContext = {
+              config,
+              cwd: config.cwd,
+              entries: entriesRef.current,
+              skills,
+              activatedSkills,
+              commands,
+              clearEntries,
+            };
+
+            try {
+              const result = await executeCommand(cmd, parsed.args, ctx);
+              if (result.type === 'text') {
+                // Show text result as info message (not error)
+                setEntries((prev) => [
+                  ...prev,
+                  {
+                    role: 'system',
+                    type: 'info',
+                    content: result.value,
+                  } satisfies SystemEntry,
+                ]);
+              } else if (result.type === 'jsx') {
+                // Render JSX output
+                setCommandOutput(result.node);
+                // Clear after a short delay
+                setTimeout(() => setCommandOutput(null), 100);
+              }
+              // 'skip' type means no output
+            } catch (error) {
+              setEntries((prev) => [
+                ...prev,
+                buildErrorEntry(error),
+              ]);
+            }
+            return;
+          }
+        }
+        // Unknown command - show error
+        setEntries((prev) => [
+          ...prev,
+          {
+            role: 'system',
+            type: 'error',
+            content: `Unknown command: ${text}`,
+          } satisfies ErrorEntry,
+        ]);
+        return;
+      }
+
+      // Regular message - send to model
       const userEntry: UserEntry = {
         role: 'user',
         content: text,
@@ -126,7 +219,7 @@ function App({ config, plugins }: AppProps): ReactNode {
       setStatus('submitted');
 
       try {
-        const harness = await getOrCreateHarness(harnessRef, config, plugins);
+        const harness = await getOrCreateHarness();
         // Build conversation history including the new user message
         const historyItems = entriesToItems([
           ...entriesRef.current,
@@ -148,17 +241,22 @@ function App({ config, plugins }: AppProps): ReactNode {
     },
     [
       config,
-      plugins,
+      commands,
+      skills,
+      clearEntries,
+      getOrCreateHarness,
     ],
   );
 
   return (
     <InkProvider>
+      {commandOutput}
       <ResponsesChat
         entries={entries}
         status={status}
         onSubmit={handleSubmit}
         model={config.model}
+        commands={commandSuggestions}
       />
     </InkProvider>
   );

--- a/packages/cli/src/tui/components/responses-chat.tsx
+++ b/packages/cli/src/tui/components/responses-chat.tsx
@@ -15,6 +15,7 @@ import {
   extractTextContent,
   getItemId,
   isErrorEntry,
+  isSystemEntry,
   isUserEntry,
 } from '../item-utils.js';
 import type { ToolCallState } from './message.js';
@@ -30,6 +31,11 @@ export interface ResponsesChatProps {
   onSubmit: (text: string) => void;
   onStop?: () => void;
   model?: string;
+  /** Slash commands for autocomplete */
+  commands?: Array<{
+    cmd: string;
+    desc?: string;
+  }>;
 }
 
 interface RenderContext {
@@ -167,6 +173,16 @@ function renderEntry(entry: ConversationEntry, index: number, ctx: RenderContext
     );
   }
 
+  if (isSystemEntry(entry)) {
+    return (
+      <Message key={`system-${index}`} {...ASSISTANT_ROLE}>
+        <Message.Content>
+          <Message.Text>{entry.content}</Message.Text>
+        </Message.Content>
+      </Message>
+    );
+  }
+
   const key = getItemId(entry);
   const isLastEntry = index === ctx.entryCount - 1;
   const isStreaming = isLastEntry && ctx.chatStatus === 'streaming' && entry.status !== 'completed';
@@ -233,6 +249,7 @@ export function ResponsesChat({
   onSubmit,
   onStop,
   model,
+  commands,
 }: ResponsesChatProps): ReactNode {
   const callNameMap = useMemo(
     () => buildCallNameMap(entries),
@@ -292,7 +309,13 @@ export function ResponsesChat({
         </Static>
         {streamingEntry && <Box>{renderEntry(streamingEntry, entries.length - 1, ctx)}</Box>}
       </Box>
-      <PromptInput status={status} onSubmit={handleSubmit} onStop={onStop} model={model} />
+      <PromptInput
+        status={status}
+        onSubmit={handleSubmit}
+        onStop={onStop}
+        model={model}
+        commands={commands}
+      />
     </Box>
   );
 }

--- a/packages/cli/src/tui/item-utils.ts
+++ b/packages/cli/src/tui/item-utils.ts
@@ -17,8 +17,14 @@ export interface ErrorEntry {
   content: string;
 }
 
+export interface SystemEntry {
+  role: 'system';
+  type: 'info';
+  content: string;
+}
+
 export type AssistantEntry = Item | StreamingItem;
-export type ConversationEntry = AssistantEntry | UserEntry | ErrorEntry;
+export type ConversationEntry = AssistantEntry | UserEntry | ErrorEntry | SystemEntry;
 type MessageContentPart = Extract<
   AssistantEntry,
   {
@@ -36,6 +42,10 @@ export function isUserEntry(entry: ConversationEntry): entry is UserEntry {
 
 export function isErrorEntry(entry: ConversationEntry): entry is ErrorEntry {
   return 'role' in entry && entry.role === 'system' && 'type' in entry && entry.type === 'error';
+}
+
+export function isSystemEntry(entry: ConversationEntry): entry is SystemEntry {
+  return 'role' in entry && entry.role === 'system' && 'type' in entry && entry.type === 'info';
 }
 
 //#endregion
@@ -111,7 +121,7 @@ export function appendOrUpdateEntry(
 ): ConversationEntry[] {
   const id = getItemId(item);
   const idx = prev.findIndex((existing) => {
-    if (isUserEntry(existing) || isErrorEntry(existing)) {
+    if (isUserEntry(existing) || isErrorEntry(existing) || isSystemEntry(existing)) {
       return false;
     }
     return getItemId(existing) === id;
@@ -127,6 +137,58 @@ export function appendOrUpdateEntry(
     ...prev,
     item,
   ];
+}
+
+//#endregion
+
+//#region Skill Activation Tracking
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasStringName(obj: Record<string, unknown>): obj is Record<string, unknown> & {
+  name: string;
+} {
+  return typeof obj.name === 'string';
+}
+
+/**
+ * Extract activated skill names from conversation entries.
+ * Looks for completed function_call items with name 'activateSkill'.
+ */
+export function extractActivatedSkills(entries: ReadonlyArray<ConversationEntry>): Set<string> {
+  const activated = new Set<string>();
+
+  for (const entry of entries) {
+    // Skip user/system entries
+    if (isUserEntry(entry) || isErrorEntry(entry) || isSystemEntry(entry)) {
+      continue;
+    }
+
+    // Look for activateSkill function calls
+    if (entry.type !== 'function_call') {
+      continue;
+    }
+    if (entry.name !== 'activateSkill') {
+      continue;
+    }
+    if (entry.status !== 'completed') {
+      continue;
+    }
+
+    // Parse the arguments to get skill name
+    try {
+      const parsed = JSON.parse(entry.arguments);
+      if (isRecord(parsed) && hasStringName(parsed)) {
+        activated.add(parsed.name);
+      }
+    } catch {
+      // Invalid JSON, skip
+    }
+  }
+
+  return activated;
 }
 
 //#endregion

--- a/packages/cli/test/commands.test.ts
+++ b/packages/cli/test/commands.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the slash command system.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import {
+  BUILTIN_COMMANDS,
+  commandsToPromptSuggestions,
+  findCommand,
+  generateCommandSuggestions,
+  getEnabledCommands,
+  getVisibleCommands,
+  hasCommand,
+  isSlashCommand,
+  parseSlashCommand,
+} from '../src/commands/index.js';
+
+describe('parseSlashCommand', () => {
+  test('returns null for non-slash input', () => {
+    expect(parseSlashCommand('hello world')).toBeNull();
+    expect(parseSlashCommand('')).toBeNull();
+    expect(parseSlashCommand('  ')).toBeNull();
+  });
+
+  test('parses command without arguments', () => {
+    const result = parseSlashCommand('/clear');
+    expect(result).toEqual({
+      commandName: 'clear',
+      args: '',
+    });
+  });
+
+  test('parses command with arguments', () => {
+    const result = parseSlashCommand('/skills search');
+    expect(result).toEqual({
+      commandName: 'skills',
+      args: 'search',
+    });
+  });
+
+  test('trims whitespace', () => {
+    const result = parseSlashCommand('  /clear  ');
+    expect(result).toEqual({
+      commandName: 'clear',
+      args: '',
+    });
+  });
+
+  test('handles multiple arguments', () => {
+    const result = parseSlashCommand('/test arg1 arg2 arg3');
+    expect(result).toEqual({
+      commandName: 'test',
+      args: 'arg1 arg2 arg3',
+    });
+  });
+});
+
+describe('isSlashCommand', () => {
+  test('returns true for slash commands', () => {
+    expect(isSlashCommand('/clear')).toBe(true);
+    expect(isSlashCommand('  /skills')).toBe(true);
+  });
+
+  test('returns false for non-slash input', () => {
+    expect(isSlashCommand('hello')).toBe(false);
+    expect(isSlashCommand('')).toBe(false);
+    expect(isSlashCommand('clear')).toBe(false);
+  });
+});
+
+describe('findCommand', () => {
+  test('finds command by name', () => {
+    const cmd = findCommand('clear', BUILTIN_COMMANDS);
+    expect(cmd).toBeDefined();
+    expect(cmd?.name).toBe('clear');
+  });
+
+  test('finds command case-insensitively', () => {
+    const cmd = findCommand('CLEAR', BUILTIN_COMMANDS);
+    expect(cmd).toBeDefined();
+    expect(cmd?.name).toBe('clear');
+  });
+
+  test('returns undefined for unknown command', () => {
+    const cmd = findCommand('unknown', BUILTIN_COMMANDS);
+    expect(cmd).toBeUndefined();
+  });
+});
+
+describe('hasCommand', () => {
+  test('returns true for existing command', () => {
+    expect(hasCommand('clear', BUILTIN_COMMANDS)).toBe(true);
+    expect(hasCommand('context', BUILTIN_COMMANDS)).toBe(true);
+    expect(hasCommand('skills', BUILTIN_COMMANDS)).toBe(true);
+  });
+
+  test('returns false for non-existing command', () => {
+    expect(hasCommand('unknown', BUILTIN_COMMANDS)).toBe(false);
+  });
+});
+
+describe('BUILTIN_COMMANDS', () => {
+  test('contains expected commands', () => {
+    const names = BUILTIN_COMMANDS.map((c) => c.name);
+    expect(names).toContain('clear');
+    expect(names).toContain('context');
+    expect(names).toContain('skills');
+  });
+
+  test('all commands have descriptions', () => {
+    for (const cmd of BUILTIN_COMMANDS) {
+      expect(cmd.description).toBeTruthy();
+    }
+  });
+});
+
+describe('getEnabledCommands', () => {
+  test('returns all commands when all enabled', () => {
+    const enabled = getEnabledCommands(BUILTIN_COMMANDS);
+    expect(enabled.length).toBe(BUILTIN_COMMANDS.length);
+  });
+});
+
+describe('getVisibleCommands', () => {
+  test('returns non-hidden enabled commands', () => {
+    const visible = getVisibleCommands(BUILTIN_COMMANDS);
+    expect(visible.length).toBe(BUILTIN_COMMANDS.length);
+  });
+});
+
+describe('commandsToPromptSuggestions', () => {
+  test('converts commands to prompt format', () => {
+    const suggestions = commandsToPromptSuggestions(BUILTIN_COMMANDS);
+    expect(suggestions.length).toBe(BUILTIN_COMMANDS.length);
+
+    for (const sug of suggestions) {
+      expect(sug.cmd).toMatch(/^\//);
+      expect(sug.desc).toBeTruthy();
+    }
+  });
+});
+
+describe('generateCommandSuggestions', () => {
+  test('returns empty for non-slash input', () => {
+    const suggestions = generateCommandSuggestions('hello', BUILTIN_COMMANDS);
+    expect(suggestions).toEqual([]);
+  });
+
+  test('returns all commands for just slash', () => {
+    const suggestions = generateCommandSuggestions('/', BUILTIN_COMMANDS);
+    expect(suggestions.length).toBe(BUILTIN_COMMANDS.length);
+  });
+
+  test('filters by prefix', () => {
+    const suggestions = generateCommandSuggestions('/cl', BUILTIN_COMMANDS);
+    expect(suggestions.length).toBeGreaterThan(0);
+    expect(suggestions[0]?.command.name).toBe('clear');
+  });
+
+  test('ranks exact matches first', () => {
+    const suggestions = generateCommandSuggestions('/clear', BUILTIN_COMMANDS);
+    expect(suggestions[0]?.command.name).toBe('clear');
+  });
+});

--- a/packages/cli/test/harness-factory.test.ts
+++ b/packages/cli/test/harness-factory.test.ts
@@ -34,7 +34,7 @@ describe('createAgentHarness', () => {
       ],
     };
 
-    const harness = await createAgentHarness(baseConfig, [
+    const { harness } = await createAgentHarness(baseConfig, [
       plugin,
     ]);
 
@@ -50,7 +50,7 @@ describe('createAgentHarness', () => {
       ],
     };
 
-    const harness = await createAgentHarness(
+    const { harness } = await createAgentHarness(
       {
         ...baseConfig,
         tools: {
@@ -76,7 +76,7 @@ describe('createAgentHarness', () => {
       ],
     };
 
-    const harness = await createAgentHarness(
+    const { harness } = await createAgentHarness(
       {
         ...baseConfig,
         tools: {
@@ -91,5 +91,12 @@ describe('createAgentHarness', () => {
     );
 
     expect(harness).toBeDefined();
+  });
+
+  it('returns canonical skill catalog', async () => {
+    const { skills } = await createAgentHarness(baseConfig, []);
+
+    expect(skills).toBeDefined();
+    expect(Array.isArray(skills)).toBe(true);
   });
 });

--- a/packages/cli/test/skills.test.ts
+++ b/packages/cli/test/skills.test.ts
@@ -1,8 +1,7 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import { discoverSkills } from '../src/skills/discovery.js';
 import { processSkillContent } from '../src/skills/processor.js';
@@ -273,7 +272,7 @@ More content.
   });
 
   test('handles command errors gracefully', async () => {
-    const content = `!exit 1`;
+    const content = '!exit 1';
 
     const result = await processSkillContent(content, tempDir);
 
@@ -297,7 +296,7 @@ More content.
     await fs.mkdir(nestedDir);
     await fs.writeFile(path.join(nestedDir, 'marker.txt'), 'found-it');
 
-    const content = `!cat marker.txt`;
+    const content = '!cat marker.txt';
 
     const result = await processSkillContent(content, nestedDir);
 


### PR DESCRIPTION
## Summary

- Add polymorphic slash command architecture with local and local-jsx command types
- Implement built-in commands: `/clear`, `/skills`, `/context`
- Unified skill catalog via `buildSkillCatalog()` as single source of truth
- Track activated skills from conversation history with visual indicators
- Add `SystemEntry` type for informational system messages (distinct from errors)
- Wire autocomplete suggestions into prompt input

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes  
- [x] `bun test` passes (excluding pre-existing harness-factory dep issue)
- [ ] Manual: Run CLI, type `/clear` - clears conversation
- [ ] Manual: Run CLI, type `/skills` - shows skills grouped by source with active state
- [ ] Manual: Run CLI, type `/context` - shows model and token usage