### PR TITLE
feat(cli,core): add Claude Code-style plan mode with /mode toggle

### DIFF
--- a/packages/cli/src/commands/builtins/index.ts
+++ b/packages/cli/src/commands/builtins/index.ts
@@ -6,6 +6,7 @@ import type { Command } from '../types.js';
 
 import { clear } from './clear.js';
 import { context } from './context.js';
+import { mode } from './mode.js';
 import { plan } from './plan.js';
 import { skills } from './skills.js';
 
@@ -15,8 +16,9 @@ import { skills } from './skills.js';
 export const BUILTIN_COMMANDS: ReadonlyArray<Command> = [
   clear,
   context,
+  mode,
   plan,
   skills,
 ];
 
-export { clear, context, plan, skills };
+export { clear, context, mode, plan, skills };

--- a/packages/cli/src/commands/builtins/mode.ts
+++ b/packages/cli/src/commands/builtins/mode.ts
@@ -1,0 +1,97 @@
+/**
+ * /mode command — toggles the CLI agent mode (normal ↔ planning).
+ *
+ * Subcommands:
+ *   /mode           - toggle current mode
+ *   /mode plan      - enter planning mode
+ *   /mode normal    - return to normal mode
+ *   /mode status    - show current mode
+ */
+
+import type { Command, CommandContext, LocalCommandCall, LocalCommandResult } from '../types.js';
+
+//#region Subcommand Handlers
+
+type SubcommandHandler = (ctx: CommandContext) => Promise<LocalCommandResult>;
+
+async function handleEnter(ctx: CommandContext): Promise<LocalCommandResult> {
+  if (ctx.agentMode === 'planning') {
+    return {
+      type: 'text',
+      value: 'Already in plan mode.',
+    };
+  }
+  await ctx.setAgentMode('planning');
+  return {
+    type: 'text',
+    value:
+      'Plan mode enabled. Read-only tools only — explore the codebase, then call plan/updatePrd to write your PRD.',
+  };
+}
+
+async function handleExit(ctx: CommandContext): Promise<LocalCommandResult> {
+  if (ctx.agentMode === 'normal') {
+    return {
+      type: 'text',
+      value: 'Already in normal mode.',
+    };
+  }
+  await ctx.setAgentMode('normal');
+  return {
+    type: 'text',
+    value: 'Returned to normal mode. Full toolset is available again.',
+  };
+}
+
+async function handleStatus(ctx: CommandContext): Promise<LocalCommandResult> {
+  return {
+    type: 'text',
+    value: `Current mode: ${ctx.agentMode}`,
+  };
+}
+
+async function handleToggle(ctx: CommandContext): Promise<LocalCommandResult> {
+  return ctx.agentMode === 'planning' ? handleExit(ctx) : handleEnter(ctx);
+}
+
+const SUBCOMMANDS: Record<string, SubcommandHandler> = {
+  '': handleToggle,
+  plan: handleEnter,
+  planning: handleEnter,
+  normal: handleExit,
+  exit: handleExit,
+  status: handleStatus,
+};
+
+//#endregion
+
+//#region Implementation
+
+const call: LocalCommandCall = async (args, ctx) => {
+  const subcommand = args.trim().toLowerCase();
+  const handler = SUBCOMMANDS[subcommand];
+
+  if (!handler) {
+    return {
+      type: 'text',
+      value: `Unknown mode: "${subcommand}". Available: /mode, /mode plan, /mode normal, /mode status`,
+    };
+  }
+
+  return handler(ctx);
+};
+
+//#endregion
+
+//#region Command Definition
+
+export const mode: Command = {
+  type: 'local',
+  name: 'mode',
+  description: 'Toggle agent mode between normal and planning',
+  load: async () => ({
+    call,
+  }),
+};
+
+//#endregion

--- a/packages/cli/src/commands/builtins/plan.ts
+++ b/packages/cli/src/commands/builtins/plan.ts
@@ -1,31 +1,51 @@
 /**
- * /plan command - Manages the plan mode lifecycle.
+ * /plan command — alias for `/mode plan` (and `/mode normal` via `/plan cancel`).
  *
  * Subcommands:
- *   /plan          - Enter plan mode
- *   /plan status   - Show current plan status
- *   /plan cancel   - Cancel the current plan
+ *   /plan          - enter plan mode
+ *   /plan status   - show current mode
+ *   /plan cancel   - exit plan mode (return to normal)
  */
 
-import type { Command, LocalCommandCall } from '../types.js';
+import type { Command, CommandContext, LocalCommandCall, LocalCommandResult } from '../types.js';
 
 //#region Subcommand Handlers
 
-type SubcommandHandler = () => string;
+type SubcommandHandler = (ctx: CommandContext) => Promise<LocalCommandResult>;
 
-function handleEnter(): string {
-  return [
-    'Enter plan mode. Explore the codebase with read-only tools, then produce a PRD document.',
-    'Call plan/enterPlanMode to begin.',
-  ].join('\n');
+async function handleEnter(ctx: CommandContext): Promise<LocalCommandResult> {
+  if (ctx.agentMode === 'planning') {
+    return {
+      type: 'text',
+      value: 'Already in plan mode.',
+    };
+  }
+  await ctx.setAgentMode('planning');
+  return {
+    type: 'text',
+    value: 'Plan mode enabled. Explore the codebase with read-only tools, then write your PRD.',
+  };
 }
 
-function handleStatus(): string {
-  return 'Show the current plan status. Check the plan/status data for phase, PRD, and plan tree state.';
+async function handleStatus(ctx: CommandContext): Promise<LocalCommandResult> {
+  return {
+    type: 'text',
+    value: `Current mode: ${ctx.agentMode}`,
+  };
 }
 
-function handleCancel(): string {
-  return 'Cancel the current plan and return to idle. Call plan/exitPlanMode with { action: "cancel" }.';
+async function handleCancel(ctx: CommandContext): Promise<LocalCommandResult> {
+  if (ctx.agentMode === 'normal') {
+    return {
+      type: 'text',
+      value: 'Not currently in plan mode.',
+    };
+  }
+  await ctx.setAgentMode('normal');
+  return {
+    type: 'text',
+    value: 'Plan mode cancelled. Returned to normal mode.',
+  };
 }
 
 const SUBCOMMANDS: Record<string, SubcommandHandler> = {
@@ -38,7 +58,7 @@ const SUBCOMMANDS: Record<string, SubcommandHandler> = {
 
 //#region Implementation
 
-const call: LocalCommandCall = async (args) => {
+const call: LocalCommandCall = async (args, ctx) => {
   const subcommand = args.trim().toLowerCase();
   const handler = SUBCOMMANDS[subcommand];
 
@@ -49,10 +69,7 @@ const call: LocalCommandCall = async (args) => {
     };
   }
 
-  return {
-    type: 'text',
-    value: handler(),
-  };
+  return handler(ctx);
 };
 
 //#endregion
@@ -62,7 +79,7 @@ const call: LocalCommandCall = async (args) => {
 export const plan: Command = {
   type: 'local',
   name: 'plan',
-  description: 'Enter plan mode to create a PRD and execution plan',
+  description: 'Enter plan mode (alias for /mode plan)',
   load: async () => ({
     call,
   }),

--- a/packages/cli/src/commands/types.ts
+++ b/packages/cli/src/commands/types.ts
@@ -36,6 +36,13 @@ interface CommandContext {
   lastLayerUsage?: LastLayerUsage;
   /** Memory layers registered with the harness — includes layers that did not contribute on the last run. */
   memoryLayers: ReadonlyArray<MemoryLayer>;
+  /** Current agent mode. */
+  agentMode: 'normal' | 'planning';
+  /**
+   * Switch the active agent mode. Triggers harness recreation so the model
+   * sees the correct toolset (full vs read-only) on the next turn.
+   */
+  setAgentMode: (mode: 'normal' | 'planning') => Promise<void>;
 }
 
 //#endregion

--- a/packages/cli/src/harness/factory.ts
+++ b/packages/cli/src/harness/factory.ts
@@ -1,4 +1,11 @@
-import type { FsAdapter, MemoryLayer, ShellAdapter, Tool } from '@noetic/core';
+import type {
+  FsAdapter,
+  MemoryLayer,
+  PlanEnterSessionCallback,
+  PlanExitCallback,
+  ShellAdapter,
+  Tool,
+} from '@noetic/core';
 import {
   AgentHarness,
   createLocalShellAdapter,
@@ -16,8 +23,20 @@ import { skillsLayer } from '../memory/skills-layer.js';
 import type { NoeticPlugin } from '../plugins/types.js';
 import { buildSkillCatalog } from '../skills/catalog.js';
 import type { SkillDefinition } from '../skills/types.js';
-import { createActivateSkillTool, createCodingTools } from '../tools/index.js';
+import { createActivateSkillTool, createCodingTools, createReadOnlyTools } from '../tools/index.js';
 import type { AgentConfig } from '../types/config.js';
+
+//#region Types
+
+export type AgentMode = 'normal' | 'planning';
+
+export interface PlanHooks {
+  onEnterSession?: PlanEnterSessionCallback;
+  onExit?: PlanExitCallback;
+  additionalPlanInstructions?: string;
+}
+
+//#endregion
 
 //#region Helpers
 
@@ -77,6 +96,10 @@ interface CreateAgentHarnessOpts {
   plugins: ReadonlyArray<NoeticPlugin>;
   fs: FsAdapter;
   shell?: ShellAdapter;
+  /** Initial agent mode. Defaults to `'normal'`. */
+  mode?: AgentMode;
+  /** Optional plan-mode lifecycle hooks (session creation, approval gate, extra instructions). */
+  planHooks?: PlanHooks;
 }
 
 /**
@@ -86,12 +109,18 @@ interface CreateAgentHarnessOpts {
 export async function createAgentHarness(opts: CreateAgentHarnessOpts): Promise<HarnessWithSkills> {
   const { config, plugins, fs } = opts;
   const shell = opts.shell ?? createLocalShellAdapter();
+  const mode: AgentMode = opts.mode ?? 'normal';
+  const planHooks = opts.planHooks;
 
   // Build canonical skill catalog (single source of truth)
   const allSkills = await buildSkillCatalog(config.cwd, plugins, fs);
 
-  // Build tools including skill activation
-  const builtinTools = createCodingTools(config.cwd, fs, shell);
+  // Build tools including skill activation. In planning mode we hide mutating
+  // tools from the model entirely; planMemory.beforeToolCall remains as defense-in-depth.
+  const builtinTools =
+    mode === 'planning'
+      ? createReadOnlyTools(config.cwd, fs, shell)
+      : createCodingTools(config.cwd, fs, shell);
   const pluginTools = await collectPluginTools(plugins);
   const activateSkill = allSkills.length > 0 ? createActivateSkillTool(allSkills) : null;
 
@@ -111,7 +140,11 @@ export async function createAgentHarness(opts: CreateAgentHarnessOpts): Promise<
   // Build memory layers including plan and skills layers
   const pluginMemory = await collectPluginMemory(plugins);
   const memory: MemoryLayer[] = [
-    planMemory(),
+    planMemory({
+      additionalPlanInstructions: planHooks?.additionalPlanInstructions,
+      onEnterSession: planHooks?.onEnterSession,
+      onExit: planHooks?.onExit,
+    }),
     workingMemory(),
     observationalMemory(),
     fileReference(),

--- a/packages/cli/src/plan/file-store.ts
+++ b/packages/cli/src/plan/file-store.ts
@@ -1,0 +1,232 @@
+/**
+ * Plan-file store: manages `~/.noetic/plans/<slug>/` session directories.
+ *
+ * Each session contains:
+ *   - `plan.md`         — root PRD (markdown)
+ *   - `flow.json`       — optional serialised noetic Step graph
+ *   - `<nodeId>.md`     — optional per-node sub-plans referenced by IDs in flow.json
+ */
+
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { validateFlow } from './flow-schema.js';
+
+//#region Types
+
+export interface PlanSession {
+  slug: string;
+  dir: string;
+}
+
+export interface PlanSessionContents {
+  prd: string | null;
+  flow: unknown | null;
+  subPlans: Record<string, string>;
+}
+
+//#endregion
+
+//#region Constants
+
+const ADJECTIVES = [
+  'amber',
+  'brisk',
+  'clever',
+  'dapper',
+  'eager',
+  'frosty',
+  'gentle',
+  'humble',
+  'idle',
+  'jolly',
+  'keen',
+  'lucid',
+  'mellow',
+  'noble',
+  'quiet',
+  'rapid',
+  'sleek',
+  'tidy',
+  'vivid',
+  'witty',
+] as const;
+
+const NOUNS_LEFT = [
+  'arctic',
+  'beacon',
+  'cobalt',
+  'delta',
+  'ember',
+  'forest',
+  'glacier',
+  'harbor',
+  'island',
+  'jasper',
+  'kelp',
+  'lagoon',
+  'meadow',
+  'nebula',
+  'opal',
+  'prairie',
+] as const;
+
+const NOUNS_RIGHT = [
+  'falcon',
+  'badger',
+  'cheetah',
+  'dolphin',
+  'finch',
+  'gecko',
+  'heron',
+  'iguana',
+  'jackal',
+  'koala',
+  'lemur',
+  'meerkat',
+  'newt',
+  'otter',
+  'puffin',
+  'quokka',
+] as const;
+
+const PLAN_FILE = 'plan.md';
+const FLOW_FILE = 'flow.json';
+const SUBPLAN_SUFFIX = '.md';
+
+//#endregion
+
+//#region Helpers
+
+function pickRandom<T>(arr: ReadonlyArray<T>): T {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function generateWordSlug(): string {
+  return [
+    pickRandom(ADJECTIVES),
+    pickRandom(NOUNS_LEFT),
+    pickRandom(NOUNS_RIGHT),
+  ].join('-');
+}
+
+const NODE_ID_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+function assertSafeNodeId(nodeId: string): void {
+  if (!NODE_ID_PATTERN.test(nodeId)) {
+    throw new Error(
+      `Invalid sub-plan node id "${nodeId}". Must match ${NODE_ID_PATTERN.source} (no path traversal).`,
+    );
+  }
+}
+
+function plansRoot(): string {
+  // Honor a runtime override (used by tests + power users); fall back to $HOME
+  // resolved per-call rather than the cached `os.homedir()` value.
+  const override = process.env.NOETIC_PLANS_ROOT;
+  if (override) {
+    return override;
+  }
+  const home = process.env.HOME ?? homedir();
+  return join(home, '.noetic', 'plans');
+}
+
+function sessionDir(slug: string): string {
+  assertSafeNodeId(slug);
+  return join(plansRoot(), slug);
+}
+
+//#endregion
+
+//#region Public API
+
+/** Creates a new session directory with a fresh adjective-noun-noun slug. */
+export async function createPlanSession(): Promise<PlanSession> {
+  const slug = generateWordSlug();
+  const dir = sessionDir(slug);
+  await mkdir(dir, {
+    recursive: true,
+  });
+  return {
+    slug,
+    dir,
+  };
+}
+
+export async function writePrd(slug: string, content: string): Promise<void> {
+  const dir = sessionDir(slug);
+  await mkdir(dir, {
+    recursive: true,
+  });
+  await writeFile(join(dir, PLAN_FILE), content, 'utf8');
+}
+
+export async function writeSubPlan(slug: string, nodeId: string, content: string): Promise<void> {
+  assertSafeNodeId(nodeId);
+  const dir = sessionDir(slug);
+  await mkdir(dir, {
+    recursive: true,
+  });
+  await writeFile(join(dir, `${nodeId}${SUBPLAN_SUFFIX}`), content, 'utf8');
+}
+
+/** Validates `flowJson` against the flow schema, then writes it. Throws on invalid input. */
+export async function writeFlow(slug: string, flowJson: unknown): Promise<void> {
+  const validated = validateFlow(flowJson);
+  const dir = sessionDir(slug);
+  await mkdir(dir, {
+    recursive: true,
+  });
+  await writeFile(join(dir, FLOW_FILE), JSON.stringify(validated, null, 2), 'utf8');
+}
+
+export async function readPlanSession(slug: string): Promise<PlanSessionContents> {
+  const dir = sessionDir(slug);
+  const entries = await readdir(dir).catch(() => null);
+  if (entries === null) {
+    return {
+      prd: null,
+      flow: null,
+      subPlans: {},
+    };
+  }
+
+  const prd = entries.includes(PLAN_FILE) ? await readFile(join(dir, PLAN_FILE), 'utf8') : null;
+
+  const flow = entries.includes(FLOW_FILE)
+    ? JSON.parse(await readFile(join(dir, FLOW_FILE), 'utf8'))
+    : null;
+
+  const subPlans: Record<string, string> = {};
+  for (const entry of entries) {
+    if (entry === PLAN_FILE || !entry.endsWith(SUBPLAN_SUFFIX)) {
+      continue;
+    }
+    const nodeId = entry.slice(0, -SUBPLAN_SUFFIX.length);
+    subPlans[nodeId] = await readFile(join(dir, entry), 'utf8');
+  }
+
+  return {
+    prd,
+    flow,
+    subPlans,
+  };
+}
+
+export async function listPlanSessions(): Promise<string[]> {
+  const root = plansRoot();
+  const entries = await readdir(root, {
+    withFileTypes: true,
+  }).catch(() => null);
+  if (entries === null) {
+    return [];
+  }
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+}
+
+export function getPlanSessionDir(slug: string): string {
+  return sessionDir(slug);
+}
+
+//#endregion

--- a/packages/cli/src/plan/flow-schema.ts
+++ b/packages/cli/src/plan/flow-schema.ts
@@ -1,0 +1,148 @@
+/**
+ * Zod schema for plan-mode flow JSON.
+ *
+ * A "flow" is a JSON-serialisable subset of noetic's `Step` shape that the model
+ * may emit during plan mode. The runtime expands each node into a concrete `Step`
+ * via the existing builders (`step.llm`, `fork`, `spawn`) at execute time.
+ *
+ * Tool references inside `llm` nodes are name strings — they get resolved against
+ * the harness's live tool registry when the flow runs.
+ */
+
+import { z } from 'zod';
+
+//#region Types (declared first so the schema definitions can reference them)
+
+interface NodeBase {
+  id: string;
+  subPlanRef?: string;
+}
+
+export interface LlmFlowNode extends NodeBase {
+  kind: 'llm';
+  model?: string;
+  instructions: string;
+  tools?: string[];
+}
+
+export interface SubagentFlowNode extends NodeBase {
+  kind: 'subagent';
+  preset: string;
+  prompt: string;
+}
+
+export interface ForkFlowNode extends NodeBase {
+  kind: 'fork';
+  mode: 'all' | 'race' | 'settle';
+  paths: FlowNode[];
+}
+
+export interface SpawnFlowNode extends NodeBase {
+  kind: 'spawn';
+  child: FlowNode;
+}
+
+export interface SequenceFlowNode extends NodeBase {
+  kind: 'sequence';
+  steps: FlowNode[];
+}
+
+export type FlowNode =
+  | LlmFlowNode
+  | SubagentFlowNode
+  | ForkFlowNode
+  | SpawnFlowNode
+  | SequenceFlowNode;
+
+//#endregion
+
+//#region Schema
+
+// The recursive reference: any child node position uses this lazy wrapper.
+const FlowNodeRef: z.ZodType<FlowNode> = z.lazy(() => FlowNodeSchema);
+
+const SHARED_FIELDS = {
+  id: z.string().min(1),
+  subPlanRef: z.string().optional(),
+} as const;
+
+const LlmNodeSchema = z.object({
+  kind: z.literal('llm'),
+  ...SHARED_FIELDS,
+  model: z.string().optional(),
+  instructions: z.string(),
+  tools: z.array(z.string()).optional(),
+});
+
+const SubagentNodeSchema = z.object({
+  kind: z.literal('subagent'),
+  ...SHARED_FIELDS,
+  preset: z.string().min(1),
+  prompt: z.string(),
+});
+
+const ForkNodeSchema = z.object({
+  kind: z.literal('fork'),
+  ...SHARED_FIELDS,
+  mode: z.enum([
+    'all',
+    'race',
+    'settle',
+  ]),
+  paths: z.array(FlowNodeRef).min(1),
+});
+
+const SpawnNodeSchema = z.object({
+  kind: z.literal('spawn'),
+  ...SHARED_FIELDS,
+  child: FlowNodeRef,
+});
+
+const SequenceNodeSchema = z.object({
+  kind: z.literal('sequence'),
+  ...SHARED_FIELDS,
+  steps: z.array(FlowNodeRef).min(1),
+});
+
+const FlowNodeSchema: z.ZodType<FlowNode> = z.discriminatedUnion('kind', [
+  LlmNodeSchema,
+  SubagentNodeSchema,
+  ForkNodeSchema,
+  SpawnNodeSchema,
+  SequenceNodeSchema,
+]);
+
+/** Top-level flow document — a single root node. */
+export const FlowSchema = FlowNodeSchema;
+
+//#endregion
+
+//#region Public API
+
+/** Validates a candidate flow document. Throws `ZodError` on invalid input. */
+export function validateFlow(input: unknown): FlowNode {
+  return FlowSchema.parse(input);
+}
+
+/** Walks a flow tree depth-first, yielding each node. */
+export function* walkFlow(root: FlowNode): Iterable<FlowNode> {
+  yield root;
+  if (root.kind === 'fork') {
+    for (const path of root.paths) {
+      yield* walkFlow(path);
+    }
+    return;
+  }
+  if (root.kind === 'sequence') {
+    for (const step of root.steps) {
+      yield* walkFlow(step);
+    }
+    return;
+  }
+  if (root.kind === 'spawn') {
+    yield* walkFlow(root.child);
+    return;
+  }
+}
+
+//#endregion

--- a/packages/cli/src/plan/subagents.ts
+++ b/packages/cli/src/plan/subagents.ts
@@ -1,0 +1,125 @@
+/**
+ * Prebuilt subagent presets used during plan mode and (optionally) by emitted flow JSON.
+ *
+ * Each preset is a factory returning a composition of existing noetic step primitives
+ * (`spawn` + `step.llm`). They are NOT new step kinds — the runtime sees only the
+ * underlying primitives, so serialisation, tracing, memory isolation all work unchanged.
+ */
+
+import type { FsAdapter, ShellAdapter, Step } from '@noetic/core';
+import { spawn, step } from '@noetic/core';
+
+import { createReadOnlyTools } from '../tools/index.js';
+
+//#region Types
+
+export interface SubagentArgs {
+  /** Free-form natural-language prompt describing the task. */
+  prompt: string;
+  /** Working directory for read-only tool resolution. */
+  cwd: string;
+  /** Model identifier passed through to the underlying `step.llm`. */
+  model: string;
+  /** Optional unique id for the spawned step. Auto-generated when omitted. */
+  id?: string;
+  /** Optional fs adapter; defaults to local fs (via `createReadOnlyTools` defaults). */
+  fs?: FsAdapter;
+  /** Optional shell adapter; defaults to local shell. */
+  shell?: ShellAdapter;
+}
+
+export type SubagentPreset = (args: SubagentArgs) => Step<unknown, string, string>;
+
+//#endregion
+
+//#region Prompts
+
+const EXPLORE_INSTRUCTIONS = [
+  'You are an Explore subagent. Your single job is to investigate a focused question about the codebase using read-only tools (Read, Grep, Find, Ls).',
+  '',
+  'Discipline:',
+  '- Do not propose designs, fixes, or implementations. Pure investigation only.',
+  '- Cite file paths with `path:line_number` when you reference specific code.',
+  '- Surface anything surprising or non-obvious — pre-existing patterns, hidden constraints, prior decisions reflected in code.',
+  '',
+  'Output format: a short, structured report (under 500 words) the orchestrator can paste directly into their planning context. No fluff.',
+].join('\n');
+
+const PLAN_INSTRUCTIONS = [
+  'You are a Plan subagent. You have already received exploration findings; your job is to design an implementation approach.',
+  '',
+  'Discipline:',
+  '- Read code yourself before recommending changes — do not trust summaries blindly.',
+  '- Propose ONE recommended approach and (briefly) one rejected alternative with the reason it lost.',
+  '- Identify the *Critical Files for Implementation*: list the file paths the implementer must touch, with line numbers when known.',
+  '- Reuse existing functions/utilities you find rather than inventing new ones; cite their paths.',
+  '',
+  'Output format:',
+  '- ## Recommended Approach',
+  '- ## Alternative Considered',
+  '- ## Critical Files for Implementation',
+  '- ## Open Questions (if any)',
+].join('\n');
+
+//#endregion
+
+//#region Helpers
+
+let counter = 0;
+function nextId(prefix: string): string {
+  counter += 1;
+  return `${prefix}-${Date.now().toString(36)}-${counter}`;
+}
+
+function buildSubagent(
+  prefix: string,
+  baseInstructions: string,
+  args: SubagentArgs,
+): Step<unknown, string, string> {
+  const id = args.id ?? nextId(prefix);
+  const tools = createReadOnlyTools(args.cwd, args.fs, args.shell);
+  const instructions = [
+    baseInstructions,
+    '',
+    '---',
+    '',
+    args.prompt,
+  ].join('\n');
+
+  return spawn<unknown, string, string>({
+    id,
+    child: step.llm<unknown, string, string>({
+      id: `${id}-llm`,
+      model: args.model,
+      instructions,
+      tools,
+    }),
+  });
+}
+
+//#endregion
+
+//#region Presets
+
+export function exploreAgent(args: SubagentArgs): Step<unknown, string, string> {
+  return buildSubagent('explore', EXPLORE_INSTRUCTIONS, args);
+}
+
+export function planAgent(args: SubagentArgs): Step<unknown, string, string> {
+  return buildSubagent('plan', PLAN_INSTRUCTIONS, args);
+}
+
+//#endregion
+
+//#region Registry
+
+export const SUBAGENT_PRESETS: Record<string, SubagentPreset> = {
+  explore: exploreAgent,
+  plan: planAgent,
+};
+
+export function resolveSubagentPreset(name: string): SubagentPreset | undefined {
+  return SUBAGENT_PRESETS[name];
+}
+
+//#endregion

--- a/packages/cli/src/plugins/types.ts
+++ b/packages/cli/src/plugins/types.ts
@@ -1,6 +1,7 @@
 import type { LastLayerUsage, MemoryLayer, Tool } from '@noetic/core';
 import type { ReactNode } from 'react';
 
+import type { SubagentPreset } from '../plan/subagents.js';
 import type { SkillDefinition } from '../skills/types.js';
 import type { AgentConfig } from '../types/config.js';
 
@@ -20,6 +21,8 @@ export interface FooterContext {
   threadId: string;
   sessionStartedAt: number;
   entryCount: number;
+  /** Current agent mode: `'normal'` (full toolset) or `'planning'` (read-only, plan mode). */
+  agentMode: 'normal' | 'planning';
 }
 
 //#endregion
@@ -43,4 +46,9 @@ export interface NoeticPlugin {
    * default verb. Called once after plugin init; no per-turn calls.
    */
   loadingMessages?: () => ReadonlyArray<string> | Promise<ReadonlyArray<string>>;
+  /**
+   * Optional registry of subagent presets the plugin contributes. These names
+   * become valid `preset` values inside plan-mode flow JSON `subagent` nodes.
+   */
+  subagentPresets?: () => Record<string, SubagentPreset> | Promise<Record<string, SubagentPreset>>;
 }

--- a/packages/cli/src/tui/app.tsx
+++ b/packages/cli/src/tui/app.tsx
@@ -8,6 +8,7 @@ import type {
   Item,
   LastLayerUsage,
   MemoryLayer,
+  PlanState,
 } from '@noetic/core';
 import { render } from 'ink';
 import type { ReactNode } from 'react';
@@ -22,13 +23,16 @@ import {
   parseSlashCommand,
 } from '../commands/index.js';
 import type { Command, CommandContext } from '../commands/types.js';
+import type { AgentMode, PlanHooks } from '../harness/factory.js';
 import { createAgentHarness } from '../harness/factory.js';
+import { createPlanSession, writeFlow, writePrd } from '../plan/file-store.js';
 import type { FooterContext as FooterContextValue, NoeticPlugin } from '../plugins/types.js';
 import type { SkillDefinition } from '../skills/types.js';
 import type { AgentRuntimeConfig } from '../types/config.js';
 import { getModelContextLimit } from '../types/model-context.js';
 import type { ChatStatus } from './components/index.js';
 import { InkProvider, ResponsesChat } from './components/index.js';
+import { PlanApprovalModal } from './components/plan-approval-modal.js';
 import { FooterContextProvider } from './footer-context.js';
 import type { ConversationEntry, ErrorEntry, SystemEntry, UserEntry } from './item-utils.js';
 import {
@@ -118,11 +122,14 @@ function App({ config, plugins }: AppProps): ReactNode {
   const [status, setStatus] = useState<ChatStatus>('ready');
   const [skills, setSkills] = useState<ReadonlyArray<SkillDefinition>>([]);
   const [modal, setModal] = useState<ModalState | null>(null);
+  const [agentMode, setAgentModeState] = useState<AgentMode>('normal');
 
   const harnessRef = useRef<AgentHarness | null>(null);
+  const harnessModeRef = useRef<AgentMode>('normal');
   const lastLayerUsageRef = useRef<LastLayerUsage | undefined>(undefined);
   const [lastLayerUsage, setLastLayerUsage] = useState<LastLayerUsage | undefined>(undefined);
   const memoryLayersRef = useRef<ReadonlyArray<MemoryLayer>>([]);
+  const pendingApprovalRef = useRef<((approved: boolean) => void) | null>(null);
   // Stable per-session threadId so memory layers that persist by thread/resource
   // scope rehydrate across turns. Random UUID lives for the CLI process lifetime.
   const threadIdRef = useRef<string>(crypto.randomUUID());
@@ -154,12 +161,17 @@ function App({ config, plugins }: AppProps): ReactNode {
     setEntries([]);
   }, []);
 
-  // Handle modal close (Escape pressed)
+  // Handle modal close (Escape pressed). If a plan-approval modal is open and
+  // the user dismisses without explicitly accepting, we treat that as rejection
+  // so the layer stays in plan mode rather than silently auto-approving.
   const handleModalClose = useCallback(() => {
     if (!modal) {
       return;
     }
-    // Add dismiss message to chat history
+    if (pendingApprovalRef.current) {
+      pendingApprovalRef.current(false);
+      pendingApprovalRef.current = null;
+    }
     setEntries((prev) => [
       ...prev,
       {
@@ -173,30 +185,102 @@ function App({ config, plugins }: AppProps): ReactNode {
     modal,
   ]);
 
+  // Plan-mode hooks: own session creation and approval-modal lifecycle.
+  // Memoised once — they read from refs so they don't need React re-renders.
+  const planHooks = useMemo<PlanHooks>(
+    () => ({
+      onEnterSession: async () => createPlanSession(),
+      onExit: async (state: PlanState) => {
+        const slug = state.planSlug;
+        return new Promise<{
+          approved: boolean;
+        }>((resolve) => {
+          pendingApprovalRef.current = async (approved) => {
+            if (approved && slug) {
+              if (state.prd) {
+                await writePrd(slug, state.prd);
+              }
+              if (state.planTree) {
+                await writeFlow(slug, state.planTree).catch(() => {
+                  // planTree may be a legacy PlanNode that doesn't match the flow schema; ignore.
+                });
+              }
+            }
+            resolve({
+              approved,
+            });
+          };
+          setModal({
+            content: (
+              <PlanApprovalModal
+                prd={state.prd ?? '(no PRD)'}
+                planTree={state.planTree}
+                onAccept={() => {
+                  const cb = pendingApprovalRef.current;
+                  pendingApprovalRef.current = null;
+                  setModal(null);
+                  cb?.(true);
+                }}
+                onReject={() => {
+                  const cb = pendingApprovalRef.current;
+                  pendingApprovalRef.current = null;
+                  setModal(null);
+                  cb?.(false);
+                }}
+              />
+            ),
+            commandName: 'plan/exitPlanMode',
+            dismissMessage: 'Plan approval dismissed (treated as rejection).',
+          });
+        });
+      },
+    }),
+    [],
+  );
+
   /**
-   * Get or create the harness, storing the canonical skill catalog.
+   * Get or create the harness for the requested mode. If the requested mode
+   * differs from the active harness's mode, the existing harness is discarded
+   * and a fresh one is built so the model sees the correct toolset.
    */
-  const getOrCreateHarness = useCallback(async (): Promise<AgentHarness> => {
-    if (harnessRef.current !== null) {
-      return harnessRef.current;
-    }
-    const {
-      harness,
-      skills: resolvedSkills,
-      memoryLayers,
-    } = await createAgentHarness({
+  const getOrCreateHarness = useCallback(
+    async (mode: AgentMode): Promise<AgentHarness> => {
+      if (harnessRef.current !== null && harnessModeRef.current === mode) {
+        return harnessRef.current;
+      }
+      const {
+        harness,
+        skills: resolvedSkills,
+        memoryLayers,
+      } = await createAgentHarness({
+        config,
+        plugins,
+        fs: config.fs,
+        mode,
+        planHooks,
+      });
+      harnessRef.current = harness;
+      harnessModeRef.current = mode;
+      memoryLayersRef.current = memoryLayers;
+      setSkills(resolvedSkills);
+      return harness;
+    },
+    [
       config,
       plugins,
-      fs: config.fs,
-    });
-    harnessRef.current = harness;
-    memoryLayersRef.current = memoryLayers;
-    setSkills(resolvedSkills);
-    return harness;
-  }, [
-    config,
-    plugins,
-  ]);
+      planHooks,
+    ],
+  );
+
+  // Switching mode invalidates the cached harness so the next turn rebuilds with
+  // the correct tool set. We don't proactively rebuild here — `getOrCreateHarness`
+  // does it lazily on the next message.
+  const setAgentMode = useCallback(async (mode: AgentMode): Promise<void> => {
+    if (harnessModeRef.current !== mode) {
+      harnessRef.current = null;
+    }
+    setAgentModeState(mode);
+  }, []);
 
   const handleSubmit = useCallback(
     async (text: string): Promise<void> => {
@@ -218,6 +302,8 @@ function App({ config, plugins }: AppProps): ReactNode {
               clearEntries,
               lastLayerUsage: lastLayerUsageRef.current,
               memoryLayers: memoryLayersRef.current,
+              agentMode,
+              setAgentMode,
             };
 
             try {
@@ -283,7 +369,7 @@ function App({ config, plugins }: AppProps): ReactNode {
       setStatus('submitted');
 
       try {
-        const harness = await getOrCreateHarness();
+        const harness = await getOrCreateHarness(agentMode);
         // Build conversation history including the new user message
         const historyItems = entriesToItems([
           ...entriesRef.current,
@@ -314,6 +400,8 @@ function App({ config, plugins }: AppProps): ReactNode {
       skills,
       clearEntries,
       getOrCreateHarness,
+      agentMode,
+      setAgentMode,
     ],
   );
 
@@ -327,6 +415,7 @@ function App({ config, plugins }: AppProps): ReactNode {
       threadId: threadIdRef.current,
       sessionStartedAt: sessionStartedAtRef.current,
       entryCount: entries.length,
+      agentMode,
     }),
     [
       config.model,
@@ -334,6 +423,7 @@ function App({ config, plugins }: AppProps): ReactNode {
       status,
       lastLayerUsage,
       entries.length,
+      agentMode,
     ],
   );
 

--- a/packages/cli/src/tui/components/plan-approval-modal.tsx
+++ b/packages/cli/src/tui/components/plan-approval-modal.tsx
@@ -1,0 +1,100 @@
+/**
+ * Plan approval modal — shown when the model calls `plan/exitPlanMode { action: 'execute' }`.
+ *
+ * Displays the proposed PRD and (if present) flow tree. The user accepts to allow
+ * execution to begin (host writes the PRD to disk and the planMemory layer
+ * transitions to Executing) or rejects to keep planning.
+ */
+
+import { Box, Text, useInput } from 'ink';
+import type { ReactNode } from 'react';
+
+import { useTheme } from './theme.js';
+
+//#region Types
+
+export interface PlanApprovalModalProps {
+  prd: string;
+  planTree: unknown | null;
+  onAccept: () => void;
+  onReject: () => void;
+}
+
+//#endregion
+
+//#region Component
+
+const MAX_PRD_LINES = 24;
+
+function truncatePrd(prd: string): {
+  lines: string[];
+  truncated: boolean;
+} {
+  const lines = prd.split('\n');
+  if (lines.length <= MAX_PRD_LINES) {
+    return {
+      lines,
+      truncated: false,
+    };
+  }
+  return {
+    lines: lines.slice(0, MAX_PRD_LINES),
+    truncated: true,
+  };
+}
+
+export function PlanApprovalModal({
+  prd,
+  planTree,
+  onAccept,
+  onReject,
+}: PlanApprovalModalProps): ReactNode {
+  const theme = useTheme();
+  const { lines, truncated } = truncatePrd(prd);
+
+  useInput((input, key) => {
+    if (key.return || input === 'y' || input === 'Y') {
+      onAccept();
+      return;
+    }
+    if (key.escape || input === 'n' || input === 'N') {
+      onReject();
+    }
+  });
+
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor={theme.primary} padding={1}>
+      <Box marginBottom={1}>
+        <Text bold color={theme.primary}>
+          Plan ready for approval
+        </Text>
+      </Box>
+
+      <Box flexDirection="column" marginBottom={1}>
+        <Text>{lines.join('\n')}</Text>
+        {truncated ? (
+          <Text color={theme.muted}>
+            … (PRD truncated for display; full content will be written to disk on accept)
+          </Text>
+        ) : null}
+      </Box>
+
+      {planTree ? (
+        <Box flexDirection="column" marginBottom={1}>
+          <Text bold color={theme.muted}>
+            Flow attached
+          </Text>
+          <Text color={theme.muted}>(JSON flow will be written to flow.json on accept)</Text>
+        </Box>
+      ) : null}
+
+      <Box>
+        <Text color={theme.success}>[Y/Enter] Accept</Text>
+        <Text>{'  '}</Text>
+        <Text color={theme.error}>[N/Esc] Reject</Text>
+      </Box>
+    </Box>
+  );
+}
+
+//#endregion

--- a/packages/cli/test/plan-file-store.test.ts
+++ b/packages/cli/test/plan-file-store.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Tests for the plan-file store and flow JSON schema.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FlowNode } from '../src/plan/flow-schema.js';
+import { validateFlow, walkFlow } from '../src/plan/flow-schema.js';
+
+//#region Flow schema
+
+describe('validateFlow', () => {
+  test('accepts a minimal llm node', () => {
+    const node: FlowNode = {
+      kind: 'llm',
+      id: 'root',
+      instructions: 'do the thing',
+    };
+    const result = validateFlow(node);
+    expect(result.kind).toBe('llm');
+    expect(result.id).toBe('root');
+  });
+
+  test('accepts a fork with two llm paths', () => {
+    const node: FlowNode = {
+      kind: 'fork',
+      id: 'parallel',
+      mode: 'all',
+      paths: [
+        {
+          kind: 'llm',
+          id: 'a',
+          instructions: 'A',
+        },
+        {
+          kind: 'llm',
+          id: 'b',
+          instructions: 'B',
+        },
+      ],
+    };
+    const result = validateFlow(node);
+    expect(result.kind).toBe('fork');
+  });
+
+  test('accepts a subagent node', () => {
+    const node: FlowNode = {
+      kind: 'subagent',
+      id: 'explore-1',
+      preset: 'explore',
+      prompt: 'find auth code',
+    };
+    expect(validateFlow(node).kind).toBe('subagent');
+  });
+
+  test('accepts deeply nested sequence + spawn', () => {
+    const node: FlowNode = {
+      kind: 'sequence',
+      id: 'seq',
+      steps: [
+        {
+          kind: 'spawn',
+          id: 'spawn-1',
+          child: {
+            kind: 'llm',
+            id: 'inner',
+            instructions: 'work',
+          },
+        },
+      ],
+    };
+    expect(validateFlow(node).kind).toBe('sequence');
+  });
+
+  test('rejects unknown kind', () => {
+    expect(() =>
+      validateFlow({
+        kind: 'bogus',
+        id: 'x',
+      }),
+    ).toThrow();
+  });
+
+  test('rejects missing required field', () => {
+    expect(() =>
+      validateFlow({
+        kind: 'llm',
+        id: 'x',
+      }),
+    ).toThrow();
+  });
+
+  test('rejects empty fork paths', () => {
+    expect(() =>
+      validateFlow({
+        kind: 'fork',
+        id: 'p',
+        mode: 'all',
+        paths: [],
+      }),
+    ).toThrow();
+  });
+
+  test('rejects empty id', () => {
+    expect(() =>
+      validateFlow({
+        kind: 'llm',
+        id: '',
+        instructions: 'x',
+      }),
+    ).toThrow();
+  });
+});
+
+describe('walkFlow', () => {
+  test('yields every node in a tree depth-first', () => {
+    const root: FlowNode = {
+      kind: 'fork',
+      id: 'root',
+      mode: 'all',
+      paths: [
+        {
+          kind: 'sequence',
+          id: 'seq',
+          steps: [
+            {
+              kind: 'llm',
+              id: 'a',
+              instructions: 'A',
+            },
+            {
+              kind: 'llm',
+              id: 'b',
+              instructions: 'B',
+            },
+          ],
+        },
+        {
+          kind: 'llm',
+          id: 'c',
+          instructions: 'C',
+        },
+      ],
+    };
+    const ids = Array.from(walkFlow(root)).map((n) => n.id);
+    expect(ids).toEqual([
+      'root',
+      'seq',
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+});
+
+//#endregion
+
+//#region File store (uses real fs in a temp HOME)
+
+async function withTempPlansRoot<T>(fn: (root: string) => Promise<T>): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), 'noetic-plans-'));
+  const prev = process.env.NOETIC_PLANS_ROOT;
+  process.env.NOETIC_PLANS_ROOT = root;
+  try {
+    return await fn(root);
+  } finally {
+    if (prev === undefined) {
+      delete process.env.NOETIC_PLANS_ROOT;
+    } else {
+      process.env.NOETIC_PLANS_ROOT = prev;
+    }
+    await rm(root, {
+      recursive: true,
+      force: true,
+    });
+  }
+}
+
+describe('plan file store', () => {
+  test('createPlanSession + writePrd + readPlanSession round-trip', async () => {
+    await withTempPlansRoot(async () => {
+      const store = await import('../src/plan/file-store.ts');
+      const session = await store.createPlanSession();
+      expect(session.slug.length).toBeGreaterThan(0);
+      expect(session.dir).toContain(session.slug);
+
+      await store.writePrd(session.slug, '# Hello\n\nWorld');
+      const contents = await store.readPlanSession(session.slug);
+      expect(contents.prd).toBe('# Hello\n\nWorld');
+      expect(contents.flow).toBeNull();
+      expect(contents.subPlans).toEqual({});
+    });
+  });
+
+  test('writeFlow validates and persists JSON', async () => {
+    await withTempPlansRoot(async () => {
+      const store = await import('../src/plan/file-store.ts');
+      const session = await store.createPlanSession();
+      const flow: FlowNode = {
+        kind: 'llm',
+        id: 'root',
+        instructions: 'go',
+      };
+      await store.writeFlow(session.slug, flow);
+      const contents = await store.readPlanSession(session.slug);
+      expect(contents.flow).toEqual(flow);
+    });
+  });
+
+  test('writeFlow rejects invalid JSON', async () => {
+    await withTempPlansRoot(async () => {
+      const store = await import('../src/plan/file-store.ts');
+      const session = await store.createPlanSession();
+      await expect(
+        store.writeFlow(session.slug, {
+          kind: 'nope',
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  test('writeSubPlan rejects path-traversal nodeIds', async () => {
+    await withTempPlansRoot(async () => {
+      const store = await import('../src/plan/file-store.ts');
+      const session = await store.createPlanSession();
+      await expect(store.writeSubPlan(session.slug, '../escape', 'hi')).rejects.toThrow();
+    });
+  });
+
+  test('listPlanSessions returns created session slugs', async () => {
+    await withTempPlansRoot(async () => {
+      const store = await import('../src/plan/file-store.ts');
+      const a = await store.createPlanSession();
+      const b = await store.createPlanSession();
+      const list = await store.listPlanSessions();
+      expect(list).toContain(a.slug);
+      expect(list).toContain(b.slug);
+    });
+  });
+
+  test('listPlanSessions returns [] when no sessions exist', async () => {
+    await withTempPlansRoot(async () => {
+      const store = await import('../src/plan/file-store.ts');
+      const list = await store.listPlanSessions();
+      expect(list).toEqual([]);
+    });
+  });
+});
+
+//#endregion

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,7 +88,9 @@ export type {
 export { observationalMemory } from './memory/layers/observational-memory';
 /** @public */
 export type {
+  PlanEnterSessionCallback,
   PlanExecutionEntry,
+  PlanExitCallback,
   PlanMemoryConfig,
   PlanState,
 } from './memory/layers/plan';

--- a/packages/core/src/memory/layers/plan.ts
+++ b/packages/core/src/memory/layers/plan.ts
@@ -52,13 +52,34 @@ export interface PlanState {
   planTree: PlanNode | null;
   executionLog: PlanExecutionEntry[];
   version: number;
+  /** Identifier of the on-disk plan session (set by `onEnterSession` host callback). */
+  planSlug?: string | null;
 }
+
+/** Host-supplied callback invoked when entering plan mode. Returns a session identifier the host owns (e.g. on-disk dir slug). */
+export type PlanEnterSessionCallback = () => Promise<{
+  slug: string;
+}>;
+
+/**
+ * Host-supplied callback invoked when the model requests `exitPlanMode` with `action: 'execute'`.
+ * Return `{ approved: false }` to keep the layer in `Planning` (e.g. user rejected the plan in the UI).
+ */
+export type PlanExitCallback = (state: PlanState) => Promise<{
+  approved: boolean;
+}>;
 
 export interface PlanMemoryConfig {
   scope?: MemoryScope;
   additionalAllowedTools?: string[];
   maxPrdLength?: number;
   maxTreeDepth?: number;
+  /** Extra free-form instructions appended to the planning-phase recall payload. */
+  additionalPlanInstructions?: string;
+  /** Called once when the layer transitions Idle → Planning. */
+  onEnterSession?: PlanEnterSessionCallback;
+  /** Called when `exitPlanMode` is requested with `action: 'execute'`. */
+  onExit?: PlanExitCallback;
 }
 
 //#endregion
@@ -106,18 +127,35 @@ function trimExecutionLog(log: PlanExecutionEntry[]): PlanExecutionEntry[] {
 
 //#region Recall Renderers
 
-function recallPlanning(state: PlanState): string {
+function recallPlanning(state: PlanState, additionalInstructions?: string): string {
   const sections: string[] = [
     '<plan_mode>',
     'You are in PLAN MODE. You may only use read-only tools (Read, Grep, Find, Ls) to explore the codebase.',
-    'Your goal is to produce a PRD document and a structured execution plan.',
+    'Your goal is to produce a PRD document and (optionally) a structured execution plan.',
     '',
-    'Available actions:',
-    '- Call plan/updatePrd with your PRD content (markdown)',
-    '- Call plan/setPlanTree with a PlanNode JSON tree',
-    '- Call plan/exitPlanMode with { action: "execute" } to begin execution',
-    '- Call plan/exitPlanMode with { action: "cancel" } to cancel',
+    '## Workflow (5 phases)',
+    '',
+    '1. **Initial Understanding** — Read code and gather context. To parallelise exploration, fork over `{ kind: "subagent", preset: "explore", prompt: "..." }` nodes; up to 3 in parallel. Each Explore subagent returns a focused report.',
+    '2. **Design** — Synthesise findings. Optionally invoke `{ kind: "subagent", preset: "plan", prompt: "..." }` (1–3 in parallel) to draft alternative implementation approaches and surface trade-offs.',
+    '3. **Review** — Read the critical files identified by your subagents directly so you understand them first-hand. If anything is ambiguous, ask the user a focused question.',
+    '4. **Final Plan** — Write the PRD via `plan/updatePrd`. Lead with a **Context** section (why this change), then your single recommended approach, the paths of files to modify, existing functions/utilities to reuse, and a **Verification** section. If the task warrants custom step orchestration, also call `plan/setPlanTree` with a JSON noetic flow built from the existing step primitives (`step.llm`, `step.branch`, `step.fork`, `step.spawn`, `step.loop`) — tool refs by name string. Otherwise omit the tree.',
+    '5. **Exit** — Call `plan/exitPlanMode` with `{ action: "execute" }` to request approval. The user must accept before execution begins; if they reject, you stay in Plan Mode and may revise.',
+    '',
+    '## Available actions',
+    '- `plan/updatePrd` — set markdown PRD content',
+    '- `plan/setPlanTree` — set the optional JSON execution plan',
+    '- `plan/exitPlanMode` `{ action: "execute" }` — request approval and exit to executing',
+    '- `plan/exitPlanMode` `{ action: "cancel" }` — discard plan and return to idle',
+    '',
+    '## Constraints',
+    '- DO NOT create, modify, or delete files (other than via `plan/updatePrd`).',
+    '- DO NOT run mutating shell commands. Read-only exploration only.',
+    '- End each turn either by asking the user a focused clarifying question or by calling `plan/exitPlanMode`.',
   ];
+
+  if (additionalInstructions) {
+    sections.push('', '## Additional Instructions', '', additionalInstructions);
+  }
 
   if (state.prd) {
     sections.push('', '## Current PRD Draft', '', state.prd);
@@ -152,7 +190,7 @@ function recallTerminal(state: PlanState): string {
   return `<plan_outcome>Plan v${state.version} ${outcome}.</plan_outcome>`;
 }
 
-type RecallRenderer = (state: PlanState) => string;
+type RecallRenderer = (state: PlanState, additionalInstructions?: string) => string;
 
 const RECALL_RENDERERS: Partial<Record<PlanPhase, RecallRenderer>> = {
   [PlanPhase.Planning]: recallPlanning,
@@ -177,6 +215,9 @@ export function planMemory(config?: PlanMemoryConfig): MemoryLayer<PlanState> {
   const maxPrdLength = config?.maxPrdLength ?? MAX_PRD_LENGTH;
   const maxTreeDepth = config?.maxTreeDepth ?? MAX_TREE_DEPTH;
   const allowedTools = buildAllowedTools(config);
+  const additionalPlanInstructions = config?.additionalPlanInstructions;
+  const onEnterSession = config?.onEnterSession;
+  const onExit = config?.onExit;
 
   return {
     id: 'plan',
@@ -225,6 +266,7 @@ export function planMemory(config?: PlanMemoryConfig): MemoryLayer<PlanState> {
               state,
             };
           }
+          const session = onEnterSession ? await onEnterSession() : null;
           return {
             result: 'Plan mode activated. Explore the codebase, then call plan/updatePrd.',
             state: {
@@ -233,6 +275,7 @@ export function planMemory(config?: PlanMemoryConfig): MemoryLayer<PlanState> {
               prd: args.goal ? `# Goal\n\n${args.goal}\n` : null,
               planTree: null,
               version: state.version + 1,
+              planSlug: session?.slug ?? null,
             },
           };
         },
@@ -345,6 +388,17 @@ export function planMemory(config?: PlanMemoryConfig): MemoryLayer<PlanState> {
             };
           }
 
+          if (onExit) {
+            const { approved } = await onExit(state);
+            if (!approved) {
+              return {
+                result:
+                  'User did not approve the plan. Stay in plan mode, address their feedback, and call plan/exitPlanMode again when ready.',
+                state,
+              };
+            }
+          }
+
           return {
             result: 'Plan mode exited. Execution phase begun.',
             state: {
@@ -373,7 +427,7 @@ export function planMemory(config?: PlanMemoryConfig): MemoryLayer<PlanState> {
           return null;
         }
 
-        const content = renderer(state);
+        const content = renderer(state, additionalPlanInstructions);
         return {
           items: [
             createMessage(content, 'developer'),

--- a/packages/core/test/memory/plan.test.ts
+++ b/packages/core/test/memory/plan.test.ts
@@ -747,6 +747,96 @@ describe('planMemory layer', () => {
 
   //#endregion
 
+  //#region Host Callbacks (onEnterSession, onExit, additionalPlanInstructions)
+
+  describe('host callbacks', () => {
+    it('calls onEnterSession and stores returned slug in state', async () => {
+      let called = 0;
+      const layer = planMemory({
+        onEnterSession: async () => {
+          called += 1;
+          return {
+            slug: 'amber-cobalt-falcon',
+          };
+        },
+      });
+      const fn = layer.provides!.enterPlanMode;
+      assert(fn.kind === 'function');
+      const result = await fn.execute({}, makeIdleState(), makeCtx());
+      assert(result.state);
+      expect(called).toBe(1);
+      expect(result.state.planSlug).toBe('amber-cobalt-falcon');
+    });
+
+    it('leaves planSlug null when no callback configured', async () => {
+      const layer = planMemory();
+      const fn = layer.provides!.enterPlanMode;
+      assert(fn.kind === 'function');
+      const result = await fn.execute({}, makeIdleState(), makeCtx());
+      assert(result.state);
+      expect(result.state.planSlug ?? null).toBeNull();
+    });
+
+    it('rejected onExit keeps phase in Planning and reports rejection', async () => {
+      const layer = planMemory({
+        onExit: async () => ({
+          approved: false,
+        }),
+      });
+      const fn = layer.provides!.exitPlanMode;
+      assert(fn.kind === 'function');
+      const inputState = makePlanningState({
+        prd: '# PRD',
+        planTree: makePlanNode(),
+      });
+      const result = await fn.execute({ action: 'execute' }, inputState, makeCtx());
+      expect(result.result).toContain('did not approve');
+      expect(result.state).toBe(inputState);
+    });
+
+    it('approved onExit transitions to Executing', async () => {
+      const layer = planMemory({
+        onExit: async () => ({
+          approved: true,
+        }),
+      });
+      const fn = layer.provides!.exitPlanMode;
+      assert(fn.kind === 'function');
+      const result = await fn.execute(
+        { action: 'execute' },
+        makePlanningState({
+          prd: '# PRD',
+          planTree: makePlanNode(),
+        }),
+        makeCtx(),
+      );
+      assert(result.state);
+      expect(result.state.phase).toBe(PlanPhase.Executing);
+    });
+
+    it('appends additionalPlanInstructions to recall payload', async () => {
+      const layer = planMemory({
+        additionalPlanInstructions: 'PROJECT_RULE: do not touch the auth module.',
+      });
+      const result = await layer.hooks.recall!({
+        log: makeItemLog(),
+        query: '',
+        ctx: makeCtx(),
+        state: makePlanningState(),
+        budget: 3e3,
+      });
+      assert(result !== null);
+      assert(typeof result !== 'string');
+      const part = result.items[0];
+      assert(part.type === 'message');
+      const text = part.content[0];
+      assert(text.type === 'input_text');
+      expect(text.text).toContain('PROJECT_RULE');
+    });
+  });
+
+  //#endregion
+
   //#region Status Data
 
   describe('status layerData', () => {

--- a/packages/core/test/memory/plan.test.ts
+++ b/packages/core/test/memory/plan.test.ts
@@ -789,7 +789,13 @@ describe('planMemory layer', () => {
         prd: '# PRD',
         planTree: makePlanNode(),
       });
-      const result = await fn.execute({ action: 'execute' }, inputState, makeCtx());
+      const result = await fn.execute(
+        {
+          action: 'execute',
+        },
+        inputState,
+        makeCtx(),
+      );
       expect(result.result).toContain('did not approve');
       expect(result.state).toBe(inputState);
     });
@@ -803,7 +809,9 @@ describe('planMemory layer', () => {
       const fn = layer.provides!.exitPlanMode;
       assert(fn.kind === 'function');
       const result = await fn.execute(
-        { action: 'execute' },
+        {
+          action: 'execute',
+        },
         makePlanningState({
           prd: '# PRD',
           planTree: makePlanNode(),

--- a/scripts/patch-sdk.js
+++ b/scripts/patch-sdk.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 // Adds compatibility shims for @openrouter/agent and @openrouter/sdk
-import { writeFileSync, readFileSync, existsSync } from 'fs';
-import { dirname, join } from 'path';
-import { fileURLToPath } from 'url';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 // Shim 1: Export aliases for renamed types
 const shimContent = `// Shim: re-export with old names for @openrouter/agent compatibility
@@ -19,8 +19,14 @@ export {
 // Patch all SDK versions that might be resolved
 const sdkPaths = [
   join(__dirname, '../node_modules/@openrouter/sdk/esm/models'),
-  join(__dirname, '../node_modules/.bun/@openrouter+sdk@0.10.2/node_modules/@openrouter/sdk/esm/models'),
-  join(__dirname, '../node_modules/.bun/@openrouter+sdk@0.5.1/node_modules/@openrouter/sdk/esm/models'),
+  join(
+    __dirname,
+    '../node_modules/.bun/@openrouter+sdk@0.10.2/node_modules/@openrouter/sdk/esm/models',
+  ),
+  join(
+    __dirname,
+    '../node_modules/.bun/@openrouter+sdk@0.5.1/node_modules/@openrouter/sdk/esm/models',
+  ),
 ];
 
 for (const modelsDir of sdkPaths) {
@@ -56,7 +62,10 @@ for (const agentPath of agentPaths) {
   let sdkExpectsOpen = false;
   const sdkCheckPaths = [
     join(agentPath, 'node_modules/@openrouter/sdk/esm/funcs/betaResponsesSend.d.ts'),
-    join(__dirname, `../node_modules/.bun/@openrouter+sdk@${sdkVersion?.replace('^', '')}/node_modules/@openrouter/sdk/esm/funcs/betaResponsesSend.d.ts`),
+    join(
+      __dirname,
+      `../node_modules/.bun/@openrouter+sdk@${sdkVersion?.replace('^', '')}/node_modules/@openrouter/sdk/esm/funcs/betaResponsesSend.d.ts`,
+    ),
     join(__dirname, '../node_modules/@openrouter/sdk/esm/funcs/betaResponsesSend.d.ts'),
   ];
 
@@ -69,7 +78,8 @@ for (const agentPath of agentPaths) {
   }
 
   let content = readFileSync(modelResultPath, 'utf-8');
-  const agentUsesResponses = content.includes('responsesRequest:') && !content.includes('openResponsesRequest:');
+  const agentUsesResponses =
+    content.includes('responsesRequest:') && !content.includes('openResponsesRequest:');
   const agentUsesOpen = content.includes('openResponsesRequest:');
 
   if (sdkExpectsOpen && agentUsesResponses) {


### PR DESCRIPTION
## Summary

- Adds a first-class plan mode to `@noetic/cli` that mirrors Claude Code's 5-phase workflow (explore → design → review → final plan → exit). `/mode plan` (or `/plan`) flips the harness to read-only tools, the footer surfaces the active mode, and `plan/exitPlanMode` opens a modal asking the user to approve before executing. Approved plans are persisted to `~/.noetic/plans/<slug>/` (`plan.md` plus optional `flow.json`).
- Extends `planMemory()` in `@noetic/core` with three optional host hooks (`onEnterSession`, `onExit`, `additionalPlanInstructions`) plus a `planSlug` state field. All additive — existing 42 plan tests still pass.
- Adds prebuilt `explore` and `plan` subagent presets that compose `spawn(step.llm({...createReadOnlyTools(cwd)}))`. They are NOT new step kinds — JSON `{ kind: 'subagent', preset: ... }` shorthand expands at execute time. Plugins can contribute presets via `NoeticPlugin.subagentPresets`.
- Flow JSON is a Zod-validated subset of the existing `Step` shape (`llm`, `fork`, `spawn`, `sequence`, `subagent`); tool refs are name strings resolved against the live registry.

## Test plan

- [x] `bun test` in `packages/core` — 47/47 plan tests pass (was 42, +5 for new hooks)
- [x] `bun run test` in `packages/cli` — 107/107 unit tests pass (+15 new in `plan-file-store.test.ts`)
- [x] `bunx tsc --noEmit` clean for every file touched (pre-existing core errors unchanged)
- [x] `bun run lint` clean
- [x] pilotty smoke: `/mode plan` → `/mode status` → `/mode normal` flip state correctly in the live TUI
- [ ] Live end-to-end: enter plan mode, drive the model through `plan/updatePrd` + `plan/exitPlanMode`, verify modal approval and disk artefacts