### PR TITLE
feat(plugin-design-deck): interactive deck picker + plugin LLM access

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,28 @@
         "@mariozechner/pi-coding-agent",
       ],
     },
+    "packages/plugin-design-deck": {
+      "name": "@noetic/plugin-design-deck",
+      "version": "0.1.0",
+      "dependencies": {
+        "@noetic/cli": "workspace:*",
+        "cli-highlight": "^2.1.11",
+        "marked": "^15.0.7",
+        "marked-terminal": "^7.3.0",
+        "zod": "^4.0.0",
+      },
+      "devDependencies": {
+        "@types/react": "^19.2.14",
+        "bun-types": "latest",
+        "ink": "^7.0.0",
+        "ink-text-input": "^6.0.0",
+        "react": "^19.2.0",
+      },
+      "peerDependencies": {
+        "ink": "^7.0.0",
+        "react": "^19.2.0",
+      },
+    },
     "packages/plugin-powerline": {
       "name": "@noetic/plugin-powerline",
       "version": "0.1.0",
@@ -206,6 +228,8 @@
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250507.0", "", { "os": "win32", "cpu": "x64" }, "sha512-c91fhNP8ufycdIDqjVyKTqeb4ewkbAYXFQbLreMVgh4LLQQPDDEte8wCdmaFy5bIL0M9d85PpdCq51RCzq/FaQ=="],
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20250327.0", "", {}, "sha512-rkoGnSY/GgBLCuhjZMIC3mt0jjqqvL17uOK92OI4eivmE+pMFOAchowDxIWOzDyYe5vwNCakbCeIM/FrSmwGJA=="],
+
+    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -403,6 +427,8 @@
 
     "@noetic/eval": ["@noetic/eval@workspace:packages/eval"],
 
+    "@noetic/plugin-design-deck": ["@noetic/plugin-design-deck@workspace:packages/plugin-design-deck"],
+
     "@noetic/plugin-powerline": ["@noetic/plugin-powerline@workspace:packages/plugin-powerline"],
 
     "@noetic/web": ["@noetic/web@workspace:packages/web"],
@@ -512,6 +538,8 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.10", "", {}, "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@4.6.0", "", {}, "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
@@ -639,6 +667,8 @@
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
@@ -675,6 +705,8 @@
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
+
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -697,9 +729,15 @@
 
     "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
 
+    "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
+
+    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
+
     "cli-truncate": ["cli-truncate@6.0.0", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-3+YKIUFsohD9MIoOFPFBldjAlnfCmCDcqe6aYGFqlDTRKg80p4wg35L+j83QQ63iOlKRccEkbn8IuM++HsgEjA=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -765,7 +803,9 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "emojilib": ["emojilib@2.4.0", "", {}, "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -782,6 +822,8 @@
     "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
 
     "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
@@ -837,6 +879,8 @@
 
     "fumadocs-ui": ["fumadocs-ui@16.6.17", "", { "dependencies": { "@fumadocs/tailwind": "0.0.3", "@radix-ui/react-accordion": "^1.2.12", "@radix-ui/react-collapsible": "^1.1.12", "@radix-ui/react-dialog": "^1.1.15", "@radix-ui/react-direction": "^1.1.1", "@radix-ui/react-navigation-menu": "^1.2.14", "@radix-ui/react-popover": "^1.1.15", "@radix-ui/react-presence": "^1.1.5", "@radix-ui/react-scroll-area": "^1.2.10", "@radix-ui/react-slot": "^1.2.4", "@radix-ui/react-tabs": "^1.1.13", "class-variance-authority": "^0.7.1", "lucide-react": "^0.577.0", "motion": "^12.36.0", "next-themes": "^0.4.6", "react-medium-image-zoom": "^5.4.1", "react-remove-scroll": "^2.7.2", "rehype-raw": "^7.0.0", "scroll-into-view-if-needed": "^3.1.0", "tailwind-merge": "^3.5.0", "unist-util-visit": "^5.1.0" }, "peerDependencies": { "@takumi-rs/image-response": "*", "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "16.6.17", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0" }, "optionalPeers": ["@takumi-rs/image-response", "@types/mdx", "@types/react", "next"] }, "sha512-RLr1Dsujq3YoOEi4cLu52mZkT8fBJUl1rq4DtVoQWhvk20WYl1aDxlBhMr4guAvG5Malwh6Vy1QJ5KbE/k2E6w=="],
 
+    "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
@@ -874,6 +918,8 @@
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
     "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
+    "highlight.js": ["highlight.js@10.7.3", "", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
@@ -972,6 +1018,10 @@
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "marked-terminal": ["marked-terminal@7.3.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "ansi-regex": "^6.1.0", "chalk": "^5.4.1", "cli-highlight": "^2.1.11", "cli-table3": "^0.6.5", "node-emoji": "^2.2.0", "supports-hyperlinks": "^3.1.0" }, "peerDependencies": { "marked": ">=1 <16" } }, "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -1107,6 +1157,8 @@
 
     "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
@@ -1121,6 +1173,8 @@
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
+    "node-emoji": ["node-emoji@2.2.0", "", { "dependencies": { "@sindresorhus/is": "^4.6.0", "char-regex": "^1.0.2", "emojilib": "^2.4.0", "skin-tone": "^2.0.0" } }, "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw=="],
+
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
     "node-liblzma": ["node-liblzma@2.2.0", "", { "dependencies": { "node-addon-api": "^8.5.0", "node-gyp-build": "^4.8.4" }, "bin": { "nxz": "lib/cli/nxz.js" } }, "sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g=="],
@@ -1128,6 +1182,8 @@
     "node-pty": ["node-pty@1.2.0-beta.11", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-THcUyu1WwdgoIyUvgXOZ70EOMXzheGa0q3tbEb5kUIfKgcpBJ+AJ9Q1kq0bKtYmQzr77usXiTORZTLmAUQlnoQ=="],
 
     "npm-to-yarn": ["npm-to-yarn@3.0.1", "", {}, "sha512-tt6PvKu4WyzPwWUzy/hvPFqn+uwXO0K1ZHka8az3NnrhWJDmSqI8ncWq0fkL0k/lmmi5tAC11FXwXuh0rFbt1A=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
@@ -1147,7 +1203,9 @@
 
     "parse-ms": ["parse-ms@3.0.0", "", {}, "sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw=="],
 
-    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+    "parse5": ["parse5@5.1.1", "", {}, "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
     "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
@@ -1243,6 +1301,8 @@
 
     "remend": ["remend@1.3.0", "", {}, "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw=="],
 
+    "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
+
     "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
 
     "retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
@@ -1272,6 +1332,8 @@
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
 
     "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
+
+    "skin-tone": ["skin-tone@2.0.0", "", { "dependencies": { "unicode-emoji-modifier-base": "^1.0.0" } }, "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA=="],
 
     "skippy": ["skippy@workspace:examples/skippy"],
 
@@ -1323,6 +1385,8 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "supports-hyperlinks": ["supports-hyperlinks@3.2.0", "", { "dependencies": { "has-flag": "^4.0.0", "supports-color": "^7.0.0" } }, "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig=="],
+
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
@@ -1338,6 +1402,10 @@
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
     "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
@@ -1372,6 +1440,8 @@
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unenv": ["unenv@2.0.0-rc.15", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.4", "ohash": "^2.0.11", "pathe": "^2.0.3", "ufo": "^1.5.4" } }, "sha512-J/rEIZU8w6FOfLNz/hNKsnY+fFHWnu9MH4yRbSZF3xbbGHovcetXPs7sD+9p8L6CeNC//I9bhRYAOsBt2u7/OA=="],
+
+    "unicode-emoji-modifier-base": ["unicode-emoji-modifier-base@1.0.0", "", {}, "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -1421,9 +1491,15 @@
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
+    "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+
+    "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
@@ -1463,6 +1539,8 @@
 
     "@noetic/core/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
+    "@noetic/plugin-design-deck/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@noetic/plugin-powerline/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@noetic/web/@types/react": ["@types/react@19.1.6", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q=="],
@@ -1493,6 +1571,16 @@
 
     "@types/diff/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
+    "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "cli-table3/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "discord.js/discord-api-types": ["discord-api-types@0.38.43", "", {}, "sha512-sSoBf/nK6m7BGtw65mi+QBuvEWaHE8MMziFLqWL+gT6ME/BLg34dRSVKS3Husx40uU06bvxUc3/X+D9Y6/zAbw=="],
@@ -1502,6 +1590,8 @@
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "get-source/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
+    "hast-util-raw/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
@@ -1533,6 +1623,8 @@
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
+    "parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
@@ -1542,8 +1634,6 @@
     "seek-bzip/commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
 
     "skippy/@types/node": ["@types/node@22.15.3", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw=="],
-
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "string-width-cjs/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
@@ -1565,6 +1655,8 @@
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "yargs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "@jest/types/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "@microsoft/tui-test/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
@@ -1574,6 +1666,18 @@
     "@microsoft/tui-test/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "cli-highlight/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "cli-table3/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "cli-table3/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "cliui/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -1677,11 +1781,13 @@
 
     "wrangler/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
 
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
-
     "wrap-ansi-cjs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "yargs/string-width/is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "@microsoft/tui-test/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -1689,10 +1795,16 @@
 
     "@microsoft/tui-test/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "cli-table3/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
     "@microsoft/tui-test/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "@microsoft/tui-test/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@microsoft/tui-test/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "@microsoft/tui-test/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
   }
 }

--- a/packages/cli/src/ai/plugin-call-model.ts
+++ b/packages/cli/src/ai/plugin-call-model.ts
@@ -74,10 +74,7 @@ const CompletionSchema = z.object({
  * narrower than the full `typeof fetch` so tests can pass simple async stubs
  * without implementing `preconnect`, etc.
  */
-export type FetchLike = (
-  input: RequestInfo | URL,
-  init?: RequestInit,
-) => Promise<Response>;
+export type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 
 interface CreateCallModelArgs {
   apiKey: string;

--- a/packages/cli/src/ai/plugin-call-model.ts
+++ b/packages/cli/src/ai/plugin-call-model.ts
@@ -1,0 +1,138 @@
+/**
+ * `callModel` helper exposed to plugins via `PluginContext`.
+ *
+ * Uses OpenRouter's OpenAI-compatible chat completions endpoint directly so
+ * the plugin API stays decoupled from the `@openrouter/agent` response-mode
+ * SDK the harness uses. Plugins get a simple "send messages, get text back"
+ * contract suitable for one-shot generation (deck options, interview
+ * follow-ups, etc.).
+ */
+
+import { z } from 'zod';
+
+//#region Types
+
+export type CallModelRole = 'system' | 'user' | 'assistant';
+
+export interface CallModelMessage {
+  role: CallModelRole;
+  content: string;
+}
+
+export interface CallModelInput {
+  messages: ReadonlyArray<CallModelMessage>;
+  /** Override the agent's default model for this call. */
+  model?: string;
+  /** Sampling temperature. Defaults to 0.7. */
+  temperature?: number;
+  /** Optional abort signal. */
+  signal?: AbortSignal;
+}
+
+export interface CallModelResponse {
+  text: string;
+  modelId: string;
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+}
+
+export type CallModel = (input: CallModelInput) => Promise<CallModelResponse>;
+
+//#endregion
+
+//#region Wire schema
+
+const CompletionSchema = z.object({
+  model: z.string().optional(),
+  choices: z
+    .array(
+      z.object({
+        message: z.object({
+          content: z.string().nullable(),
+        }),
+      }),
+    )
+    .min(1),
+  usage: z
+    .object({
+      prompt_tokens: z.number(),
+      completion_tokens: z.number(),
+      total_tokens: z.number(),
+    })
+    .optional(),
+});
+
+//#endregion
+
+//#region Factory
+
+/**
+ * Minimal fetch-like shape accepted by `createCallModel` — intentionally
+ * narrower than the full `typeof fetch` so tests can pass simple async stubs
+ * without implementing `preconnect`, etc.
+ */
+export type FetchLike = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>;
+
+interface CreateCallModelArgs {
+  apiKey: string;
+  defaultModel: string;
+  /** Override the OpenRouter endpoint, mostly for tests. */
+  endpoint?: string;
+  /** Override `fetch` for tests. */
+  fetchFn?: FetchLike;
+}
+
+const DEFAULT_ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
+
+export function createCallModel(args: CreateCallModelArgs): CallModel {
+  const endpoint = args.endpoint ?? DEFAULT_ENDPOINT;
+  const fetchFn = args.fetchFn ?? fetch;
+  return async function callModel(input) {
+    const body = {
+      model: input.model ?? args.defaultModel,
+      messages: input.messages,
+      temperature: input.temperature ?? 0.7,
+    };
+    const response = await fetchFn(endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${args.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+      signal: input.signal,
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`callModel failed: ${response.status} ${response.statusText} ${text}`);
+    }
+    const parsed = CompletionSchema.safeParse(await response.json());
+    if (!parsed.success) {
+      throw new Error(`callModel: malformed response: ${parsed.error.message}`);
+    }
+    const choice = parsed.data.choices[0];
+    if (!choice) {
+      throw new Error('callModel: empty choices array');
+    }
+    const text = choice.message.content ?? '';
+    return {
+      text,
+      modelId: parsed.data.model ?? body.model,
+      usage: parsed.data.usage
+        ? {
+            promptTokens: parsed.data.usage.prompt_tokens,
+            completionTokens: parsed.data.usage.completion_tokens,
+            totalTokens: parsed.data.usage.total_tokens,
+          }
+        : undefined,
+    };
+  };
+}
+
+//#endregion

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -6,6 +6,7 @@
 
 import { createLocalFsAdapter } from '@noetic/core';
 import { discoverConfig, resolvePluginBaseDir } from '../config/discovery.js';
+import { createPluginContextBuilder } from '../plugins/context.js';
 import { loadPlugins } from '../plugins/loader.js';
 import { runAgent } from '../tui/app.js';
 import type { AgentRuntimeConfig } from '../types/config.js';
@@ -15,7 +16,8 @@ const argsConfig = parseArgs(process.argv);
 const discovered = await discoverConfig();
 const baseConfig = discovered?.config ?? argsConfig;
 const pluginBaseDir = discovered ? resolvePluginBaseDir(discovered.sourcePath) : baseConfig.cwd;
-const plugins = await loadPlugins(baseConfig, pluginBaseDir);
+const buildCtx = createPluginContextBuilder(baseConfig);
+const plugins = await loadPlugins(baseConfig, pluginBaseDir, buildCtx);
 
 const runtimeConfig: AgentRuntimeConfig = {
   ...baseConfig,

--- a/packages/cli/src/commands/execute.ts
+++ b/packages/cli/src/commands/execute.ts
@@ -8,6 +8,16 @@ import type { Command, CommandContext, CommandExecutionResult } from './types.js
 
 //#region Execute
 
+export interface ExecuteCommandOptions {
+  /**
+   * Called when a JSX modal command invokes its `onDone` AFTER the modal has
+   * opened — e.g. a deck submit that should post a summary to chat and
+   * dismiss the modal. The App owns this handler so it can mutate chat +
+   * modal state directly; `executeCommand` has no access to React state.
+   */
+  onJsxComplete?: (result: string | undefined) => void;
+}
+
 /**
  * Execute a command and return the result.
  */
@@ -15,8 +25,8 @@ export async function executeCommand(
   command: Command,
   args: string,
   ctx: CommandContext,
+  options: ExecuteCommandOptions = {},
 ): Promise<CommandExecutionResult> {
-  // Check if command is enabled
   if (command.isEnabled && !command.isEnabled()) {
     return {
       type: 'text',
@@ -32,46 +42,26 @@ export async function executeCommand(
 
   if (command.type === 'local-jsx') {
     const mod = await command.load();
-    // For JSX commands, we need to handle two possible outcomes:
-    // 1. The command returns a ReactNode to display as modal
-    // 2. The command calls onDone with optional text result
-    // The first one to resolve wins.
-    return new Promise((resolve) => {
-      let resolved = false;
-      const onDone = (result?: string): void => {
-        if (resolved) {
-          return;
-        }
-        resolved = true;
-        if (result) {
-          resolve({
-            type: 'text',
-            value: result,
-          });
-        } else {
-          resolve({
-            type: 'skip',
-          });
-        }
-      };
-      mod.call(onDone, ctx, args).then((node) => {
-        if (resolved) {
-          return;
-        }
-        resolved = true;
-        // Return as modal - command name is capitalized
-        const displayName = command.name.charAt(0).toUpperCase() + command.name.slice(1);
-        resolve({
-          type: 'modal',
-          node,
-          commandName: command.name,
-          dismissMessage: `${displayName} dialog dismissed`,
-        });
-      });
-    });
+    let modalOpened = false;
+    const onDone = (result?: string): void => {
+      // Before the modal opens, onDone isn't yet meaningful — the command
+      // should return its node synchronously. After the modal opens, this
+      // forwards completion to the App so chat + modal state can update.
+      if (modalOpened) {
+        options.onJsxComplete?.(result);
+      }
+    };
+    const node = await mod.call(onDone, ctx, args);
+    modalOpened = true;
+    const displayName = command.name.charAt(0).toUpperCase() + command.name.slice(1);
+    return {
+      type: 'modal',
+      node,
+      commandName: command.name,
+      dismissMessage: `${displayName} dialog dismissed`,
+    };
   }
 
-  // Exhaustive check - should never reach here
   const _exhaustive: never = command;
   return _exhaustive;
 }

--- a/packages/cli/src/commands/execute.ts
+++ b/packages/cli/src/commands/execute.ts
@@ -18,15 +18,19 @@ export interface ExecuteCommandOptions {
   onJsxComplete?: (result: string | undefined) => void;
 }
 
+export interface ExecuteCommandArgs {
+  command: Command;
+  args: string;
+  ctx: CommandContext;
+  options?: ExecuteCommandOptions;
+}
+
 /**
  * Execute a command and return the result.
  */
-export async function executeCommand(
-  command: Command,
-  args: string,
-  ctx: CommandContext,
-  options: ExecuteCommandOptions = {},
-): Promise<CommandExecutionResult> {
+export async function executeCommand(input: ExecuteCommandArgs): Promise<CommandExecutionResult> {
+  const { command, args: commandArgs, ctx, options = {} } = input;
+
   if (command.isEnabled && !command.isEnabled()) {
     return {
       type: 'text',
@@ -36,7 +40,7 @@ export async function executeCommand(
 
   if (command.type === 'local') {
     const mod = await command.load();
-    const result = await mod.call(args, ctx);
+    const result = await mod.call(commandArgs, ctx);
     return result;
   }
 
@@ -51,7 +55,7 @@ export async function executeCommand(
         options.onJsxComplete?.(result);
       }
     };
-    const node = await mod.call(onDone, ctx, args);
+    const node = await mod.call(onDone, ctx, commandArgs);
     modalOpened = true;
     const displayName = command.name.charAt(0).toUpperCase() + command.name.slice(1);
     return {

--- a/packages/cli/src/harness/factory.ts
+++ b/packages/cli/src/harness/factory.ts
@@ -13,6 +13,7 @@ import {
 
 import { buildSystemPrompt } from '../ai/system-prompt.js';
 import { skillsLayer } from '../memory/skills-layer.js';
+import type { PluginContextBuilder } from '../plugins/context.js';
 import type { NoeticPlugin } from '../plugins/types.js';
 import { buildSkillCatalog } from '../skills/catalog.js';
 import type { SkillDefinition } from '../skills/types.js';
@@ -21,10 +22,13 @@ import type { AgentConfig } from '../types/config.js';
 
 //#region Helpers
 
-async function collectPluginTools(plugins: ReadonlyArray<NoeticPlugin>): Promise<Tool[]> {
+async function collectPluginTools(
+  plugins: ReadonlyArray<NoeticPlugin>,
+  buildCtx: PluginContextBuilder,
+): Promise<Tool[]> {
   const tools: Tool[] = [];
   for (const plugin of plugins) {
-    const pluginTools = await plugin.tools?.();
+    const pluginTools = await plugin.tools?.(buildCtx(plugin.name));
     if (!pluginTools) {
       continue;
     }
@@ -33,10 +37,13 @@ async function collectPluginTools(plugins: ReadonlyArray<NoeticPlugin>): Promise
   return tools;
 }
 
-async function collectPluginMemory(plugins: ReadonlyArray<NoeticPlugin>): Promise<MemoryLayer[]> {
+async function collectPluginMemory(
+  plugins: ReadonlyArray<NoeticPlugin>,
+  buildCtx: PluginContextBuilder,
+): Promise<MemoryLayer[]> {
   const layers: MemoryLayer[] = [];
   for (const plugin of plugins) {
-    const memoryLayers = await plugin.memoryLayers?.();
+    const memoryLayers = await plugin.memoryLayers?.(buildCtx(plugin.name));
     if (!memoryLayers) {
       continue;
     }
@@ -77,6 +84,7 @@ interface CreateAgentHarnessOpts {
   plugins: ReadonlyArray<NoeticPlugin>;
   fs: FsAdapter;
   shell?: ShellAdapter;
+  buildContext: PluginContextBuilder;
 }
 
 /**
@@ -84,15 +92,20 @@ interface CreateAgentHarnessOpts {
  * Returns both the harness and the canonical skill catalog for UI use.
  */
 export async function createAgentHarness(opts: CreateAgentHarnessOpts): Promise<HarnessWithSkills> {
-  const { config, plugins, fs } = opts;
+  const { config, plugins, fs, buildContext } = opts;
   const shell = opts.shell ?? createLocalShellAdapter();
 
   // Build canonical skill catalog (single source of truth)
-  const allSkills = await buildSkillCatalog(config.cwd, plugins, fs);
+  const allSkills = await buildSkillCatalog({
+    cwd: config.cwd,
+    plugins,
+    fs,
+    buildCtx: buildContext,
+  });
 
   // Build tools including skill activation
   const builtinTools = createCodingTools(config.cwd, fs, shell);
-  const pluginTools = await collectPluginTools(plugins);
+  const pluginTools = await collectPluginTools(plugins, buildContext);
   const activateSkill = allSkills.length > 0 ? createActivateSkillTool(allSkills) : null;
 
   const tools = filterTools(
@@ -109,7 +122,7 @@ export async function createAgentHarness(opts: CreateAgentHarnessOpts): Promise<
   );
 
   // Build memory layers including plan and skills layers
-  const pluginMemory = await collectPluginMemory(plugins);
+  const pluginMemory = await collectPluginMemory(plugins, buildContext);
   const memory: MemoryLayer[] = [
     planMemory(),
     workingMemory(),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,11 +2,32 @@
  * @noetic/cli — Coding agent CLI/TUI package.
  */
 
+export type {
+  CallModel,
+  CallModelInput,
+  CallModelMessage,
+  CallModelResponse,
+  CallModelRole,
+} from './ai/plugin-call-model.js';
 export { buildSystemPrompt } from './ai/system-prompt.js';
+export type {
+  Command,
+  CommandBase,
+  CommandContext,
+  CommandExecutionResult,
+  LocalCommand,
+  LocalCommandCall,
+  LocalCommandModule,
+  LocalCommandResult,
+  LocalJsxCommand,
+  LocalJsxCommandCall,
+  LocalJsxCommandModule,
+  LocalJsxCommandOnDone,
+} from './commands/types.js';
 export { discoverConfig, resolvePluginBaseDir } from './config/discovery.js';
 export { createAgentHarness, type HarnessWithSkills } from './harness/factory.js';
 export { disposePlugins, loadPlugins } from './plugins/loader.js';
-export type { FooterContext, NoeticPlugin } from './plugins/types.js';
+export type { FooterContext, NoeticPlugin, PluginContext } from './plugins/types.js';
 export { createCodingTools, createReadOnlyTools } from './tools/index.js';
 export { ResponsesChat, type ResponsesChatProps } from './tui/components/index.js';
 export { FooterContextProvider, useFooterContext } from './tui/footer-context.js';

--- a/packages/cli/src/plugins/context.ts
+++ b/packages/cli/src/plugins/context.ts
@@ -1,0 +1,23 @@
+/**
+ * PluginContext factory. The CLI builds one of these per process and then
+ * stamps out a per-plugin context (with plugin-scoped `dataDir`) on demand.
+ */
+
+import { createCallModel } from '../ai/plugin-call-model.js';
+import type { AgentConfig } from '../types/config.js';
+import { createDataDir, pluginNameToDirSegment } from './data-dir.js';
+import type { PluginContext } from './types.js';
+
+export type PluginContextBuilder = (pluginName: string) => PluginContext;
+
+export function createPluginContextBuilder(config: AgentConfig): PluginContextBuilder {
+  const callModel = createCallModel({
+    apiKey: config.apiKey,
+    defaultModel: config.model,
+  });
+  return (pluginName: string) => ({
+    config,
+    callModel,
+    dataDir: createDataDir(config.cwd, pluginNameToDirSegment(pluginName)),
+  });
+}

--- a/packages/cli/src/plugins/data-dir.ts
+++ b/packages/cli/src/plugins/data-dir.ts
@@ -1,0 +1,44 @@
+/**
+ * Plugin-scoped data directory helper. Each plugin gets:
+ *   - `project` scope → `<cwd>/.noetic/<plugin-name>/`
+ *   - `user` scope    → `~/.noetic/<plugin-name>/`
+ *
+ * Created lazily on first access.
+ */
+
+import { mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export type DataDirScope = 'project' | 'user';
+
+const PLUGIN_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+export function createDataDir(cwd: string, pluginName: string): (scope: DataDirScope) => string {
+  if (!isSafePluginName(pluginName)) {
+    throw new Error(`Invalid plugin name for data dir: ${pluginName}`);
+  }
+  return (scope) => {
+    const base =
+      scope === 'project'
+        ? join(cwd, '.noetic', pluginName)
+        : join(homedir(), '.noetic', pluginName);
+    mkdirSync(base, {
+      recursive: true,
+    });
+    return base;
+  };
+}
+
+/**
+ * Plugins can have slash-prefixed package names (e.g. `@noetic/plugin-foo`).
+ * We normalise to a filesystem-safe segment by stripping the scope.
+ */
+export function pluginNameToDirSegment(pluginName: string): string {
+  const bare = pluginName.startsWith('@') ? pluginName.split('/').slice(1).join('-') : pluginName;
+  return bare.replace(/[^a-zA-Z0-9._-]/g, '-');
+}
+
+function isSafePluginName(name: string): boolean {
+  return PLUGIN_NAME_PATTERN.test(name);
+}

--- a/packages/cli/src/plugins/loader.ts
+++ b/packages/cli/src/plugins/loader.ts
@@ -2,6 +2,7 @@ import { isAbsolute, resolve } from 'node:path';
 import { z } from 'zod';
 
 import type { AgentConfig, PluginSpec } from '../types/config.js';
+import type { PluginContextBuilder } from './context.js';
 import type { NoeticPlugin } from './types.js';
 
 //#region Schemas
@@ -17,36 +18,36 @@ const NoeticPluginSchema = z
     version: z.string(),
     tools: z.unknown().optional(),
     memoryLayers: z.unknown().optional(),
+    skills: z.unknown().optional(),
     initialize: z.unknown().optional(),
     dispose: z.unknown().optional(),
     footer: z.unknown().optional(),
     loadingMessages: z.unknown().optional(),
+    commands: z.unknown().optional(),
   })
   .refine(
     (obj) => {
-      if (obj.tools !== undefined && typeof obj.tools !== 'function') {
-        return false;
-      }
-      if (obj.memoryLayers !== undefined && typeof obj.memoryLayers !== 'function') {
-        return false;
-      }
-      if (obj.initialize !== undefined && typeof obj.initialize !== 'function') {
-        return false;
-      }
-      if (obj.dispose !== undefined && typeof obj.dispose !== 'function') {
-        return false;
-      }
-      if (obj.footer !== undefined && typeof obj.footer !== 'function') {
-        return false;
-      }
-      if (obj.loadingMessages !== undefined && typeof obj.loadingMessages !== 'function') {
-        return false;
+      const fnFields = [
+        'tools',
+        'memoryLayers',
+        'skills',
+        'initialize',
+        'dispose',
+        'footer',
+        'loadingMessages',
+        'commands',
+      ] as const;
+      for (const field of fnFields) {
+        const value = obj[field];
+        if (value !== undefined && typeof value !== 'function') {
+          return false;
+        }
       }
       return true;
     },
     {
       message:
-        'Optional fields (tools, memoryLayers, initialize, dispose, footer, loadingMessages) must be functions if provided',
+        'Optional hook fields (tools, memoryLayers, skills, initialize, dispose, footer, loadingMessages, commands) must be functions if provided',
     },
   );
 
@@ -89,11 +90,12 @@ function resolvePluginPath(spec: PluginSpec, baseDir: string): string {
     return spec;
   }
 
-  if (spec.path) {
-    if (isAbsolute(spec.path)) {
-      return spec.path;
+  const path = typeof spec.path === 'string' ? spec.path : undefined;
+  if (path) {
+    if (isAbsolute(path)) {
+      return path;
     }
-    return resolve(baseDir, spec.path);
+    return resolve(baseDir, path);
   }
 
   return spec.name;
@@ -122,7 +124,11 @@ async function importPlugin(spec: PluginSpec, baseDir: string): Promise<NoeticPl
 
 //#region Public API
 
-export async function loadPlugins(config: AgentConfig, baseDir: string): Promise<NoeticPlugin[]> {
+export async function loadPlugins(
+  config: AgentConfig,
+  baseDir: string,
+  buildContext?: PluginContextBuilder,
+): Promise<NoeticPlugin[]> {
   const plugins: NoeticPlugin[] = [];
   const seenNames = new Set<string>();
 
@@ -132,7 +138,14 @@ export async function loadPlugins(config: AgentConfig, baseDir: string): Promise
       throw new Error(`Duplicate plugin name: ${plugin.name}`);
     }
     seenNames.add(plugin.name);
-    await plugin.initialize?.(config);
+    if (plugin.initialize) {
+      if (!buildContext) {
+        throw new Error(
+          `Plugin ${plugin.name} defines initialize but loadPlugins was called without a context builder`,
+        );
+      }
+      await plugin.initialize(buildContext(plugin.name));
+    }
     plugins.push(plugin);
   }
 

--- a/packages/cli/src/plugins/types.ts
+++ b/packages/cli/src/plugins/types.ts
@@ -1,8 +1,11 @@
 import type { LastLayerUsage, MemoryLayer, Tool } from '@noetic/core';
 import type { ReactNode } from 'react';
 
+import type { CallModel } from '../ai/plugin-call-model.js';
+import type { Command } from '../commands/types.js';
 import type { SkillDefinition } from '../skills/types.js';
 import type { AgentConfig } from '../types/config.js';
+import type { DataDirScope } from './data-dir.js';
 
 //#region Footer extension point
 
@@ -24,13 +27,47 @@ export interface FooterContext {
 
 //#endregion
 
+//#region Plugin context
+
+/**
+ * Capabilities the host CLI injects into every plugin hook. Introducing new
+ * fields on `PluginContext` is additive; existing plugins keep compiling.
+ */
+export interface PluginContext {
+  /** The parsed agent config (model, apiKey, cwd, ...). */
+  config: AgentConfig;
+  /**
+   * Call the configured LLM for one-shot generation (not tool loops). Uses
+   * the same API key as the harness. Plugins that need tool loops should
+   * register tools instead and let the harness drive the turn.
+   */
+  callModel: CallModel;
+  /**
+   * Returns a plugin-scoped data directory, creating it if needed.
+   *  - 'project' → `<cwd>/.noetic/<plugin-name>/`
+   *  - 'user'    → `~/.noetic/<plugin-name>/`
+   */
+  dataDir: (scope: DataDirScope) => string;
+}
+
+//#endregion
+
 export interface NoeticPlugin {
   name: string;
   version: string;
-  tools?: () => ReadonlyArray<Tool> | Promise<ReadonlyArray<Tool>>;
-  memoryLayers?: () => ReadonlyArray<MemoryLayer> | Promise<ReadonlyArray<MemoryLayer>>;
-  skills?: () => ReadonlyArray<SkillDefinition> | Promise<ReadonlyArray<SkillDefinition>>;
-  initialize?: (config: AgentConfig) => Promise<void>;
+  tools?: (ctx: PluginContext) => ReadonlyArray<Tool> | Promise<ReadonlyArray<Tool>>;
+  memoryLayers?: (
+    ctx: PluginContext,
+  ) => ReadonlyArray<MemoryLayer> | Promise<ReadonlyArray<MemoryLayer>>;
+  skills?: (
+    ctx: PluginContext,
+  ) => ReadonlyArray<SkillDefinition> | Promise<ReadonlyArray<SkillDefinition>>;
+  /**
+   * Called once after the plugin loads and before the TUI mounts. Receives
+   * the plugin context so it can cache `callModel`, `dataDir`, etc. for later
+   * use from hooks like `footer`, `commands`, `loadingMessages`.
+   */
+  initialize?: (ctx: PluginContext) => Promise<void>;
   dispose?: () => Promise<void>;
   /**
    * Optional footer component rendered between the chat area and the prompt input.
@@ -43,4 +80,10 @@ export interface NoeticPlugin {
    * default verb. Called once after plugin init; no per-turn calls.
    */
   loadingMessages?: () => ReadonlyArray<string> | Promise<ReadonlyArray<string>>;
+  /**
+   * Optional slash commands contributed by this plugin. Merged into the CLI's
+   * built-in commands with plugin commands appearing after built-ins (so a
+   * plugin can't shadow `/help`, `/context`, etc.).
+   */
+  commands?: (ctx: PluginContext) => ReadonlyArray<Command> | Promise<ReadonlyArray<Command>>;
 }

--- a/packages/cli/src/skills/catalog.ts
+++ b/packages/cli/src/skills/catalog.ts
@@ -6,6 +6,7 @@
  */
 
 import type { FsAdapter } from '@noetic/core';
+import type { PluginContextBuilder } from '../plugins/context.js';
 import type { NoeticPlugin } from '../plugins/types.js';
 
 import { discoverSkills } from './discovery.js';
@@ -16,10 +17,11 @@ import { SkillSource } from './types.js';
 
 async function collectPluginSkills(
   plugins: ReadonlyArray<NoeticPlugin>,
+  buildCtx: PluginContextBuilder,
 ): Promise<SkillDefinition[]> {
   const skills: SkillDefinition[] = [];
   for (const plugin of plugins) {
-    const pluginSkills = await plugin.skills?.();
+    const pluginSkills = await plugin.skills?.(buildCtx(plugin.name));
     if (!pluginSkills) {
       continue;
     }
@@ -44,13 +46,17 @@ async function collectPluginSkills(
  * This is the single source of truth for skill discovery.
  * Filesystem skills have priority over plugin skills with the same name.
  */
-export async function buildSkillCatalog(
-  cwd: string,
-  plugins: ReadonlyArray<NoeticPlugin>,
-  fs: FsAdapter,
-): Promise<SkillDefinition[]> {
+export interface BuildSkillCatalogArgs {
+  cwd: string;
+  plugins: ReadonlyArray<NoeticPlugin>;
+  fs: FsAdapter;
+  buildCtx: PluginContextBuilder;
+}
+
+export async function buildSkillCatalog(args: BuildSkillCatalogArgs): Promise<SkillDefinition[]> {
+  const { cwd, plugins, fs, buildCtx } = args;
   const filesystemSkills = await discoverSkills(cwd, fs);
-  const pluginSkills = await collectPluginSkills(plugins);
+  const pluginSkills = await collectPluginSkills(plugins, buildCtx);
 
   // Merge skills (filesystem skills have priority, they're already deduplicated)
   const skillsByName = new Map<string, SkillDefinition>();

--- a/packages/cli/src/tui/app.tsx
+++ b/packages/cli/src/tui/app.tsx
@@ -351,19 +351,24 @@ function App({ config, plugins }: AppProps): ReactNode {
             };
 
             try {
-              const result = await executeCommand(cmd, parsed.args, ctx, {
-                onJsxComplete: (summary) => {
-                  if (summary) {
-                    setEntries((prev) => [
-                      ...prev,
-                      {
-                        role: 'system',
-                        type: 'info',
-                        content: summary,
-                      } satisfies SystemEntry,
-                    ]);
-                  }
-                  setModal(null);
+              const result = await executeCommand({
+                command: cmd,
+                args: parsed.args,
+                ctx,
+                options: {
+                  onJsxComplete: (summary) => {
+                    if (summary) {
+                      setEntries((prev) => [
+                        ...prev,
+                        {
+                          role: 'system',
+                          type: 'info',
+                          content: summary,
+                        } satisfies SystemEntry,
+                      ]);
+                    }
+                    setModal(null);
+                  },
                 },
               });
               if (result.type === 'text') {

--- a/packages/cli/src/tui/app.tsx
+++ b/packages/cli/src/tui/app.tsx
@@ -11,7 +11,7 @@ import type {
 } from '@noetic/core';
 import { render } from 'ink';
 import type { ReactNode } from 'react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   BUILTIN_COMMANDS,
@@ -23,6 +23,7 @@ import {
 } from '../commands/index.js';
 import type { Command, CommandContext } from '../commands/types.js';
 import { createAgentHarness } from '../harness/factory.js';
+import { createPluginContextBuilder } from '../plugins/context.js';
 import type { FooterContext as FooterContextValue, NoeticPlugin } from '../plugins/types.js';
 import type { SkillDefinition } from '../skills/types.js';
 import type { AgentRuntimeConfig } from '../types/config.js';
@@ -118,6 +119,14 @@ function App({ config, plugins }: AppProps): ReactNode {
   const [status, setStatus] = useState<ChatStatus>('ready');
   const [skills, setSkills] = useState<ReadonlyArray<SkillDefinition>>([]);
   const [modal, setModal] = useState<ModalState | null>(null);
+  const [pluginCommands, setPluginCommands] = useState<ReadonlyArray<Command>>([]);
+
+  const buildCtx = useMemo(
+    () => createPluginContextBuilder(config),
+    [
+      config,
+    ],
+  );
 
   const harnessRef = useRef<AgentHarness | null>(null);
   const lastLayerUsageRef = useRef<LastLayerUsage | undefined>(undefined);
@@ -133,12 +142,45 @@ function App({ config, plugins }: AppProps): ReactNode {
   const entriesRef = useRef(entries);
   entriesRef.current = entries;
 
-  // Built-in commands only - skills are not slash commands
+  // Collect plugin-contributed commands. Done in an effect so a plugin's
+  // commands() can be async (e.g. read prior snapshots from disk).
+  useEffect(() => {
+    let cancelled = false;
+    async function collect(): Promise<void> {
+      const lists = await Promise.all(
+        plugins.map(async (p): Promise<ReadonlyArray<Command>> => {
+          if (!p.commands) {
+            return [];
+          }
+          try {
+            return await p.commands(buildCtx(p.name));
+          } catch {
+            return [];
+          }
+        }),
+      );
+      if (cancelled) {
+        return;
+      }
+      setPluginCommands(lists.flat());
+    }
+    void collect();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    plugins,
+    buildCtx,
+  ]);
+
   const commands = useMemo<Command[]>(
     () => [
       ...BUILTIN_COMMANDS,
+      ...pluginCommands,
     ],
-    [],
+    [
+      pluginCommands,
+    ],
   );
 
   // Convert commands to PromptInput format
@@ -188,6 +230,7 @@ function App({ config, plugins }: AppProps): ReactNode {
       config,
       plugins,
       fs: config.fs,
+      buildContext: buildCtx,
     });
     harnessRef.current = harness;
     memoryLayersRef.current = memoryLayers;
@@ -196,6 +239,7 @@ function App({ config, plugins }: AppProps): ReactNode {
   }, [
     config,
     plugins,
+    buildCtx,
   ]);
 
   const handleSubmit = useCallback(
@@ -221,7 +265,21 @@ function App({ config, plugins }: AppProps): ReactNode {
             };
 
             try {
-              const result = await executeCommand(cmd, parsed.args, ctx);
+              const result = await executeCommand(cmd, parsed.args, ctx, {
+                onJsxComplete: (summary) => {
+                  if (summary) {
+                    setEntries((prev) => [
+                      ...prev,
+                      {
+                        role: 'system',
+                        type: 'info',
+                        content: summary,
+                      } satisfies SystemEntry,
+                    ]);
+                  }
+                  setModal(null);
+                },
+              });
               if (result.type === 'text') {
                 // Show text result as info message (not error)
                 setEntries((prev) => [

--- a/packages/cli/test/data-dir.test.ts
+++ b/packages/cli/test/data-dir.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+import { existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createDataDir, pluginNameToDirSegment } from '../src/plugins/data-dir.js';
+
+describe('pluginNameToDirSegment', () => {
+  it('strips scope prefix', () => {
+    expect(pluginNameToDirSegment('@noetic/plugin-powerline')).toBe('plugin-powerline');
+  });
+
+  it('leaves un-scoped names alone', () => {
+    expect(pluginNameToDirSegment('plain-plugin')).toBe('plain-plugin');
+  });
+
+  it('sanitises spaces and slashes to dashes', () => {
+    expect(pluginNameToDirSegment('weird/one/with spaces')).toBe('weird-one-with-spaces');
+  });
+
+  it('strips scope prefix then sanitises rest', () => {
+    expect(pluginNameToDirSegment('@scope/plugin/sub')).toBe('plugin-sub');
+  });
+});
+
+describe('createDataDir', () => {
+  it('creates a project-scoped dir under cwd/.noetic/<name>', () => {
+    const base = mkdtempSync(join(tmpdir(), 'noetic-dd-'));
+    const dataDir = createDataDir(base, 'plugin-foo');
+    const projectDir = dataDir('project');
+    expect(projectDir).toBe(join(base, '.noetic', 'plugin-foo'));
+    expect(existsSync(projectDir)).toBe(true);
+  });
+
+  it('rejects names with path separators', () => {
+    expect(() => createDataDir('/tmp', '../evil')).toThrow(/Invalid plugin name/);
+  });
+});

--- a/packages/cli/test/harness-factory.test.ts
+++ b/packages/cli/test/harness-factory.test.ts
@@ -5,6 +5,7 @@ import { createLocalFsAdapter } from '@noetic/core';
 import { z } from 'zod';
 
 import { createAgentHarness } from '../src/harness/factory.js';
+import { createPluginContextBuilder } from '../src/plugins/context.js';
 import type { NoeticPlugin } from '../src/plugins/types.js';
 import type { AgentConfig } from '../src/types/config.js';
 
@@ -16,6 +17,8 @@ const baseConfig: AgentConfig = {
   apiKey: 'test-key',
   maxTurns: 5,
 };
+
+const buildContext = createPluginContextBuilder(baseConfig);
 
 function makePluginTool(name: string): Tool {
   return {
@@ -43,6 +46,7 @@ describe('createAgentHarness', () => {
         plugin,
       ],
       fs: testFs,
+      buildContext,
     });
 
     expect(harness).toBeDefined();
@@ -70,6 +74,7 @@ describe('createAgentHarness', () => {
         plugin,
       ],
       fs: testFs,
+      buildContext,
     });
 
     expect(harness).toBeDefined();
@@ -97,6 +102,7 @@ describe('createAgentHarness', () => {
         plugin,
       ],
       fs: testFs,
+      buildContext,
     });
 
     expect(harness).toBeDefined();
@@ -107,6 +113,7 @@ describe('createAgentHarness', () => {
       config: baseConfig,
       plugins: [],
       fs: testFs,
+      buildContext,
     });
 
     expect(skills).toBeDefined();

--- a/packages/cli/test/plugin-call-model.test.ts
+++ b/packages/cli/test/plugin-call-model.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createCallModel } from '../src/ai/plugin-call-model.js';
+
+describe('createCallModel', () => {
+  test('sends bearer auth + body, parses OpenAI-compatible response', async () => {
+    let capturedUrl: string | undefined;
+    let capturedBody: string | undefined;
+    let capturedAuth: string | undefined;
+    const fetchFn = async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      capturedUrl = typeof input === 'string' ? input : input.toString();
+      capturedBody = typeof init?.body === 'string' ? init.body : undefined;
+      const headers = new Headers(init?.headers);
+      capturedAuth = headers.get('authorization') ?? undefined;
+      return new Response(
+        JSON.stringify({
+          model: 'anthropic/claude-sonnet-4',
+          choices: [
+            {
+              message: {
+                content: 'hello world',
+              },
+            },
+          ],
+          usage: {
+            prompt_tokens: 10,
+            completion_tokens: 5,
+            total_tokens: 15,
+          },
+        }),
+        {
+          status: 200,
+        },
+      );
+    };
+
+    const callModel = createCallModel({
+      apiKey: 'sk-test',
+      defaultModel: 'anthropic/claude-sonnet-4',
+      fetchFn,
+    });
+    const result = await callModel({
+      messages: [
+        {
+          role: 'system',
+          content: 'be brief',
+        },
+        {
+          role: 'user',
+          content: 'say hi',
+        },
+      ],
+    });
+
+    expect(result.text).toBe('hello world');
+    expect(result.modelId).toBe('anthropic/claude-sonnet-4');
+    expect(result.usage?.totalTokens).toBe(15);
+    expect(capturedAuth).toBe('Bearer sk-test');
+    expect(capturedUrl).toContain('openrouter.ai');
+    expect(capturedBody).toContain('say hi');
+  });
+
+  test('throws on non-ok response', async () => {
+    const fetchFn = async (): Promise<Response> =>
+      new Response('server oops', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+    const callModel = createCallModel({
+      apiKey: 'k',
+      defaultModel: 'm',
+      fetchFn,
+    });
+    await expect(
+      callModel({
+        messages: [
+          {
+            role: 'user',
+            content: 'x',
+          },
+        ],
+      }),
+    ).rejects.toThrow(/callModel failed/);
+  });
+
+  test('throws on malformed response', async () => {
+    const fetchFn = async (): Promise<Response> =>
+      new Response(
+        JSON.stringify({
+          junk: 'yes',
+        }),
+        {
+          status: 200,
+        },
+      );
+    const callModel = createCallModel({
+      apiKey: 'k',
+      defaultModel: 'm',
+      fetchFn,
+    });
+    await expect(
+      callModel({
+        messages: [
+          {
+            role: 'user',
+            content: 'x',
+          },
+        ],
+      }),
+    ).rejects.toThrow(/malformed response/);
+  });
+});

--- a/packages/cli/test/plugin-loader.test.ts
+++ b/packages/cli/test/plugin-loader.test.ts
@@ -3,7 +3,9 @@ import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { createPluginContextBuilder } from '../src/plugins/context.js';
 import { disposePlugins, loadPlugins } from '../src/plugins/loader.js';
+import type { NoeticPlugin } from '../src/plugins/types.js';
 import type { AgentConfig } from '../src/types/config.js';
 
 const baseConfig: AgentConfig = {
@@ -12,6 +14,8 @@ const baseConfig: AgentConfig = {
   apiKey: 'test-key',
   maxTurns: 3,
 };
+
+const buildCtx = createPluginContextBuilder(baseConfig);
 
 describe('plugin loader', () => {
   it('loads a local plugin module from relative path', async () => {
@@ -37,6 +41,7 @@ describe('plugin loader', () => {
         ],
       },
       dir,
+      buildCtx,
     );
 
     expect(plugins).toHaveLength(1);
@@ -66,6 +71,7 @@ describe('plugin loader', () => {
           ],
         },
         dir,
+        buildCtx,
       ),
     ).rejects.toThrow('Duplicate plugin name');
   });
@@ -96,6 +102,7 @@ describe('plugin loader', () => {
         ],
       },
       dir,
+      buildCtx,
     );
 
     expect(plugins[0]?.name).toBe('with-ui');
@@ -126,6 +133,7 @@ describe('plugin loader', () => {
           ],
         },
         dir,
+        buildCtx,
       ),
     ).rejects.toThrow('Invalid plugin');
   });
@@ -149,6 +157,7 @@ describe('plugin loader', () => {
         ],
       },
       process.cwd(),
+      buildCtx,
     );
 
     expect(plugins).toHaveLength(1);
@@ -157,6 +166,69 @@ describe('plugin loader', () => {
     expect(initCalls).toEqual([
       'inline-plugin',
     ]);
+  });
+
+  it('passes a PluginContext into initialize', async () => {
+    let receivedCtx: unknown = null;
+    const inspector: NoeticPlugin = {
+      name: 'ctx-inspector',
+      version: '1.0.0',
+      initialize: async (ctx) => {
+        receivedCtx = ctx;
+      },
+    };
+    await loadPlugins(
+      {
+        ...baseConfig,
+        plugins: [
+          inspector,
+        ],
+      },
+      process.cwd(),
+      buildCtx,
+    );
+    expect(receivedCtx).not.toBeNull();
+    if (
+      receivedCtx !== null &&
+      typeof receivedCtx === 'object' &&
+      'config' in receivedCtx &&
+      'callModel' in receivedCtx &&
+      'dataDir' in receivedCtx
+    ) {
+      expect(typeof receivedCtx.callModel).toBe('function');
+      expect(typeof receivedCtx.dataDir).toBe('function');
+    } else {
+      throw new Error('ctx missing expected shape');
+    }
+  });
+
+  it('accepts plugins that provide commands', async () => {
+    const plugins = await loadPlugins(
+      {
+        ...baseConfig,
+        plugins: [
+          {
+            name: 'with-commands',
+            version: '1.0.0',
+            commands: () => [
+              {
+                name: 'my-cmd',
+                description: 'test',
+                type: 'local',
+                load: async () => ({
+                  call: async () => ({
+                    type: 'skip',
+                  }),
+                }),
+              },
+            ],
+          },
+        ],
+      },
+      process.cwd(),
+      buildCtx,
+    );
+    expect(typeof plugins[0]?.commands).toBe('function');
   });
 
   it('disposes plugins in reverse order', async () => {

--- a/packages/plugin-design-deck/package.json
+++ b/packages/plugin-design-deck/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@noetic/plugin-design-deck",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.tsx",
+  "types": "src/index.tsx",
+  "dependencies": {
+    "@noetic/cli": "workspace:*",
+    "cli-highlight": "^2.1.11",
+    "marked": "^15.0.7",
+    "marked-terminal": "^7.3.0",
+    "zod": "^4.0.0"
+  },
+  "peerDependencies": {
+    "ink": "^7.0.0",
+    "react": "^19.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "bun-types": "latest",
+    "ink": "^7.0.0",
+    "ink-text-input": "^6.0.0",
+    "react": "^19.2.0"
+  },
+  "scripts": {
+    "test": "bun test test/*.test.ts",
+    "test:coverage": "bun test test/*.test.ts --coverage --coverage-reporter=text --coverage-reporter=json",
+    "typecheck": "bunx tsc --noEmit",
+    "lint": "bunx biome check .",
+    "lint:fix": "bunx biome check --fix ."
+  }
+}

--- a/packages/plugin-design-deck/src/commands/deck-discover.tsx
+++ b/packages/plugin-design-deck/src/commands/deck-discover.tsx
@@ -1,0 +1,35 @@
+import type { Command, PluginContext } from '@noetic/cli';
+import type { ReactNode } from 'react';
+
+import type { DesignDeckOptions } from '../options.js';
+import { DiscoverModal } from '../ui/discover-modal.js';
+
+interface Deps {
+  ctx: PluginContext;
+  options: DesignDeckOptions;
+}
+
+export function deckDiscoverCommand({ ctx, options }: Deps): Command {
+  return {
+    name: 'deck-discover',
+    description: 'Interview-driven deck: answer a few questions, get a deck',
+    type: 'local-jsx',
+    load: async () => ({
+      call: async (onDone: (result?: string) => void): Promise<ReactNode> => {
+        const dataDir = ctx.dataDir('project');
+        return (
+          <DiscoverModal
+            callModel={ctx.callModel}
+            dataDir={dataDir}
+            generateCount={options.generateCount}
+            maxOptionsPerSlide={options.maxOptionsPerSlide}
+            autoSaveOnSubmit={options.autoSaveOnSubmit}
+            autoSaveOnCancel={options.autoSaveOnCancel}
+            generateModel={options.generateModel}
+            onDone={(summary) => onDone(summary)}
+          />
+        );
+      },
+    }),
+  };
+}

--- a/packages/plugin-design-deck/src/commands/deck.tsx
+++ b/packages/plugin-design-deck/src/commands/deck.tsx
@@ -1,0 +1,64 @@
+import type { Command, PluginContext } from '@noetic/cli';
+import type { ReactNode } from 'react';
+
+import type { DesignDeckOptions } from '../options.js';
+import { DeckModal } from '../ui/deck-modal.js';
+import { LoaderModal } from '../ui/loader-modal.js';
+
+interface Deps {
+  ctx: PluginContext;
+  options: DesignDeckOptions;
+}
+
+export function deckCommand({ ctx, options }: Deps): Command {
+  return {
+    name: 'deck',
+    description: 'Open a design deck to pick one option per slide',
+    type: 'local-jsx',
+    load: async () => ({
+      call: async (
+        onDone: (result?: string) => void,
+        _cmdCtx,
+        args: string,
+      ): Promise<ReactNode> => {
+        const topic = args.trim();
+        const dataDir = ctx.dataDir('project');
+        const sharedProps = {
+          callModel: ctx.callModel,
+          dataDir,
+          generateCount: options.generateCount,
+          maxOptionsPerSlide: options.maxOptionsPerSlide,
+          autoSaveOnSubmit: options.autoSaveOnSubmit,
+          autoSaveOnCancel: options.autoSaveOnCancel,
+          generateModel: options.generateModel,
+          onDone: (summary: string) => onDone(summary),
+        };
+        if (topic.length === 0) {
+          return (
+            <DeckModal
+              {...sharedProps}
+              deck={{
+                title: 'Empty deck',
+                slides: [
+                  {
+                    id: 'topic-missing',
+                    title: 'Provide a topic',
+                    context: 'Run `/deck <topic>` or try `/deck-discover`.',
+                    options: [
+                      {
+                        label: 'OK',
+                        description: 'Close this deck.',
+                        previewBlocks: [],
+                      },
+                    ],
+                  },
+                ],
+              }}
+            />
+          );
+        }
+        return <LoaderModal {...sharedProps} topic={topic} />;
+      },
+    }),
+  };
+}

--- a/packages/plugin-design-deck/src/generate/build-deck.ts
+++ b/packages/plugin-design-deck/src/generate/build-deck.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import type { CallModel } from '@noetic/cli';
+import type { Deck } from '../types.js';
+import { DeckSchema } from '../types.js';
+import { extractJson } from './shared.js';
+
+const PROMPT_URL = new URL('../prompts/deck.md', import.meta.url);
+
+interface BuildDeckArgs {
+  callModel: CallModel;
+  topic: string;
+  model?: string;
+}
+
+export async function buildDeck(args: BuildDeckArgs): Promise<Deck> {
+  const systemPrompt = readFileSync(PROMPT_URL, 'utf8');
+  const response = await args.callModel({
+    messages: [
+      {
+        role: 'system',
+        content: systemPrompt,
+      },
+      {
+        role: 'user',
+        content: `Topic: ${args.topic}\n\nProduce the deck now.`,
+      },
+    ],
+    model: args.model,
+    temperature: 0.7,
+  });
+  const parsed = DeckSchema.safeParse(extractJson(response.text));
+  if (!parsed.success) {
+    throw new Error(`Deck generation failed schema check: ${parsed.error.message}`);
+  }
+  return parsed.data;
+}

--- a/packages/plugin-design-deck/src/generate/discover.ts
+++ b/packages/plugin-design-deck/src/generate/discover.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import type { CallModel, CallModelMessage } from '@noetic/cli';
+import type { Deck } from '../types.js';
+import { DeckSchema } from '../types.js';
+import { extractJson } from './shared.js';
+
+const PROMPT_URL = new URL('../prompts/deck-discover.md', import.meta.url);
+
+export interface DiscoverTurn {
+  question: string;
+  answer: string;
+}
+
+interface NextArgs {
+  callModel: CallModel;
+  history: ReadonlyArray<DiscoverTurn>;
+  model?: string;
+}
+
+export type DiscoverResult =
+  | {
+      kind: 'question';
+      question: string;
+    }
+  | {
+      kind: 'deck';
+      deck: Deck;
+    };
+
+export async function nextDiscoverTurn(args: NextArgs): Promise<DiscoverResult> {
+  const systemPrompt = readFileSync(PROMPT_URL, 'utf8');
+  const messages: CallModelMessage[] = [
+    {
+      role: 'system',
+      content: systemPrompt,
+    },
+  ];
+  for (const turn of args.history) {
+    messages.push({
+      role: 'assistant',
+      content: turn.question,
+    });
+    messages.push({
+      role: 'user',
+      content: turn.answer,
+    });
+  }
+  if (args.history.length === 0) {
+    messages.push({
+      role: 'user',
+      content: 'Begin the interview. Ask your first question.',
+    });
+  }
+  const response = await args.callModel({
+    messages,
+    model: args.model,
+    temperature: 0.5,
+  });
+  const text = response.text.trim();
+  const maybeJson = extractJson(text);
+  const asDeck = DeckSchema.safeParse(maybeJson);
+  if (asDeck.success) {
+    return {
+      kind: 'deck',
+      deck: asDeck.data,
+    };
+  }
+  return {
+    kind: 'question',
+    question: text,
+  };
+}

--- a/packages/plugin-design-deck/src/generate/more-options.ts
+++ b/packages/plugin-design-deck/src/generate/more-options.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import type { CallModel } from '@noetic/cli';
+import { z } from 'zod';
+import type { DeckOption, Slide } from '../types.js';
+import { OptionSchema } from '../types.js';
+import { extractJson } from './shared.js';
+
+const PROMPT_URL = new URL('../prompts/more-options.md', import.meta.url);
+
+const OptionArraySchema = z.array(OptionSchema).min(1);
+
+interface MoreOptionsArgs {
+  callModel: CallModel;
+  slide: Slide;
+  count: number;
+  model?: string;
+}
+
+export async function generateMoreOptions(args: MoreOptionsArgs): Promise<DeckOption[]> {
+  const systemPrompt = readFileSync(PROMPT_URL, 'utf8');
+  const existingLabels = args.slide.options.map((o) => `- ${o.label}: ${o.description}`).join('\n');
+  const user = [
+    `Slide title: ${args.slide.title}`,
+    `Slide context: ${args.slide.context}`,
+    'Existing options:',
+    existingLabels,
+    `Produce ${args.count} new distinct option(s). JSON array only.`,
+  ].join('\n\n');
+  const response = await args.callModel({
+    messages: [
+      {
+        role: 'system',
+        content: systemPrompt,
+      },
+      {
+        role: 'user',
+        content: user,
+      },
+    ],
+    model: args.model,
+    temperature: 0.9,
+  });
+  const parsed = OptionArraySchema.safeParse(extractJson(response.text));
+  if (!parsed.success) {
+    throw new Error(`More-options generation failed schema check: ${parsed.error.message}`);
+  }
+  return parsed.data.slice(0, args.count);
+}

--- a/packages/plugin-design-deck/src/generate/shared.ts
+++ b/packages/plugin-design-deck/src/generate/shared.ts
@@ -1,0 +1,47 @@
+/**
+ * Parse JSON out of an LLM response that may or may not be wrapped in a
+ * ```json fence. Returns `null` if no valid JSON can be extracted.
+ */
+export function extractJson(raw: string): unknown {
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/);
+  const candidate = fenced?.[1]?.trim() ?? trimmed;
+  try {
+    return JSON.parse(candidate);
+  } catch {
+    // Last-chance: sometimes the model emits text before/after JSON. Try the
+    // first { or [ through the matching last } or ].
+    const start = indexOfFirst(candidate, '{', '[');
+    const end = indexOfLast(candidate, '}', ']');
+    if (start < 0 || end <= start) {
+      return null;
+    }
+    try {
+      return JSON.parse(candidate.slice(start, end + 1));
+    } catch {
+      return null;
+    }
+  }
+}
+
+function indexOfFirst(source: string, ...chars: string[]): number {
+  let best = -1;
+  for (const c of chars) {
+    const i = source.indexOf(c);
+    if (i >= 0 && (best < 0 || i < best)) {
+      best = i;
+    }
+  }
+  return best;
+}
+
+function indexOfLast(source: string, ...chars: string[]): number {
+  let best = -1;
+  for (const c of chars) {
+    const i = source.lastIndexOf(c);
+    if (i > best) {
+      best = i;
+    }
+  }
+  return best;
+}

--- a/packages/plugin-design-deck/src/index.tsx
+++ b/packages/plugin-design-deck/src/index.tsx
@@ -1,0 +1,57 @@
+/**
+ * @noetic/plugin-design-deck
+ *
+ * Interactive visual-decision modal for the Noetic CLI. Renders a deck of
+ * slides where the user picks one option per slide, then returns the
+ * selections to chat so the next agent turn can act on them.
+ *
+ * Ported (UI-layer rewritten) from https://github.com/nicobailon/pi-design-deck.
+ *
+ * Usage (in noetic.config.ts):
+ * ```ts
+ * import designDeck from '@noetic/plugin-design-deck';
+ *
+ * export default {
+ *   plugins: [ designDeck({ generateCount: 3 }) ],
+ * };
+ * ```
+ */
+
+import type { NoeticPlugin } from '@noetic/cli';
+
+import { deckCommand } from './commands/deck.js';
+import { deckDiscoverCommand } from './commands/deck-discover.js';
+import type { DesignDeckInput } from './options.js';
+import { DesignDeckInputSchema, DesignDeckOptionsSchema } from './options.js';
+
+const NAME = '@noetic/plugin-design-deck';
+const VERSION = '0.1.0';
+
+export default function designDeck(userInput: DesignDeckInput = {}): NoeticPlugin {
+  const inputParsed = DesignDeckInputSchema.parse(userInput);
+  const options = DesignDeckOptionsSchema.parse(inputParsed);
+
+  return {
+    name: NAME,
+    version: VERSION,
+    commands: (ctx) => [
+      deckCommand({
+        ctx,
+        options,
+      }),
+      deckDiscoverCommand({
+        ctx,
+        options,
+      }),
+    ],
+  };
+}
+
+export type { DesignDeckInput, DesignDeckOptions } from './options.js';
+export type {
+  Deck,
+  DeckOption,
+  DeckSelections,
+  PreviewBlock,
+  Slide,
+} from './types.js';

--- a/packages/plugin-design-deck/src/marked-terminal.d.ts
+++ b/packages/plugin-design-deck/src/marked-terminal.d.ts
@@ -1,0 +1,20 @@
+/**
+ * Minimal ambient declaration for marked-terminal v7.
+ * The @types/marked-terminal package is stale (v6) and miscompiles against
+ * marked v15. At runtime `markedTerminal()` returns a MarkedExtension that
+ * `marked.use()` accepts — we only need that contract.
+ */
+declare module 'marked-terminal' {
+  import type { MarkedExtension } from 'marked';
+
+  export interface MarkedTerminalOptions {
+    reflowText?: boolean;
+    width?: number;
+    [key: string]: unknown;
+  }
+
+  export function markedTerminal(
+    options?: MarkedTerminalOptions,
+    highlightOptions?: Record<string, unknown>,
+  ): MarkedExtension;
+}

--- a/packages/plugin-design-deck/src/options.ts
+++ b/packages/plugin-design-deck/src/options.ts
@@ -1,0 +1,24 @@
+/**
+ * Plugin option schema. Parsed once when the plugin factory is called from the
+ * user's `noetic.config.ts`.
+ */
+
+import { z } from 'zod';
+
+export const DesignDeckOptionsSchema = z.object({
+  /** How many options to request per `G` generate-more press. */
+  generateCount: z.number().int().positive().max(12).default(3),
+  /** Maximum total options per slide; generate-more caps here. */
+  maxOptionsPerSlide: z.number().int().positive().max(20).default(9),
+  /** Write a snapshot even when the user cancels the deck. */
+  autoSaveOnCancel: z.boolean().default(true),
+  /** Write a snapshot when the user submits. */
+  autoSaveOnSubmit: z.boolean().default(true),
+  /** Override the model used for in-modal generation (defaults to agent's model). */
+  generateModel: z.string().optional(),
+});
+
+export type DesignDeckOptions = z.infer<typeof DesignDeckOptionsSchema>;
+export type DesignDeckInput = z.input<typeof DesignDeckOptionsSchema>;
+
+export const DesignDeckInputSchema = DesignDeckOptionsSchema.partial().default(() => ({}));

--- a/packages/plugin-design-deck/src/prompts/deck-discover.md
+++ b/packages/plugin-design-deck/src/prompts/deck-discover.md
@@ -1,0 +1,15 @@
+# Deck Discovery Interviewer
+
+Phase 1 (interview): You ask 3–5 short, concrete questions to understand what
+the user is designing. Ask ONE question per turn. Never ask the same question
+twice. Keep each question under 20 words. Do not answer for the user.
+
+Phase 2 (generate): When the user replies with the literal word `DONE` (or
+you have enough info after 5 questions), switch to generate mode and produce
+a deck as strict JSON — same schema as the Design Deck Author prompt. No
+prose outside the JSON.
+
+Output contract:
+- While interviewing: return a single plain-text question, nothing else.
+- When generating the deck: return only JSON matching the DeckSchema.
+- Never mix prose and JSON.

--- a/packages/plugin-design-deck/src/prompts/deck.md
+++ b/packages/plugin-design-deck/src/prompts/deck.md
@@ -1,0 +1,42 @@
+# Design Deck Author
+
+You design a "deck" — a set of slides where each slide is one decision the
+user must make, with 2–4 concrete options. The user picks one per slide.
+
+Produce strict JSON matching this schema. No prose outside the JSON.
+
+```
+{
+  "title": "<deck title, 3-8 words>",
+  "slides": [
+    {
+      "id": "<kebab-case unique id>",
+      "title": "<slide question in 3-8 words>",
+      "context": "<one sentence context>",
+      "columns": 2 | 3 | 4,
+      "options": [
+        {
+          "label": "<option name, 1-3 words>",
+          "description": "<1 sentence tradeoff summary>",
+          "aside": "<optional extra note, may contain \\n>",
+          "recommended": true | false,
+          "previewBlocks": [
+            { "type": "text", "body": "..." },
+            { "type": "code", "language": "ts", "source": "..." },
+            { "type": "markdown", "body": "..." },
+            { "type": "ascii", "body": "..." }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+Rules:
+- 2 to 6 slides.
+- 2 to 4 options per slide.
+- At most one option per slide marked `recommended: true`.
+- `previewBlocks` is 0 to 3 blocks; prefer one short code or markdown block
+  that demonstrates the option concretely.
+- Valid JSON only. No trailing commas. No comments.

--- a/packages/plugin-design-deck/src/prompts/more-options.md
+++ b/packages/plugin-design-deck/src/prompts/more-options.md
@@ -1,0 +1,22 @@
+# More Options Author
+
+You add more options to an existing slide in a design deck. Respond with
+strict JSON — an array of option objects matching this schema:
+
+```
+[
+  {
+    "label": "<1-3 words, distinct from existing labels>",
+    "description": "<1 sentence tradeoff summary>",
+    "aside": "<optional>",
+    "recommended": false,
+    "previewBlocks": [...]
+  }
+]
+```
+
+Rules:
+- Return exactly the number of options requested.
+- New options must differ materially from the existing set.
+- Do not set `recommended: true` unless the new option is a clear win.
+- Valid JSON array only. No prose.

--- a/packages/plugin-design-deck/src/snapshot.ts
+++ b/packages/plugin-design-deck/src/snapshot.ts
@@ -1,0 +1,126 @@
+/**
+ * Snapshot persistence for design decks. Each snapshot is a directory
+ * `<dataDir>/<slug>-<ISO date>[ -submitted | -cancelled ]/` containing:
+ *  - deck.json       — full Deck + selections + metadata
+ *  - summary.md      — human-readable Markdown summary of the run
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { Deck, DeckSelections } from './types.js';
+
+const MAX_SLUG_LEN = 60;
+
+export type SnapshotStatus = 'submitted' | 'cancelled';
+
+export interface SnapshotRecord {
+  version: 1;
+  at: string;
+  status: SnapshotStatus;
+  deck: Deck;
+  selections: DeckSelections;
+}
+
+interface WriteArgs {
+  dataDir: string;
+  deck: Deck;
+  selections: DeckSelections;
+  status: SnapshotStatus;
+  now?: Date;
+}
+
+export interface WriteResult {
+  dir: string;
+  jsonPath: string;
+  summaryPath: string;
+}
+
+export function writeSnapshot(args: WriteArgs): WriteResult {
+  const now = args.now ?? new Date();
+  const slug = slugify(args.deck.title);
+  const stamp = now.toISOString().replace(/[:.]/g, '-');
+  const dirName = `${slug}-${stamp}-${args.status}`;
+  const dir = join(args.dataDir, dirName);
+  mkdirSync(dir, {
+    recursive: true,
+  });
+  const record: SnapshotRecord = {
+    version: 1,
+    at: now.toISOString(),
+    status: args.status,
+    deck: args.deck,
+    selections: args.selections,
+  };
+  const jsonPath = join(dir, 'deck.json');
+  const summaryPath = join(dir, 'summary.md');
+  writeFileSync(jsonPath, JSON.stringify(record, null, 2));
+  writeFileSync(summaryPath, buildSummary(record));
+  return {
+    dir,
+    jsonPath,
+    summaryPath,
+  };
+}
+
+export function readSnapshot(jsonPath: string): SnapshotRecord {
+  const raw = readFileSync(jsonPath, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!isSnapshotRecord(parsed)) {
+    throw new Error(`Invalid snapshot at ${jsonPath}`);
+  }
+  return parsed;
+}
+
+export function slugify(input: string): string {
+  const cleaned = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  const base = cleaned.length > 0 ? cleaned : 'deck';
+  return base.slice(0, MAX_SLUG_LEN);
+}
+
+function buildSummary(record: SnapshotRecord): string {
+  const lines: string[] = [
+    `# ${record.deck.title}`,
+    '',
+    `- Status: **${record.status}**`,
+    `- At: ${record.at}`,
+    `- Slides: ${record.deck.slides.length}`,
+    `- Selections: ${Object.keys(record.selections).length}`,
+    '',
+    '## Selections',
+    '',
+  ];
+  for (const slide of record.deck.slides) {
+    const chosen = record.selections[slide.id];
+    lines.push(`- **${slide.title}** — ${chosen ?? '_(none)_'}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function isSnapshotRecord(value: unknown): value is SnapshotRecord {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  if (
+    !('version' in value) ||
+    !('at' in value) ||
+    !('status' in value) ||
+    !('deck' in value) ||
+    !('selections' in value)
+  ) {
+    return false;
+  }
+  const status = value.status;
+  return (
+    value.version === 1 &&
+    typeof value.at === 'string' &&
+    (status === 'submitted' || status === 'cancelled') &&
+    typeof value.deck === 'object' &&
+    value.deck !== null &&
+    typeof value.selections === 'object' &&
+    value.selections !== null
+  );
+}

--- a/packages/plugin-design-deck/src/types.ts
+++ b/packages/plugin-design-deck/src/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Deck data model. Ink-focused subset of pi-design-deck's schema — no
+ * mermaid/html/image preview blocks (no DOM in a terminal). Unknown block
+ * types stay parseable so forward-compat decks from pi don't crash; the UI
+ * renders a muted `[unsupported: {type}]` placeholder for them instead.
+ */
+
+import { z } from 'zod';
+
+const KnownPreviewBlockSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('text'),
+    body: z.string(),
+  }),
+  z.object({
+    type: z.literal('code'),
+    language: z.string().default('text'),
+    source: z.string(),
+  }),
+  z.object({
+    type: z.literal('markdown'),
+    body: z.string(),
+  }),
+  z.object({
+    type: z.literal('ascii'),
+    body: z.string(),
+  }),
+]);
+
+const UnsupportedPreviewBlockSchema = z
+  .object({
+    type: z.string(),
+  })
+  .passthrough();
+
+export const PreviewBlockSchema = z.union([
+  KnownPreviewBlockSchema,
+  UnsupportedPreviewBlockSchema,
+]);
+
+export type KnownPreviewBlock = z.infer<typeof KnownPreviewBlockSchema>;
+export type PreviewBlock = z.infer<typeof PreviewBlockSchema>;
+
+export const OptionSchema = z.object({
+  label: z.string().min(1),
+  description: z.string().default(''),
+  aside: z.string().optional(),
+  recommended: z.boolean().optional(),
+  previewBlocks: z.array(PreviewBlockSchema).default([]),
+});
+
+export type DeckOption = z.infer<typeof OptionSchema>;
+
+export const SlideSchema = z.object({
+  id: z.string().min(1),
+  title: z.string().min(1),
+  context: z.string().default(''),
+  columns: z
+    .union([
+      z.literal(1),
+      z.literal(2),
+      z.literal(3),
+      z.literal(4),
+    ])
+    .optional(),
+  options: z.array(OptionSchema).min(1),
+});
+
+export type Slide = z.infer<typeof SlideSchema>;
+
+export const DeckSchema = z.object({
+  title: z.string().min(1),
+  slides: z.array(SlideSchema).min(1),
+});
+
+export type Deck = z.infer<typeof DeckSchema>;
+
+export interface DeckSelections {
+  [slideId: string]: string;
+}
+
+/** Narrowing helper for the preview-block discriminated union. */
+export function isKnownPreviewBlock(block: PreviewBlock): block is KnownPreviewBlock {
+  return (
+    block.type === 'text' ||
+    block.type === 'code' ||
+    block.type === 'markdown' ||
+    block.type === 'ascii'
+  );
+}

--- a/packages/plugin-design-deck/src/ui/ascii-block.tsx
+++ b/packages/plugin-design-deck/src/ui/ascii-block.tsx
@@ -1,0 +1,25 @@
+import { Box, Text } from 'ink';
+import type { ReactNode } from 'react';
+
+interface AsciiBlockProps {
+  body: string;
+  maxLines?: number;
+}
+
+const MAX_LINES = 16;
+
+export function AsciiBlock({ body, maxLines = MAX_LINES }: AsciiBlockProps): ReactNode {
+  const lines = body.split('\n');
+  const hidden = lines.length > maxLines ? lines.length - maxLines : 0;
+  const visible = hidden > 0 ? lines.slice(0, maxLines).join('\n') : body;
+  return (
+    <Box flexDirection="column" borderStyle="round" borderDimColor paddingX={1}>
+      <Text>{visible}</Text>
+      {hidden > 0 ? (
+        <Text dimColor>
+          … {hidden} more line{hidden === 1 ? '' : 's'}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/plugin-design-deck/src/ui/code-block.tsx
+++ b/packages/plugin-design-deck/src/ui/code-block.tsx
@@ -1,0 +1,58 @@
+import { highlight, supportsLanguage } from 'cli-highlight';
+import { Box, Text } from 'ink';
+import type { ReactNode } from 'react';
+
+const MAX_LINES = 16;
+
+interface CodeBlockProps {
+  language: string;
+  source: string;
+  maxLines?: number;
+}
+
+export function CodeBlock({ language, source, maxLines = MAX_LINES }: CodeBlockProps): ReactNode {
+  const lang = supportsLanguage(language) ? language : 'text';
+  const { lines, hidden } = truncate(source, maxLines);
+  const highlighted = safeHighlight(lines.join('\n'), lang);
+  return (
+    <Box flexDirection="column" borderStyle="round" borderDimColor paddingX={1}>
+      <Text>{highlighted}</Text>
+      {hidden > 0 ? (
+        <Text dimColor>
+          … {hidden} more line{hidden === 1 ? '' : 's'}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+function truncate(
+  source: string,
+  maxLines: number,
+): {
+  lines: string[];
+  hidden: number;
+} {
+  const all = source.split('\n');
+  if (all.length <= maxLines) {
+    return {
+      lines: all,
+      hidden: 0,
+    };
+  }
+  return {
+    lines: all.slice(0, maxLines),
+    hidden: all.length - maxLines,
+  };
+}
+
+function safeHighlight(source: string, language: string): string {
+  try {
+    return highlight(source, {
+      language,
+      ignoreIllegals: true,
+    });
+  } catch {
+    return source;
+  }
+}

--- a/packages/plugin-design-deck/src/ui/deck-modal.tsx
+++ b/packages/plugin-design-deck/src/ui/deck-modal.tsx
@@ -1,0 +1,506 @@
+import type { CallModel } from '@noetic/cli';
+import { Box, Text, useInput } from 'ink';
+import type { ReactNode } from 'react';
+import { useCallback, useReducer } from 'react';
+
+import { generateMoreOptions } from '../generate/more-options.js';
+import type { WriteResult } from '../snapshot.js';
+import { writeSnapshot } from '../snapshot.js';
+import type { Deck, DeckOption, DeckSelections } from '../types.js';
+import { ShortcutsHint } from './shortcuts-hint.js';
+import { SlideView } from './slide-view.js';
+
+//#region State
+
+interface DeckState {
+  deck: Deck;
+  slideIndex: number;
+  focusIndex: number;
+  selections: DeckSelections;
+  generating: boolean;
+  error: string | null;
+  confirmingCancel: boolean;
+  lastSnapshot: WriteResult | null;
+}
+
+type DeckAction =
+  | {
+      type: 'focus-prev';
+    }
+  | {
+      type: 'focus-next';
+    }
+  | {
+      type: 'slide-prev';
+    }
+  | {
+      type: 'slide-next';
+    }
+  | {
+      type: 'select';
+      label: string;
+    }
+  | {
+      type: 'select-by-number';
+      n: number;
+    }
+  | {
+      type: 'generating-start';
+    }
+  | {
+      type: 'generating-end';
+      newOptions: DeckOption[];
+    }
+  | {
+      type: 'generating-error';
+      message: string;
+    }
+  | {
+      type: 'clear-error';
+    }
+  | {
+      type: 'confirm-cancel-enter';
+    }
+  | {
+      type: 'confirm-cancel-exit';
+    }
+  | {
+      type: 'snapshot-written';
+      result: WriteResult;
+    };
+
+function reducer(state: DeckState, action: DeckAction): DeckState {
+  if (action.type === 'focus-prev') {
+    const slide = state.deck.slides[state.slideIndex];
+    if (!slide) {
+      return state;
+    }
+    const next = (state.focusIndex - 1 + slide.options.length) % slide.options.length;
+    return {
+      ...state,
+      focusIndex: next,
+    };
+  }
+  if (action.type === 'focus-next') {
+    const slide = state.deck.slides[state.slideIndex];
+    if (!slide) {
+      return state;
+    }
+    const next = (state.focusIndex + 1) % slide.options.length;
+    return {
+      ...state,
+      focusIndex: next,
+    };
+  }
+  if (action.type === 'slide-prev') {
+    const idx = Math.max(0, state.slideIndex - 1);
+    return {
+      ...state,
+      slideIndex: idx,
+      focusIndex: 0,
+    };
+  }
+  if (action.type === 'slide-next') {
+    const idx = Math.min(state.deck.slides.length - 1, state.slideIndex + 1);
+    return {
+      ...state,
+      slideIndex: idx,
+      focusIndex: 0,
+    };
+  }
+  if (action.type === 'select') {
+    const slide = state.deck.slides[state.slideIndex];
+    if (!slide) {
+      return state;
+    }
+    const selections = {
+      ...state.selections,
+    };
+    if (selections[slide.id] === action.label) {
+      delete selections[slide.id];
+    } else {
+      selections[slide.id] = action.label;
+    }
+    return {
+      ...state,
+      selections,
+    };
+  }
+  if (action.type === 'select-by-number') {
+    const slide = state.deck.slides[state.slideIndex];
+    if (!slide) {
+      return state;
+    }
+    const option = slide.options[action.n];
+    if (!option) {
+      return state;
+    }
+    return {
+      ...state,
+      focusIndex: action.n,
+      selections: {
+        ...state.selections,
+        [slide.id]: option.label,
+      },
+    };
+  }
+  if (action.type === 'generating-start') {
+    return {
+      ...state,
+      generating: true,
+      error: null,
+    };
+  }
+  if (action.type === 'generating-end') {
+    const slide = state.deck.slides[state.slideIndex];
+    if (!slide) {
+      return {
+        ...state,
+        generating: false,
+      };
+    }
+    const updatedSlide = {
+      ...slide,
+      options: [
+        ...slide.options,
+        ...action.newOptions,
+      ],
+    };
+    const slides = state.deck.slides.map((s, i) => (i === state.slideIndex ? updatedSlide : s));
+    return {
+      ...state,
+      generating: false,
+      deck: {
+        ...state.deck,
+        slides,
+      },
+    };
+  }
+  if (action.type === 'generating-error') {
+    return {
+      ...state,
+      generating: false,
+      error: action.message,
+    };
+  }
+  if (action.type === 'clear-error') {
+    return {
+      ...state,
+      error: null,
+    };
+  }
+  if (action.type === 'confirm-cancel-enter') {
+    return {
+      ...state,
+      confirmingCancel: true,
+    };
+  }
+  if (action.type === 'confirm-cancel-exit') {
+    return {
+      ...state,
+      confirmingCancel: false,
+    };
+  }
+  if (action.type === 'snapshot-written') {
+    return {
+      ...state,
+      lastSnapshot: action.result,
+    };
+  }
+  return state;
+}
+
+//#endregion
+
+//#region Component
+
+export interface DeckModalProps {
+  deck: Deck;
+  callModel: CallModel;
+  dataDir: string;
+  generateModel?: string;
+  generateCount: number;
+  maxOptionsPerSlide: number;
+  autoSaveOnSubmit: boolean;
+  autoSaveOnCancel: boolean;
+  onDone: (summary: string) => void;
+}
+
+export function DeckModal(props: DeckModalProps): ReactNode {
+  const [state, dispatch] = useReducer(reducer, {
+    deck: props.deck,
+    slideIndex: 0,
+    focusIndex: 0,
+    selections: {},
+    generating: false,
+    error: null,
+    confirmingCancel: false,
+    lastSnapshot: null,
+  });
+
+  const currentSlide = state.deck.slides[state.slideIndex];
+
+  const doSubmit = useCallback(() => {
+    let result: WriteResult | null = null;
+    if (props.autoSaveOnSubmit) {
+      result = writeSnapshot({
+        dataDir: props.dataDir,
+        deck: state.deck,
+        selections: state.selections,
+        status: 'submitted',
+      });
+      dispatch({
+        type: 'snapshot-written',
+        result,
+      });
+    }
+    props.onDone(buildSubmitSummary(state.deck, state.selections, result));
+  }, [
+    props,
+    state.deck,
+    state.selections,
+  ]);
+
+  const doCancel = useCallback(() => {
+    let result: WriteResult | null = null;
+    if (props.autoSaveOnCancel && Object.keys(state.selections).length > 0) {
+      result = writeSnapshot({
+        dataDir: props.dataDir,
+        deck: state.deck,
+        selections: state.selections,
+        status: 'cancelled',
+      });
+    }
+    props.onDone(buildCancelSummary(state.deck, state.selections, result));
+  }, [
+    props,
+    state.deck,
+    state.selections,
+  ]);
+
+  const doGenerate = useCallback(async (): Promise<void> => {
+    if (!currentSlide) {
+      return;
+    }
+    const remaining = props.maxOptionsPerSlide - currentSlide.options.length;
+    if (remaining <= 0) {
+      dispatch({
+        type: 'generating-error',
+        message: `Slide already at max (${props.maxOptionsPerSlide}) options.`,
+      });
+      return;
+    }
+    const count = Math.min(props.generateCount, remaining);
+    dispatch({
+      type: 'generating-start',
+    });
+    try {
+      const newOptions = await generateMoreOptions({
+        callModel: props.callModel,
+        slide: currentSlide,
+        count,
+        model: props.generateModel,
+      });
+      dispatch({
+        type: 'generating-end',
+        newOptions,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      dispatch({
+        type: 'generating-error',
+        message,
+      });
+    }
+  }, [
+    currentSlide,
+    props.callModel,
+    props.generateCount,
+    props.generateModel,
+    props.maxOptionsPerSlide,
+  ]);
+
+  useInput((input, key) => {
+    if (state.confirmingCancel) {
+      if (input === 'y' || input === 'Y') {
+        doCancel();
+        return;
+      }
+      if (input === 'n' || input === 'N' || key.escape) {
+        dispatch({
+          type: 'confirm-cancel-exit',
+        });
+        return;
+      }
+      return;
+    }
+    if (state.generating) {
+      return;
+    }
+    if (key.leftArrow) {
+      dispatch({
+        type: 'slide-prev',
+      });
+      return;
+    }
+    if (key.rightArrow) {
+      dispatch({
+        type: 'slide-next',
+      });
+      return;
+    }
+    if (key.upArrow) {
+      dispatch({
+        type: 'focus-prev',
+      });
+      return;
+    }
+    if (key.downArrow) {
+      dispatch({
+        type: 'focus-next',
+      });
+      return;
+    }
+    if (/^[1-9]$/.test(input)) {
+      dispatch({
+        type: 'select-by-number',
+        n: Number(input) - 1,
+      });
+      return;
+    }
+    if (input === ' ') {
+      if (currentSlide) {
+        const option = currentSlide.options[state.focusIndex];
+        if (option) {
+          dispatch({
+            type: 'select',
+            label: option.label,
+          });
+        }
+      }
+      return;
+    }
+    if (input === 'g' || input === 'G') {
+      void doGenerate();
+      return;
+    }
+    if (input === 's' || input === 'S') {
+      const result = writeSnapshot({
+        dataDir: props.dataDir,
+        deck: state.deck,
+        selections: state.selections,
+        status: 'submitted',
+      });
+      dispatch({
+        type: 'snapshot-written',
+        result,
+      });
+      return;
+    }
+    if (key.return) {
+      doSubmit();
+      return;
+    }
+    if (key.escape) {
+      if (Object.keys(state.selections).length > 0) {
+        dispatch({
+          type: 'confirm-cancel-enter',
+        });
+        return;
+      }
+      doCancel();
+    }
+  });
+
+  const slideCount = state.deck.slides.length;
+  const header = `Deck: ${state.deck.title}   Slide ${state.slideIndex + 1} of ${slideCount}`;
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Box justifyContent="space-between">
+        <Text bold>{header}</Text>
+        <Text dimColor>
+          {Object.keys(state.selections).length} / {slideCount} selected
+        </Text>
+      </Box>
+      <Box marginTop={1} flexDirection="column" flexGrow={1}>
+        {currentSlide ? (
+          <>
+            <Text bold color="cyan">
+              {currentSlide.title}
+            </Text>
+            <Box marginTop={1}>
+              <SlideView
+                slide={currentSlide}
+                focusIndex={state.focusIndex}
+                selections={state.selections}
+                generating={state.generating}
+              />
+            </Box>
+          </>
+        ) : (
+          <Text>Empty deck.</Text>
+        )}
+      </Box>
+      {state.error ? (
+        <Box marginTop={1}>
+          <Text color="red">Error: {state.error}</Text>
+        </Box>
+      ) : null}
+      {state.lastSnapshot ? (
+        <Box marginTop={1}>
+          <Text dimColor>Saved: {state.lastSnapshot.dir}</Text>
+        </Box>
+      ) : null}
+      {state.confirmingCancel ? (
+        <Box marginTop={1}>
+          <Text color="yellow">Cancel deck? (y / n)</Text>
+        </Box>
+      ) : (
+        <Box marginTop={1}>
+          <ShortcutsHint />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+//#endregion
+
+//#region Summary builders
+
+function buildSubmitSummary(
+  deck: Deck,
+  selections: DeckSelections,
+  snapshot: WriteResult | null,
+): string {
+  const lines: string[] = [];
+  lines.push(`Design deck "${deck.title}" submitted with selections:`);
+  lines.push('```json');
+  lines.push(JSON.stringify(selections, null, 2));
+  lines.push('```');
+  for (const slide of deck.slides) {
+    const chosen = selections[slide.id];
+    lines.push(`- ${slide.title}: ${chosen ?? '(none)'}`);
+  }
+  if (snapshot) {
+    lines.push(`Snapshot: ${snapshot.dir}`);
+  }
+  return lines.join('\n');
+}
+
+function buildCancelSummary(
+  deck: Deck,
+  selections: DeckSelections,
+  snapshot: WriteResult | null,
+): string {
+  const count = Object.keys(selections).length;
+  const lines: string[] = [
+    `Design deck "${deck.title}" cancelled${count > 0 ? ` with ${count} partial selection(s)` : ''}.`,
+  ];
+  if (snapshot) {
+    lines.push(`Partial snapshot: ${snapshot.dir}`);
+  }
+  return lines.join('\n');
+}
+
+//#endregion

--- a/packages/plugin-design-deck/src/ui/discover-modal.tsx
+++ b/packages/plugin-design-deck/src/ui/discover-modal.tsx
@@ -1,0 +1,151 @@
+import { Box, Text, useInput } from 'ink';
+import TextInput from 'ink-text-input';
+import type { ReactNode } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import type { DiscoverTurn } from '../generate/discover.js';
+import { nextDiscoverTurn } from '../generate/discover.js';
+import type { Deck } from '../types.js';
+import type { DeckModalProps } from './deck-modal.js';
+import { DeckModal } from './deck-modal.js';
+
+type Mode =
+  | {
+      kind: 'loading';
+    }
+  | {
+      kind: 'question';
+      question: string;
+    }
+  | {
+      kind: 'error';
+      message: string;
+    }
+  | {
+      kind: 'deck';
+      deck: Deck;
+    };
+
+type DiscoverModalProps = Omit<DeckModalProps, 'deck'>;
+
+export function DiscoverModal(props: DiscoverModalProps): ReactNode {
+  const [mode, setMode] = useState<Mode>({
+    kind: 'loading',
+  });
+  const [history, setHistory] = useState<ReadonlyArray<DiscoverTurn>>([]);
+  const [answer, setAnswer] = useState('');
+
+  const advance = useCallback(
+    async (historyAfter: ReadonlyArray<DiscoverTurn>): Promise<void> => {
+      setMode({
+        kind: 'loading',
+      });
+      try {
+        const result = await nextDiscoverTurn({
+          callModel: props.callModel,
+          history: historyAfter,
+          model: props.generateModel,
+        });
+        if (result.kind === 'deck') {
+          setMode({
+            kind: 'deck',
+            deck: result.deck,
+          });
+        } else {
+          setMode({
+            kind: 'question',
+            question: result.question,
+          });
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setMode({
+          kind: 'error',
+          message,
+        });
+      }
+    },
+    [
+      props.callModel,
+      props.generateModel,
+    ],
+  );
+
+  useEffect(() => {
+    void advance([]);
+  }, [
+    advance,
+  ]);
+
+  useInput((_input, key) => {
+    if (mode.kind === 'error' && key.escape) {
+      props.onDone('Discover cancelled.');
+    }
+  });
+
+  if (mode.kind === 'deck') {
+    return <DeckModal {...props} deck={mode.deck} />;
+  }
+
+  if (mode.kind === 'loading') {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Text bold>Deck discovery</Text>
+        <Box marginTop={1}>
+          <Text dimColor>Thinking…</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (mode.kind === 'error') {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Text bold color="red">
+          Discover failed
+        </Text>
+        <Box marginTop={1}>
+          <Text>{mode.message}</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Esc to cancel.</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text bold>Deck discovery</Text>
+      <Box marginTop={1} flexDirection="column">
+        <Text color="cyan">{mode.question}</Text>
+        <Box marginTop={1}>
+          <Text>{'> '}</Text>
+          <TextInput
+            value={answer}
+            onChange={setAnswer}
+            onSubmit={(value) => {
+              const trimmed = value.trim();
+              if (trimmed.length === 0) {
+                return;
+              }
+              const turn: DiscoverTurn = {
+                question: mode.question,
+                answer: trimmed,
+              };
+              const next = [
+                ...history,
+                turn,
+              ];
+              setHistory(next);
+              setAnswer('');
+              void advance(next);
+            }}
+          />
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Type DONE to generate the deck now.</Text>
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/plugin-design-deck/src/ui/loader-modal.tsx
+++ b/packages/plugin-design-deck/src/ui/loader-modal.tsx
@@ -1,0 +1,112 @@
+/**
+ * Wrapper that generates a deck from a topic (via buildDeck) and then hands
+ * off to DeckModal. Shows a spinner line while the first generation is in
+ * flight so the modal isn't a blank frame.
+ */
+
+import { Box, Text, useInput } from 'ink';
+import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+
+import { buildDeck } from '../generate/build-deck.js';
+import type { Deck } from '../types.js';
+import type { DeckModalProps } from './deck-modal.js';
+import { DeckModal } from './deck-modal.js';
+
+type State =
+  | {
+      kind: 'loading';
+      topic: string;
+    }
+  | {
+      kind: 'error';
+      message: string;
+    }
+  | {
+      kind: 'deck';
+      deck: Deck;
+    };
+
+interface LoaderModalProps extends Omit<DeckModalProps, 'deck'> {
+  topic: string;
+  model?: string;
+}
+
+export function LoaderModal(props: LoaderModalProps): ReactNode {
+  const [state, setState] = useState<State>({
+    kind: 'loading',
+    topic: props.topic,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run(): Promise<void> {
+      try {
+        const deck = await buildDeck({
+          callModel: props.callModel,
+          topic: props.topic,
+          model: props.model ?? props.generateModel,
+        });
+        if (cancelled) {
+          return;
+        }
+        setState({
+          kind: 'deck',
+          deck,
+        });
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        setState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    props.callModel,
+    props.topic,
+    props.model,
+    props.generateModel,
+  ]);
+
+  useInput((_input, key) => {
+    if (state.kind === 'error' && key.escape) {
+      props.onDone('Deck generation cancelled.');
+    }
+  });
+
+  if (state.kind === 'loading') {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Text bold>Design deck</Text>
+        <Box marginTop={1}>
+          <Text dimColor>Generating a deck for: {state.topic}…</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (state.kind === 'error') {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Text bold color="red">
+          Deck generation failed
+        </Text>
+        <Box marginTop={1}>
+          <Text>{state.message}</Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text dimColor>Esc to cancel.</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return <DeckModal {...props} deck={state.deck} />;
+}

--- a/packages/plugin-design-deck/src/ui/markdown-block.tsx
+++ b/packages/plugin-design-deck/src/ui/markdown-block.tsx
@@ -1,0 +1,67 @@
+import { Box, Text } from 'ink';
+import { Marked } from 'marked';
+import { markedTerminal } from 'marked-terminal';
+import type { ReactNode } from 'react';
+
+interface MarkdownBlockProps {
+  body: string;
+  maxLines?: number;
+}
+
+const MAX_LINES = 16;
+
+// Single shared Marked instance; marked-terminal registers chalk-based renderers.
+const marked = new Marked();
+marked.use(
+  markedTerminal({
+    reflowText: false,
+    width: 60,
+  }),
+);
+
+export function MarkdownBlock({ body, maxLines = MAX_LINES }: MarkdownBlockProps): ReactNode {
+  const rendered = renderMarkdown(body);
+  const { visible, hidden } = truncate(rendered, maxLines);
+  return (
+    <Box flexDirection="column" borderStyle="round" borderDimColor paddingX={1}>
+      <Text>{visible}</Text>
+      {hidden > 0 ? (
+        <Text dimColor>
+          … {hidden} more line{hidden === 1 ? '' : 's'}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
+
+function renderMarkdown(body: string): string {
+  try {
+    const result = marked.parse(body);
+    if (typeof result === 'string') {
+      return result.trimEnd();
+    }
+    return body;
+  } catch {
+    return body;
+  }
+}
+
+function truncate(
+  text: string,
+  maxLines: number,
+): {
+  visible: string;
+  hidden: number;
+} {
+  const lines = text.split('\n');
+  if (lines.length <= maxLines) {
+    return {
+      visible: text,
+      hidden: 0,
+    };
+  }
+  return {
+    visible: lines.slice(0, maxLines).join('\n'),
+    hidden: lines.length - maxLines,
+  };
+}

--- a/packages/plugin-design-deck/src/ui/option-card.tsx
+++ b/packages/plugin-design-deck/src/ui/option-card.tsx
@@ -1,0 +1,65 @@
+import { Box, Text } from 'ink';
+import type { ReactNode } from 'react';
+
+import type { DeckOption } from '../types.js';
+import { PreviewBlockView } from './preview-block.js';
+
+interface OptionCardProps {
+  option: DeckOption;
+  index: number;
+  focused: boolean;
+  selected: boolean;
+  width?: number;
+}
+
+export function OptionCard({
+  option,
+  index,
+  focused,
+  selected,
+  width,
+}: OptionCardProps): ReactNode {
+  const marker = selected ? '▸' : focused ? '•' : ' ';
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle={focused ? 'double' : 'round'}
+      borderColor={selected ? 'green' : focused ? 'cyan' : undefined}
+      borderDimColor={!focused && !selected}
+      paddingX={1}
+      paddingY={0}
+      width={width}
+      flexGrow={1}
+    >
+      <Box flexDirection="row">
+        <Text color={selected ? 'green' : focused ? 'cyan' : undefined} bold>
+          {marker} {index + 1}. {option.label}
+        </Text>
+        {option.recommended ? <Text color="yellow"> ★</Text> : null}
+      </Box>
+      {option.description ? (
+        <Box>
+          <Text dimColor>{option.description}</Text>
+        </Box>
+      ) : null}
+      {option.previewBlocks.length > 0 ? (
+        <Box flexDirection="column" marginTop={1}>
+          {option.previewBlocks.map((block, i) => (
+            <PreviewBlockView
+              // biome-ignore lint/suspicious/noArrayIndexKey: preview block order is stable for a given option
+              key={`${block.type}-${i}`}
+              block={block}
+            />
+          ))}
+        </Box>
+      ) : null}
+      {option.aside ? (
+        <Box marginTop={1}>
+          <Text dimColor italic>
+            {option.aside}
+          </Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}

--- a/packages/plugin-design-deck/src/ui/preview-block.tsx
+++ b/packages/plugin-design-deck/src/ui/preview-block.tsx
@@ -1,0 +1,35 @@
+import { Box, Text } from 'ink';
+import type { ReactNode } from 'react';
+import type { PreviewBlock } from '../types.js';
+import { isKnownPreviewBlock } from '../types.js';
+import { AsciiBlock } from './ascii-block.js';
+import { CodeBlock } from './code-block.js';
+import { MarkdownBlock } from './markdown-block.js';
+
+interface PreviewBlockViewProps {
+  block: PreviewBlock;
+}
+
+export function PreviewBlockView({ block }: PreviewBlockViewProps): ReactNode {
+  if (!isKnownPreviewBlock(block)) {
+    return (
+      <Box paddingX={1}>
+        <Text dimColor>[unsupported preview: {block.type}]</Text>
+      </Box>
+    );
+  }
+  if (block.type === 'text') {
+    return (
+      <Box paddingX={1}>
+        <Text>{block.body}</Text>
+      </Box>
+    );
+  }
+  if (block.type === 'code') {
+    return <CodeBlock language={block.language} source={block.source} />;
+  }
+  if (block.type === 'markdown') {
+    return <MarkdownBlock body={block.body} />;
+  }
+  return <AsciiBlock body={block.body} />;
+}

--- a/packages/plugin-design-deck/src/ui/shortcuts-hint.tsx
+++ b/packages/plugin-design-deck/src/ui/shortcuts-hint.tsx
@@ -1,0 +1,29 @@
+import { Box, Text } from 'ink';
+import type { ReactNode } from 'react';
+
+const HINTS = [
+  '← → slide',
+  '↑ ↓ focus',
+  '1-9 select',
+  'Space toggle',
+  'G generate',
+  'S save',
+  'Enter submit',
+  'Esc cancel',
+];
+
+export function ShortcutsHint(): ReactNode {
+  return (
+    <Box flexDirection="row">
+      {HINTS.map((hint, i) => (
+        <Box
+          // biome-ignore lint/suspicious/noArrayIndexKey: hints are a fixed static list
+          key={`hint-${i}`}
+        >
+          <Text dimColor>{hint}</Text>
+          {i < HINTS.length - 1 ? <Text dimColor> · </Text> : null}
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/packages/plugin-design-deck/src/ui/slide-view.tsx
+++ b/packages/plugin-design-deck/src/ui/slide-view.tsx
@@ -1,0 +1,98 @@
+import { Box, Text } from 'ink';
+import type { ReactNode } from 'react';
+
+import type { DeckSelections, Slide } from '../types.js';
+import { OptionCard } from './option-card.js';
+
+interface SlideViewProps {
+  slide: Slide;
+  focusIndex: number;
+  selections: DeckSelections;
+  generating: boolean;
+}
+
+export function SlideView({
+  slide,
+  focusIndex,
+  selections,
+  generating,
+}: SlideViewProps): ReactNode {
+  const selectedLabel = selections[slide.id];
+  const columns = slide.columns ?? pickColumns(slide.options.length);
+  return (
+    <Box flexDirection="column">
+      {slide.context ? (
+        <Box marginBottom={1}>
+          <Text dimColor>{slide.context}</Text>
+        </Box>
+      ) : null}
+      <OptionGrid
+        slideOptions={slide.options}
+        focusIndex={focusIndex}
+        selectedLabel={selectedLabel}
+        columns={columns}
+      />
+      {generating ? (
+        <Box marginTop={1}>
+          <Text dimColor>Generating more options…</Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+function pickColumns(count: number): 1 | 2 | 3 | 4 {
+  if (count >= 4) {
+    return 4;
+  }
+  if (count === 3) {
+    return 3;
+  }
+  if (count === 2) {
+    return 2;
+  }
+  return 1;
+}
+
+interface OptionGridProps {
+  slideOptions: Slide['options'];
+  focusIndex: number;
+  selectedLabel: string | undefined;
+  columns: 1 | 2 | 3 | 4;
+}
+
+function OptionGrid({
+  slideOptions,
+  focusIndex,
+  selectedLabel,
+  columns,
+}: OptionGridProps): ReactNode {
+  const rows: Slide['options'][] = [];
+  for (let i = 0; i < slideOptions.length; i += columns) {
+    rows.push(slideOptions.slice(i, i + columns));
+  }
+  return (
+    <Box flexDirection="column">
+      {rows.map((row, rowIndex) => (
+        <Box
+          // biome-ignore lint/suspicious/noArrayIndexKey: row order is fixed by slice index
+          key={`row-${rowIndex}`}
+          flexDirection="row"
+        >
+          {row.map((option, colIndex) => {
+            const flatIndex = rowIndex * columns + colIndex;
+            return (
+              <OptionCard
+                key={`${flatIndex}-${option.label}`}
+                option={option}
+                index={flatIndex}
+                focused={flatIndex === focusIndex}
+                selected={option.label === selectedLabel}
+              />
+            );
+          })}
+        </Box>
+      ))}
+    </Box>
+  );
+}

--- a/packages/plugin-design-deck/test/build-deck.test.ts
+++ b/packages/plugin-design-deck/test/build-deck.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+
+import type { CallModel, CallModelInput, CallModelResponse } from '@noetic/cli';
+
+import { buildDeck } from '../src/generate/build-deck.js';
+
+function mockCallModel(text: string, record: CallModelInput[] = []): CallModel {
+  return async (input) => {
+    record.push(input);
+    const response: CallModelResponse = {
+      text,
+      modelId: input.model ?? 'mock',
+    };
+    return response;
+  };
+}
+
+describe('buildDeck', () => {
+  test('parses a valid deck JSON response', async () => {
+    const deck = await buildDeck({
+      callModel: mockCallModel(
+        JSON.stringify({
+          title: 'Pick an ORM',
+          slides: [
+            {
+              id: 'orm',
+              title: 'Pick an ORM',
+              context: 'For Postgres.',
+              options: [
+                {
+                  label: 'Drizzle',
+                  description: 'typesafe',
+                },
+                {
+                  label: 'Prisma',
+                  description: 'popular',
+                },
+              ],
+            },
+          ],
+        }),
+      ),
+      topic: 'Pick an ORM for Postgres',
+    });
+    expect(deck.title).toBe('Pick an ORM');
+    expect(deck.slides[0]?.options).toHaveLength(2);
+  });
+
+  test('throws on invalid JSON', async () => {
+    await expect(
+      buildDeck({
+        callModel: mockCallModel('not json'),
+        topic: 'x',
+      }),
+    ).rejects.toThrow(/schema check/);
+  });
+
+  test('passes topic into the user message', async () => {
+    const record: CallModelInput[] = [];
+    await expect(
+      buildDeck({
+        callModel: mockCallModel(
+          JSON.stringify({
+            title: 'T',
+            slides: [
+              {
+                id: 'a',
+                title: 't',
+                options: [
+                  {
+                    label: 'x',
+                  },
+                ],
+              },
+            ],
+          }),
+          record,
+        ),
+        topic: 'MY UNIQUE TOPIC',
+      }),
+    ).resolves.toBeTruthy();
+    const userMsg = record[0]?.messages.find((m) => m.role === 'user');
+    expect(userMsg?.content).toContain('MY UNIQUE TOPIC');
+  });
+});

--- a/packages/plugin-design-deck/test/generate-shared.test.ts
+++ b/packages/plugin-design-deck/test/generate-shared.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+
+import { extractJson } from '../src/generate/shared.js';
+
+describe('extractJson', () => {
+  test('parses plain JSON', () => {
+    expect(extractJson('{"a":1}')).toEqual({
+      a: 1,
+    });
+  });
+
+  test('strips ```json fences', () => {
+    expect(extractJson('```json\n{"a":1}\n```')).toEqual({
+      a: 1,
+    });
+  });
+
+  test('strips bare ``` fences', () => {
+    expect(extractJson('```\n[1,2,3]\n```')).toEqual([
+      1,
+      2,
+      3,
+    ]);
+  });
+
+  test('finds JSON embedded in prose', () => {
+    expect(extractJson('here you go: {"ok":true} — enjoy')).toEqual({
+      ok: true,
+    });
+  });
+
+  test('returns null on unparseable input', () => {
+    expect(extractJson('nothing to see here')).toBeNull();
+  });
+});

--- a/packages/plugin-design-deck/test/snapshot.test.ts
+++ b/packages/plugin-design-deck/test/snapshot.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { readSnapshot, slugify, writeSnapshot } from '../src/snapshot.js';
+
+describe('slugify', () => {
+  test('lowercase, alnum + dashes only', () => {
+    expect(slugify('Pick a Database!!')).toBe('pick-a-database');
+  });
+
+  test('collapses repeated non-alnum', () => {
+    expect(slugify('a   b___c')).toBe('a-b-c');
+  });
+
+  test('falls back to "deck" for empty input', () => {
+    expect(slugify('!!!')).toBe('deck');
+  });
+
+  test('caps length', () => {
+    const long = 'a'.repeat(200);
+    expect(slugify(long).length).toBeLessThanOrEqual(60);
+  });
+});
+
+describe('writeSnapshot', () => {
+  test('round-trips a deck + selections', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dd-snap-'));
+    const deck = {
+      title: 'Pick one',
+      slides: [
+        {
+          id: 'pick',
+          title: 'Pick one',
+          context: 'Choose A or B.',
+          options: [
+            {
+              label: 'A',
+              description: 'first',
+              previewBlocks: [],
+            },
+            {
+              label: 'B',
+              description: 'second',
+              previewBlocks: [],
+            },
+          ],
+        },
+      ],
+    };
+    const selections = {
+      pick: 'A',
+    };
+    const now = new Date('2026-04-20T19:00:00.000Z');
+    const result = writeSnapshot({
+      dataDir: dir,
+      deck,
+      selections,
+      status: 'submitted',
+      now,
+    });
+    expect(result.dir.endsWith('-submitted')).toBe(true);
+    const restored = readSnapshot(result.jsonPath);
+    expect(restored.deck.title).toBe('Pick one');
+    expect(restored.selections).toEqual(selections);
+    expect(restored.status).toBe('submitted');
+    const summary = readFileSync(result.summaryPath, 'utf8');
+    expect(summary).toContain('# Pick one');
+    expect(summary).toContain('- **Pick one** — A');
+  });
+});

--- a/packages/plugin-design-deck/test/types.test.ts
+++ b/packages/plugin-design-deck/test/types.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+
+import { DeckSchema, isKnownPreviewBlock, PreviewBlockSchema } from '../src/types.js';
+
+describe('DeckSchema', () => {
+  test('parses a minimal deck', () => {
+    const result = DeckSchema.safeParse({
+      title: 'x',
+      slides: [
+        {
+          id: 's1',
+          title: 't',
+          options: [
+            {
+              label: 'a',
+            },
+          ],
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.slides[0]?.options[0]?.description).toBe('');
+      expect(result.data.slides[0]?.options[0]?.previewBlocks).toEqual([]);
+    }
+  });
+
+  test('rejects empty slides array', () => {
+    expect(
+      DeckSchema.safeParse({
+        title: 'x',
+        slides: [],
+      }).success,
+    ).toBe(false);
+  });
+
+  test('rejects slide with zero options', () => {
+    expect(
+      DeckSchema.safeParse({
+        title: 'x',
+        slides: [
+          {
+            id: 's1',
+            title: 't',
+            options: [],
+          },
+        ],
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe('PreviewBlockSchema', () => {
+  test('parses text block', () => {
+    const out = PreviewBlockSchema.parse({
+      type: 'text',
+      body: 'hi',
+    });
+    expect(out.type).toBe('text');
+  });
+
+  test('parses code block with default language', () => {
+    const out = PreviewBlockSchema.parse({
+      type: 'code',
+      source: 'x=1',
+    });
+    if (out.type === 'code') {
+      expect(out.language).toBe('text');
+    }
+  });
+
+  test('tolerates unknown block types (forward-compat)', () => {
+    const out = PreviewBlockSchema.parse({
+      type: 'mermaid',
+      source: 'graph TD;A-->B;',
+    });
+    expect(out.type).toBe('mermaid');
+    expect(isKnownPreviewBlock(out)).toBe(false);
+  });
+
+  test('isKnownPreviewBlock narrows known types', () => {
+    const block = PreviewBlockSchema.parse({
+      type: 'ascii',
+      body: 'X',
+    });
+    expect(isKnownPreviewBlock(block)).toBe(true);
+  });
+});

--- a/packages/plugin-design-deck/tsconfig.json
+++ b/packages/plugin-design-deck/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "skipLibCheck": true,
+    "jsx": "react-jsx",
+    "types": ["bun-types"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"]
+}

--- a/packages/plugin-powerline/src/index.tsx
+++ b/packages/plugin-powerline/src/index.tsx
@@ -37,7 +37,6 @@ export default function powerline(userInput: PowerlineInput = {}): NoeticPlugin 
   const inputParsed = PowerlineInputSchema.parse(userInput);
   const options = PowerlineOptionsSchema.parse(inputParsed);
 
-  let apiKey = '';
   let vibes: ReadonlyArray<string> = [];
 
   const segments = options.segments ?? PRESETS[options.preset];
@@ -45,11 +44,10 @@ export default function powerline(userInput: PowerlineInput = {}): NoeticPlugin 
   return {
     name: NAME,
     version: VERSION,
-    initialize: async (config) => {
-      apiKey = config.apiKey;
+    initialize: async (ctx) => {
       vibes = await resolveVibes({
         options: options.vibe,
-        apiKey,
+        apiKey: ctx.config.apiKey,
       });
     },
     loadingMessages: () => vibes,


### PR DESCRIPTION
## Summary

Ports [pi-design-deck](https://github.com/nicobailon/pi-design-deck) to Noetic as a new plugin `@noetic/plugin-design-deck`. The upstream project renders in a WKWebView/browser with SSE streaming; this port rebuilds the UI ground-up in Ink while keeping the JSON data model compatible. Surfaces two general plugin-API gaps and closes them:

- `PluginContext` with `callModel` + `dataDir`, replacing the bare `AgentConfig` passed to hooks.
- `NoeticPlugin.commands` hook — plugins can now register slash commands.

## What ships

- **`@noetic/plugin-design-deck`** — new package. Three commands:
  - `/deck <topic>` → generates and opens a deck; navigate arrows/1-9/Space/G, submit Enter, cancel Esc.
  - `/deck-discover` → interview the user for a few turns, then generate a deck.
  - (`/deck-plan` deferred to v2.)
- Preview blocks: `text`, `code` (syntax-highlighted via `cli-highlight`), `markdown` (`marked` + `marked-terminal`), `ascii` pass-through. Unknown types render as `[unsupported: type]` so pi decks with mermaid/html/image parse cleanly.
- Snapshots on submit/cancel go to project-scoped `./.noetic/plugin-design-deck/<slug>-<date>-<status>/` with `deck.json` + `summary.md`.
- Selections return to chat as a fenced-JSON block + per-slide list + snapshot path.

## CLI plugin-API changes

- `PluginContext.callModel`: fetch-wrapped OpenRouter chat-completion so plugins can do one-shot LLM calls without `@openrouter/agent`.
- `PluginContext.dataDir('project' | 'user')`: lazy-mkdir'd plugin-scoped dir.
- `NoeticPlugin.commands(ctx)` hook; merged into `BUILTIN_COMMANDS` by `App.tsx` (plugin commands come after, so they can't shadow `/help` etc.).
- `NoeticPlugin.{tools,memoryLayers,skills,initialize}` now receive `PluginContext` instead of `AgentConfig` (breaking — `@noetic/plugin-powerline` migrated in the same commit).
- Fixes latent bug in `executeCommand`: JSX commands' `onDone` callback was dead once the modal opened. Now routed through a new `onJsxComplete` handler owned by `App.tsx` so the modal can dismiss itself + post to chat.

## Test plan

- [x] `bun test` in `@noetic/plugin-design-deck` — 20/20 pass (schemas, snapshot, JSON extractor, build-deck mocked).
- [x] `bun test` in `@noetic/cli` — 103/103 pass, new cases for `PluginContext` shape, `commands` hook, `dataDir` helper, `createCallModel` wire format.
- [x] `bun test` in `@noetic/plugin-powerline` — 27/27 pass (regression check after ctx migration).
- [x] `bunx biome check` clean across all three packages.
- [x] `bun run typecheck` clean in plugin-design-deck and plugin-powerline (CLI has two pre-existing errors from prior PRs, unchanged by this branch).
- [x] End-to-end via pilotty:
  - `/deck pick a test assertion library` → deck rendered (4 slides, syntax-highlighted code previews), arrow nav, `1` to select, Enter to submit.
  - Modal dismissed, JSON selections + summary posted to chat.
  - Snapshot written at `/tmp/deck-test/.noetic/plugin-design-deck/<slug>-<ts>-submitted/deck.json` — verified on disk.
  - `/deck-discover` asked interview questions, accepted `DONE` to kick generation.

## Follow-ups

- Tighten `deck-discover.md` prompt — current model sometimes emits non-schema JSON after `DONE`; the discover modal falls back to showing raw output.
- `/deck-plan <file>` command (reading a PRD and seeding decisions).
- Re-entry / "continue from snapshot" picker.