### PR TITLE
Docs site: NOETIC / section breadcrumb header + smaller mobile type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 dist/
 dist-bin/
+dist-server/
+coverage/
+docs/superpowers/
 .next/
 packages/web/.next/
 packages/web/.source/

--- a/packages/chat-sdk/src/noetic-chat.ts
+++ b/packages/chat-sdk/src/noetic-chat.ts
@@ -1,4 +1,9 @@
-import type { ExecuteInput, ExecuteOptions, HarnessResponse, SessionScope } from '@noetic-tools/core';
+import type {
+  ExecuteInput,
+  ExecuteOptions,
+  HarnessResponse,
+  SessionScope,
+} from '@noetic-tools/core';
 import type {
   ActionHandler,
   Adapter,

--- a/packages/chat-sdk/test/noetic-chat.test.ts
+++ b/packages/chat-sdk/test/noetic-chat.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import type { ExecuteInput, ExecuteOptions, HarnessResponse, SessionScope } from '@noetic-tools/core';
+import type {
+  ExecuteInput,
+  ExecuteOptions,
+  HarnessResponse,
+  SessionScope,
+} from '@noetic-tools/core';
 
 import { buildThreadExecuteFn } from '../src/noetic-chat';
 

--- a/packages/cli/src/cli/run-setup-flow.tsx
+++ b/packages/cli/src/cli/run-setup-flow.tsx
@@ -18,9 +18,9 @@ import { BINARY_MANIFEST } from '../setup/binary-manifest.js';
 import { detectOs, detectPackageManagers } from '../setup/platform.js';
 import { resolveBinaryStatuses } from '../setup/resolver.js';
 import type { BinaryAvailability, BinaryId, BinaryStatus } from '../setup/types.js';
-import type { AgentConfig } from '../types/config.js';
 import { InkProvider } from '../tui/components/index.js';
 import { SetupScreen } from '../tui/screens/setup-screen.js';
+import type { AgentConfig } from '../types/config.js';
 
 //#region Types
 
@@ -45,7 +45,7 @@ export async function runSetupFlow(options: RunSetupFlowOptions): Promise<Binary
     return initial;
   }
 
-  const isInteractive = options.isInteractive ?? (process.stdin.isTTY === true);
+  const isInteractive = options.isInteractive ?? process.stdin.isTTY === true;
   if (!isInteractive) {
     emitNonTtyNotices(missing, options.writeNotice);
     return withDefaults(initial, missing, 'ignored');
@@ -96,10 +96,7 @@ function mergeAvailability(
   base: Map<BinaryId, 'present' | 'ignored'>,
   overlay: ReadonlyMap<BinaryId, 'present' | 'ignored'>,
 ): BinaryAvailability {
-  for (const [
-    k,
-    v,
-  ] of overlay) {
+  for (const [k, v] of overlay) {
     base.set(k, v);
   }
   return base;

--- a/packages/cli/src/config/agent-md-loader.ts
+++ b/packages/cli/src/config/agent-md-loader.ts
@@ -16,8 +16,8 @@
 import { realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
-import type { FsAdapter, ShellAdapter } from '@noetic-tools/core';
 import { createLocalShellAdapter } from '@noetic/platform-node';
+import type { FsAdapter, ShellAdapter } from '@noetic-tools/core';
 import { processSkillContent } from '../util/skill-processor.js';
 
 //#region Types

--- a/packages/cli/src/harness/deps/core.ts
+++ b/packages/cli/src/harness/deps/core.ts
@@ -1,3 +1,4 @@
+export { createFileStorage, createLocalSubprocessAdapter } from '@noetic/platform-node';
 export type {
   AgentHarness,
   FsAdapter,
@@ -18,4 +19,3 @@ export {
   toolMemoryLayer,
   workingMemory,
 } from '@noetic-tools/core';
-export { createFileStorage, createLocalSubprocessAdapter } from '@noetic/platform-node';

--- a/packages/cli/src/harness/shell-adapter-bootstrap.ts
+++ b/packages/cli/src/harness/shell-adapter-bootstrap.ts
@@ -1,4 +1,5 @@
-import { createLocalShellAdapter, type LocalShellAdapter } from '@noetic/platform-node';
+import type { LocalShellAdapter } from '@noetic/platform-node';
+import { createLocalShellAdapter } from '@noetic/platform-node';
 import type { AgentConfig } from '../types/config.js';
 
 //#region Types

--- a/packages/cli/src/setup/types.ts
+++ b/packages/cli/src/setup/types.ts
@@ -105,11 +105,17 @@ export interface BinaryDescriptor {
   /** Returns true if the binary is usable. */
   detect: () => Promise<boolean>;
   /** Ordered auto-install options for the detected (os, pms). */
-  installOptionsFor: (os: OsKind, pms: ReadonlyArray<PackageManager>) => ReadonlyArray<InstallOption>;
+  installOptionsFor: (
+    os: OsKind,
+    pms: ReadonlyArray<PackageManager>,
+  ) => ReadonlyArray<InstallOption>;
   /** Multi-line manual instructions rendered in the manual waiter screen. */
   manualInstructionsFor: (os: OsKind) => string;
   /** Tools affected when this binary is missing-and-ignored. */
-  affects: ReadonlyArray<{ toolId: 'interactive-terminal' | 'browser' | 'bash'; mode: 'omit' | 'degrade' }>;
+  affects: ReadonlyArray<{
+    toolId: 'interactive-terminal' | 'browser' | 'bash';
+    mode: 'omit' | 'degrade';
+  }>;
 }
 
 //#endregion

--- a/packages/cli/src/setup/user-config-writer.ts
+++ b/packages/cli/src/setup/user-config-writer.ts
@@ -110,8 +110,14 @@ function serialize(state: UserSetupFile): string {
 //#region Public API
 
 export type AppendResult =
-  | { status: 'written'; path: string }
-  | { status: 'already-present'; path: string };
+  | {
+      status: 'written';
+      path: string;
+    }
+  | {
+      status: 'already-present';
+      path: string;
+    };
 
 /**
  * Merge `id` into the user-global ignore list. Idempotent: a second call

--- a/packages/cli/src/setup/workspace-root.ts
+++ b/packages/cli/src/setup/workspace-root.ts
@@ -26,7 +26,7 @@ function hasWorkspaceMarker(dir: string): boolean {
   try {
     const pkgPath = join(dir, 'package.json');
     const raw = readFileSync(pkgPath, 'utf8');
-    const parsed: unknown = JSON.parse(raw);
+    const parsed = JSON.parse(raw);
     if (isPkgWithWorkspaces(parsed)) {
       return true;
     }

--- a/packages/cli/src/setup/workspace-root.ts
+++ b/packages/cli/src/setup/workspace-root.ts
@@ -37,7 +37,9 @@ function hasWorkspaceMarker(dir: string): boolean {
   return false;
 }
 
-function isPkgWithWorkspaces(value: unknown): value is { workspaces: unknown } {
+function isPkgWithWorkspaces(value: unknown): value is {
+  workspaces: unknown;
+} {
   if (typeof value !== 'object' || value === null) {
     return false;
   }

--- a/packages/cli/src/tasks/runtime/cli.ts
+++ b/packages/cli/src/tasks/runtime/cli.ts
@@ -11,9 +11,12 @@ import { fileURLToPath } from 'node:url';
 import { TaskSource } from '@noetic/code-agent/tasks/schema';
 import type { TaskStoreContext } from '@noetic/code-agent/tasks/store/fs-node';
 import { resolveSubprocessRoot } from '@noetic/code-agent/tasks/store/fs-node';
+import {
+  createFileStorage,
+  createLocalFsAdapter,
+  createLocalSubprocessAdapter,
+} from '@noetic/platform-node';
 import type { FsAdapter } from '@noetic-tools/core';
-import { createFileStorage } from '@noetic/platform-node';
-import { createLocalFsAdapter, createLocalSubprocessAdapter } from '@noetic/platform-node';
 import { formatError, requireProjectRoot } from './handlers/_shared.js';
 import { autopilotHandler, steerTaskHandler } from './handlers/autopilot.js';
 import {

--- a/packages/cli/src/tasks/runtime/handlers/state.ts
+++ b/packages/cli/src/tasks/runtime/handlers/state.ts
@@ -15,8 +15,8 @@ import {
   taskDirPaths,
 } from '@noetic/code-agent/tasks/store/fs-node';
 import { execTolerantOfMissing, isShellMissing } from '@noetic/code-agent/tasks/worktree-node';
-import type { FsAdapter, ShellAdapter, ShellExecResult } from '@noetic-tools/core';
 import { createLocalFsAdapter, createLocalShellAdapter } from '@noetic/platform-node';
+import type { FsAdapter, ShellAdapter, ShellExecResult } from '@noetic-tools/core';
 import type { AgentCiActionResult, Signaller } from '../agent-ci-control.js';
 import { togglePauseAgentCiRun } from '../agent-ci-control.js';
 import { deriveColumn, KanbanColumn, moveTask } from '../kanban.js';

--- a/packages/cli/src/tasks/runtime/hierarchy/daemon-bootstrap.ts
+++ b/packages/cli/src/tasks/runtime/hierarchy/daemon-bootstrap.ts
@@ -29,9 +29,13 @@ import {
 } from '@noetic/code-agent/tasks/ipc-node';
 import type { TaskStoreContext } from '@noetic/code-agent/tasks/store/fs-node';
 import { resolveSubprocessRoot } from '@noetic/code-agent/tasks/store/fs-node';
+import {
+  createFileStorage,
+  createLocalFsAdapter,
+  createLocalShellAdapter,
+  createLocalSubprocessAdapter,
+} from '@noetic/platform-node';
 import type { AgentHarness, StorageAdapter, SubprocessAdapter } from '@noetic-tools/core';
-import { createFileStorage, createLocalFsAdapter, createLocalShellAdapter } from '@noetic/platform-node';
-import { createLocalSubprocessAdapter } from '@noetic/platform-node';
 import { defaultSignaller } from '../agent-ci-control.js';
 import { DEFAULT_MODEL } from '../defaults.js';
 import { startImplementerRun } from '../implementer-launcher.js';

--- a/packages/cli/src/tasks/runtime/hierarchy/reconcile-flow.ts
+++ b/packages/cli/src/tasks/runtime/hierarchy/reconcile-flow.ts
@@ -14,9 +14,9 @@ import { reconcileTasksFs } from '@noetic/code-agent/tasks';
 import type { TaskStoreContext } from '@noetic/code-agent/tasks/store/fs-node';
 import type { ProjectWorktree } from '@noetic/code-agent/tasks/worktree-node';
 import { loadProjectWorktrees } from '@noetic/code-agent/tasks/worktree-node';
+import { createLocalShellAdapter } from '@noetic/platform-node';
 import type { ContextMemory, ShellAdapter, Step } from '@noetic-tools/core';
 import { every, step } from '@noetic-tools/core';
-import { createLocalShellAdapter } from '@noetic/platform-node';
 
 //#region Types
 

--- a/packages/cli/src/tasks/runtime/implementer-runner-parts/core.ts
+++ b/packages/cli/src/tasks/runtime/implementer-runner-parts/core.ts
@@ -1,3 +1,9 @@
+export {
+  AgentIpcServer,
+  createLocalFsAdapter,
+  createLocalShellAdapter,
+  unlinkSocketSync,
+} from '@noetic/platform-node';
 export type { Item } from '@noetic-tools/core';
 export {
   createDetachedSignal,
@@ -5,9 +11,3 @@ export {
   createStallNudgeHook,
   runnableLoop,
 } from '@noetic-tools/core';
-export {
-  AgentIpcServer,
-  createLocalFsAdapter,
-  createLocalShellAdapter,
-  unlinkSocketSync,
-} from '@noetic/platform-node';

--- a/packages/cli/src/tasks/runtime/mutation-policy.ts
+++ b/packages/cli/src/tasks/runtime/mutation-policy.ts
@@ -15,8 +15,8 @@ import { resolve } from '@noetic/code-agent/tasks/path-utils';
 import { TaskSource } from '@noetic/code-agent/tasks/schema';
 import type { TaskStoreContext } from '@noetic/code-agent/tasks/store/fs-node';
 import { listTasks } from '@noetic/code-agent/tasks/store/fs-node';
-import type { ShellAdapter } from '@noetic-tools/core';
 import { createLocalFsAdapter } from '@noetic/platform-node';
+import type { ShellAdapter } from '@noetic-tools/core';
 import type {
   MutationPolicy,
   MutationPolicyDecision,

--- a/packages/cli/src/tasks/runtime/planner-runner.ts
+++ b/packages/cli/src/tasks/runtime/planner-runner.ts
@@ -27,6 +27,12 @@ import {
   saveTask,
   taskDirPaths,
 } from '@noetic/code-agent/tasks/store/fs-node';
+import {
+  AgentIpcServer,
+  createLocalFsAdapter,
+  createLocalShellAdapter,
+  unlinkSocketSync,
+} from '@noetic/platform-node';
 import type { Item } from '@noetic-tools/core';
 import {
   createDetachedSignal,
@@ -34,12 +40,6 @@ import {
   createStallNudgeHook,
   runnableLoop,
 } from '@noetic-tools/core';
-import {
-  AgentIpcServer,
-  createLocalFsAdapter,
-  createLocalShellAdapter,
-  unlinkSocketSync,
-} from '@noetic/platform-node';
 import { createSteeringFileLayer } from '../../memory/steering-file-layer.js';
 import { createCodingTools } from '../../tools/index.js';
 import { DEFAULT_MODEL } from './defaults.js';

--- a/packages/cli/src/tasks/runtime/tools.ts
+++ b/packages/cli/src/tasks/runtime/tools.ts
@@ -15,10 +15,9 @@
 import { TaskIdSchema, TaskSource } from '@noetic/code-agent/tasks/schema';
 import type { TaskStoreContext } from '@noetic/code-agent/tasks/store/fs-node';
 import { resolveSubprocessRoot } from '@noetic/code-agent/tasks/store/fs-node';
+import { createFileStorage, createLocalSubprocessAdapter } from '@noetic/platform-node';
 import type { Tool } from '@noetic-tools/core';
 import { tool } from '@noetic-tools/core';
-import { createFileStorage } from '@noetic/platform-node';
-import { createLocalSubprocessAdapter } from '@noetic/platform-node';
 import { z } from 'zod';
 import { autopilotHandler, planTaskHandler, steerTaskHandler } from './handlers/autopilot.js';
 import {

--- a/packages/cli/src/tui/app-parts/deps.ts
+++ b/packages/cli/src/tui/app-parts/deps.ts
@@ -4,6 +4,7 @@ export { createAskUserService } from '@noetic/code-agent/ask-user-service';
 export type { LspService } from '@noetic/code-agent/lsp';
 export type { SkillDefinition } from '@noetic/code-agent/skills';
 export { buildSkillCatalog } from '@noetic/code-agent/skills';
+export { createLocalShellAdapter } from '@noetic/platform-node';
 export type {
   AgentHarness,
   AskUserOutput,
@@ -16,4 +17,3 @@ export type {
   ShellAdapter,
   StreamEvent,
 } from '@noetic-tools/core';
-export { createLocalShellAdapter } from '@noetic/platform-node';

--- a/packages/cli/src/tui/components/ask-user/ask-user-modal.tsx
+++ b/packages/cli/src/tui/components/ask-user/ask-user-modal.tsx
@@ -8,7 +8,12 @@
  * Ported from ~/Desktop/claude-code-main/src/components/permissions/AskUserQuestionPermissionRequest/AskUserQuestionPermissionRequest.tsx.
  */
 
-import type { AskUserAnnotation, AskUserInput, AskUserOutput, AskUserQuestion } from '@noetic-tools/core';
+import type {
+  AskUserAnnotation,
+  AskUserInput,
+  AskUserOutput,
+  AskUserQuestion,
+} from '@noetic-tools/core';
 import { Box, Text, useStdout } from 'ink';
 import { useMemo, useState } from 'react';
 import { useTheme } from '../theme.js';

--- a/packages/cli/src/tui/screens/setup-install-runner.tsx
+++ b/packages/cli/src/tui/screens/setup-install-runner.tsx
@@ -27,9 +27,19 @@ export interface SetupInstallRunnerProps {
 //#region State
 
 type Phase =
-  | { kind: 'running'; lines: ReadonlyArray<string> }
-  | { kind: 'verifying'; lines: ReadonlyArray<string> }
-  | { kind: 'failed'; lines: ReadonlyArray<string>; reason: string };
+  | {
+      kind: 'running';
+      lines: ReadonlyArray<string>;
+    }
+  | {
+      kind: 'verifying';
+      lines: ReadonlyArray<string>;
+    }
+  | {
+      kind: 'failed';
+      lines: ReadonlyArray<string>;
+      reason: string;
+    };
 
 const TAIL_SIZE = 20;
 

--- a/packages/cli/src/tui/screens/setup-install-runner.tsx
+++ b/packages/cli/src/tui/screens/setup-install-runner.tsx
@@ -26,18 +26,23 @@ export interface SetupInstallRunnerProps {
 
 //#region State
 
+interface LogLine {
+  readonly id: number;
+  readonly text: string;
+}
+
 type Phase =
   | {
       kind: 'running';
-      lines: ReadonlyArray<string>;
+      lines: ReadonlyArray<LogLine>;
     }
   | {
       kind: 'verifying';
-      lines: ReadonlyArray<string>;
+      lines: ReadonlyArray<LogLine>;
     }
   | {
       kind: 'failed';
-      lines: ReadonlyArray<string>;
+      lines: ReadonlyArray<LogLine>;
       reason: string;
     };
 
@@ -64,15 +69,19 @@ export function SetupInstallRunner({
     cancelRef.current = handle.cancel;
     let cancelled = false;
 
-    (async () => {
-      const tail: string[] = [];
+    async function run(): Promise<void> {
+      const tail: LogLine[] = [];
+      let nextLineId = 0;
       let exitCode: number | null = null;
       for await (const event of handle.events) {
         if (cancelled) {
           return;
         }
         if (event.kind === 'line') {
-          tail.push(event.text);
+          tail.push({
+            id: nextLineId++,
+            text: event.text,
+          });
           while (tail.length > TAIL_SIZE) {
             tail.shift();
           }
@@ -122,7 +131,9 @@ export function SetupInstallRunner({
       }
 
       onInstalled();
-    })();
+    }
+
+    void run();
 
     return () => {
       cancelled = true;
@@ -162,9 +173,9 @@ export function SetupInstallRunner({
         $ {option.command} {option.args.join(' ')}
       </Text>
       <Box flexDirection="column" marginTop={1}>
-        {phase.lines.map((line, idx) => (
-          <Text key={`${idx}-${line.slice(0, 16)}`} dimColor>
-            {line}
+        {phase.lines.map((line) => (
+          <Text key={line.id} dimColor>
+            {line.text}
           </Text>
         ))}
       </Box>

--- a/packages/cli/src/tui/screens/setup-manual-waiter.tsx
+++ b/packages/cli/src/tui/screens/setup-manual-waiter.tsx
@@ -81,16 +81,19 @@ export function SetupManualWaiter({
 
   return (
     <Box flexDirection="column" padding={1}>
-      <Text bold>
-        Install {descriptor.displayName} manually
-      </Text>
+      <Text bold>Install {descriptor.displayName} manually</Text>
       <Box flexDirection="column" marginTop={1}>
-        {descriptor.manualInstructionsFor(os).split('\n').map((line, idx) => (
-          <Text key={`${idx}-${line.slice(0, 12)}`}>{line}</Text>
-        ))}
+        {descriptor
+          .manualInstructionsFor(os)
+          .split('\n')
+          .map((line, idx) => (
+            <Text key={`${idx}-${line.slice(0, 12)}`}>{line}</Text>
+          ))}
       </Box>
       <Box marginTop={1}>
-        <Text color="cyan">… polling every {POLL_MS / 1_000}s (checked {attempts} times)</Text>
+        <Text color="cyan">
+          … polling every {POLL_MS / 1_000}s (checked {attempts} times)
+        </Text>
       </Box>
       <Box marginTop={1}>
         <Text dimColor>i ignore · b back</Text>

--- a/packages/cli/src/tui/screens/setup-manual-waiter.tsx
+++ b/packages/cli/src/tui/screens/setup-manual-waiter.tsx
@@ -86,8 +86,8 @@ export function SetupManualWaiter({
         {descriptor
           .manualInstructionsFor(os)
           .split('\n')
-          .map((line, idx) => (
-            <Text key={`${idx}-${line.slice(0, 12)}`}>{line}</Text>
+          .map((line) => (
+            <Text key={line}>{line}</Text>
           ))}
       </Box>
       <Box marginTop={1}>

--- a/packages/cli/src/tui/screens/setup-screen.tsx
+++ b/packages/cli/src/tui/screens/setup-screen.tsx
@@ -24,8 +24,8 @@ import type {
   PackageManager,
 } from '../../setup/types.js';
 import { appendIgnoredBinary } from '../../setup/user-config-writer.js';
-import { Select } from '../components/custom-select/index.js';
 import type { Option } from '../components/custom-select/index.js';
+import { Select } from '../components/custom-select/index.js';
 import { SetupInstallRunner } from './setup-install-runner.js';
 import { SetupManualWaiter } from './setup-manual-waiter.js';
 
@@ -55,10 +55,20 @@ export interface SetupScreenProps {
 //#region Per-binary state
 
 type BinaryScreenState =
-  | { kind: 'menu' }
-  | { kind: 'auto'; option: InstallOption }
-  | { kind: 'manual' }
-  | { kind: 'done'; outcome: 'present' | 'ignored' };
+  | {
+      kind: 'menu';
+    }
+  | {
+      kind: 'auto';
+      option: InstallOption;
+    }
+  | {
+      kind: 'manual';
+    }
+  | {
+      kind: 'done';
+      outcome: 'present' | 'ignored';
+    };
 
 //#endregion
 
@@ -72,9 +82,7 @@ export function SetupScreen({
   onPersistIgnore,
 }: SetupScreenProps) {
   const [cursor, setCursor] = useState(0);
-  const [outcomes, setOutcomes] = useState<ReadonlyMap<BinaryId, 'present' | 'ignored'>>(
-    new Map(),
-  );
+  const [outcomes, setOutcomes] = useState<ReadonlyMap<BinaryId, 'present' | 'ignored'>>(new Map());
 
   const current = missing[cursor];
   const descriptor = useMemo(() => {
@@ -190,9 +198,11 @@ function BinaryPrompt({
   ]);
 
   const handleIgnore = useCallback(async () => {
-    const persist = onPersistIgnore ?? (async (id: BinaryId) => {
-      await appendIgnoredBinary(id);
-    });
+    const persist =
+      onPersistIgnore ??
+      (async (id: BinaryId) => {
+        await appendIgnoredBinary(id);
+      });
     try {
       await persist(descriptor.id);
     } catch (err) {
@@ -297,7 +307,9 @@ export function describeIgnoreImpact(descriptor: BinaryDescriptor): string {
   const degrades = descriptor.affects.filter((a) => a.mode === 'degrade').map((a) => a.toolId);
   const parts: string[] = [];
   if (omits.length > 0) {
-    parts.push(`the ${omits.join(', ')} tool${omits.length === 1 ? '' : 's'} will not be registered`);
+    parts.push(
+      `the ${omits.join(', ')} tool${omits.length === 1 ? '' : 's'} will not be registered`,
+    );
   }
   if (degrades.length > 0) {
     parts.push(

--- a/packages/cli/src/tui/task-chat/use-task-chat.ts
+++ b/packages/cli/src/tui/task-chat/use-task-chat.ts
@@ -9,10 +9,10 @@
  * `submitAskUser` / `cancelAskUser`) so the TUI can render the modal.
  */
 
-import type { AskUserOutput, StreamingItem } from '@noetic-tools/core';
-import { ItemSchema } from '@noetic-tools/core';
 import type { AskUserPendingFrame, AskUserStreamEvent } from '@noetic/platform-node';
 import { AgentIpcClient } from '@noetic/platform-node';
+import type { AskUserOutput, StreamingItem } from '@noetic-tools/core';
+import { ItemSchema } from '@noetic-tools/core';
 import { useEffect, useRef, useState } from 'react';
 import type { ConversationEntry } from '../item-utils.js';
 import { appendOrUpdateEntry } from '../item-utils.js';

--- a/packages/cli/test/agent-md-layer.test.ts
+++ b/packages/cli/test/agent-md-layer.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'bun:test';
-
+import { createLocalFsAdapter, createLocalShellAdapter } from '@noetic/platform-node';
 import type { ExecutionContext, ItemLog, ScopedStorage } from '@noetic-tools/core';
 import { Slot } from '@noetic-tools/core';
-import { createLocalFsAdapter, createLocalShellAdapter } from '@noetic/platform-node';
 
 import type { AgentInstructionResult } from '../src/config/agent-md-loader.js';
 import { agentMdLayer } from '../src/memory/agent-md-layer.js';

--- a/packages/cli/test/agent-md-loader.test.ts
+++ b/packages/cli/test/agent-md-loader.test.ts
@@ -2,9 +2,8 @@ import { describe, expect, it } from 'bun:test';
 import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-
-import type { FsAdapter, FsStats, ShellAdapter, ShellExecResult } from '@noetic-tools/core';
 import { createLocalFsAdapter } from '@noetic/platform-node';
+import type { FsAdapter, FsStats, ShellAdapter, ShellExecResult } from '@noetic-tools/core';
 
 import { loadAgentInstructions } from '../src/config/agent-md-loader.js';
 

--- a/packages/cli/test/follow-cd.test.ts
+++ b/packages/cli/test/follow-cd.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { createLocalFsAdapter } from '@noetic/platform-node';
 import type {
   CwdState,
   ShellAdapter,
@@ -14,7 +15,6 @@ import type {
   ShellExecResult,
   ToolExecutionContext,
 } from '@noetic-tools/core';
-import { createLocalFsAdapter } from '@noetic/platform-node';
 import type { BashOutput } from '../src/tools/bash.js';
 import { BashOutputSchema, createBashTool } from '../src/tools/bash.js';
 import { createEditTool } from '../src/tools/edit.js';

--- a/packages/cli/test/harness-factory.test.ts
+++ b/packages/cli/test/harness-factory.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'bun:test';
-
+import { createLocalFsAdapter } from '@noetic/platform-node';
 import type { Tool } from '@noetic-tools/core';
 import { Slot } from '@noetic-tools/core';
-import { createLocalFsAdapter } from '@noetic/platform-node';
 import { z } from 'zod';
 
 import { createAgentHarness } from '../src/harness/factory.js';

--- a/packages/cli/test/mutation-policy.test.ts
+++ b/packages/cli/test/mutation-policy.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from 'bun:test';
-import type { FsAdapter, ShellAdapter, ShellExecOptions, ShellExecResult } from '@noetic-tools/core';
+import type {
+  FsAdapter,
+  ShellAdapter,
+  ShellExecOptions,
+  ShellExecResult,
+} from '@noetic-tools/core';
 import { BashOutputSchema, createBashTool } from '../src/tools/bash.js';
 import { createEditTool, EditOutputSchema } from '../src/tools/edit.js';
 import type { MutationPolicy } from '../src/tools/mutation-policy.js';

--- a/packages/cli/test/reminder-layer.test.ts
+++ b/packages/cli/test/reminder-layer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-
+import { createLocalFsAdapter, createLocalShellAdapter } from '@noetic/platform-node';
 import type {
   ExecutionContext,
   FunctionCallItem,
@@ -12,7 +12,6 @@ import type {
   ScopedStorage,
 } from '@noetic-tools/core';
 import { Slot } from '@noetic-tools/core';
-import { createLocalFsAdapter, createLocalShellAdapter } from '@noetic/platform-node';
 
 import { reminderLayer } from '../src/memory/reminder-layer.js';
 import type { ReminderLayerState } from '../src/memory/reminder-triggers.js';

--- a/packages/cli/test/setup-platform.test.ts
+++ b/packages/cli/test/setup-platform.test.ts
@@ -10,9 +10,9 @@ describe('detectOs', () => {
     // We cannot actually flip process.platform — instead verify the current
     // platform is one of the four supported values and the resolver returns it.
     const result = detectOs();
-    expect(result === 'macos' || result === 'linux' || result === 'windows' || result === 'other').toBe(
-      true,
-    );
+    expect(
+      result === 'macos' || result === 'linux' || result === 'windows' || result === 'other',
+    ).toBe(true);
   });
 });
 

--- a/packages/cli/test/setup-resolver.test.ts
+++ b/packages/cli/test/setup-resolver.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'bun:test';
 
 import { resolveBinaryStatuses } from '../src/setup/resolver.js';
-import type { AgentConfig } from '../src/types/config.js';
 import type { BinaryDescriptor } from '../src/setup/types.js';
+import type { AgentConfig } from '../src/types/config.js';
 
 function makeConfig(ignored: ReadonlyArray<string> = []): AgentConfig {
   return {
@@ -50,9 +50,14 @@ describe('resolveBinaryStatuses', () => {
       manualInstructionsFor: () => '',
       affects: [],
     };
-    const result = await resolveBinaryStatuses(makeConfig(['rtk']), [
-      descriptor,
-    ]);
+    const result = await resolveBinaryStatuses(
+      makeConfig([
+        'rtk',
+      ]),
+      [
+        descriptor,
+      ],
+    );
     expect(result).toEqual([
       {
         id: 'rtk',
@@ -87,11 +92,16 @@ describe('resolveBinaryStatuses', () => {
   });
 
   it('handles mixed ignored / present / missing in one call', async () => {
-    const result = await resolveBinaryStatuses(makeConfig(['rtk']), [
-      makeDescriptor('rtk', true),
-      makeDescriptor('pilotty', true),
-      makeDescriptor('agent-browser', false),
-    ]);
+    const result = await resolveBinaryStatuses(
+      makeConfig([
+        'rtk',
+      ]),
+      [
+        makeDescriptor('rtk', true),
+        makeDescriptor('pilotty', true),
+        makeDescriptor('agent-browser', false),
+      ],
+    );
     expect(result).toEqual([
       {
         id: 'rtk',
@@ -109,9 +119,14 @@ describe('resolveBinaryStatuses', () => {
   });
 
   it('ignores unknown ids in the config silently', async () => {
-    const result = await resolveBinaryStatuses(makeConfig(['definitely-not-a-binary']), [
-      makeDescriptor('rtk', true),
-    ]);
+    const result = await resolveBinaryStatuses(
+      makeConfig([
+        'definitely-not-a-binary',
+      ]),
+      [
+        makeDescriptor('rtk', true),
+      ],
+    );
     expect(result).toEqual([
       {
         id: 'rtk',

--- a/packages/cli/test/steering-file-layer.test.ts
+++ b/packages/cli/test/steering-file-layer.test.ts
@@ -1,8 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-
+import { createLocalShellAdapter } from '@noetic/platform-node';
 import type { ExecutionContext, FsAdapter, ItemLog, ScopedStorage } from '@noetic-tools/core';
 import { Slot } from '@noetic-tools/core';
-import { createLocalShellAdapter } from '@noetic/platform-node';
 
 import { createSteeringFileLayer } from '../src/memory/steering-file-layer.js';
 import { MemFs } from './tasks/_helpers.js';

--- a/packages/cli/test/tasks/memory/fix-feedback-layer.test.ts
+++ b/packages/cli/test/tasks/memory/fix-feedback-layer.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import assert from 'node:assert';
-
-import type { ExecutionContext, Item, ItemLog, ScopedStorage } from '@noetic-tools/core';
 import { createLocalFsAdapter, createLocalShellAdapter } from '@noetic/platform-node';
+import type { ExecutionContext, Item, ItemLog, ScopedStorage } from '@noetic-tools/core';
 import type { AssertionOutcome } from '../../../src/tasks/runtime/hierarchy/schemas.js';
 import { AssertionStatus } from '../../../src/tasks/runtime/hierarchy/schemas.js';
 import type { FixFeedbackState } from '../../../src/tasks/runtime/memory/fix-feedback-layer.js';

--- a/packages/cli/test/tasks/memory/planner-attempt-layer.test.ts
+++ b/packages/cli/test/tasks/memory/planner-attempt-layer.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import assert from 'node:assert';
-
-import type { ExecutionContext, ScopedStorage } from '@noetic-tools/core';
 import { createLocalShellAdapter } from '@noetic/platform-node';
+import type { ExecutionContext, ScopedStorage } from '@noetic-tools/core';
 import type { PlannerAttemptState } from '../../../src/tasks/runtime/memory/planner-attempt-layer.js';
 import {
   createPlannerAttemptLayer,

--- a/packages/cli/test/tasks/planner-chat-e2e.test.ts
+++ b/packages/cli/test/tasks/planner-chat-e2e.test.ts
@@ -16,9 +16,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
-
-import { createFileStorage, createLocalFsAdapter } from '@noetic/platform-node';
-import { createLocalSubprocessAdapter } from '@noetic/platform-node';
+import {
+  createFileStorage,
+  createLocalFsAdapter,
+  createLocalSubprocessAdapter,
+} from '@noetic/platform-node';
 
 import { createTaskHandler } from '../../src/tasks/runtime/handlers/lifecycle.js';
 import { ensureChatTarget } from '../../src/tasks/runtime/resolve-chat-target.js';

--- a/packages/cli/test/teammate-inbound.test.ts
+++ b/packages/cli/test/teammate-inbound.test.ts
@@ -4,8 +4,8 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import type { DetachedHandle, ExecutionContext, Item, ItemLog } from '@noetic-tools/core';
 import { createLocalFsAdapter, createLocalShellAdapter } from '@noetic/platform-node';
+import type { DetachedHandle, ExecutionContext, Item, ItemLog } from '@noetic-tools/core';
 import { TeammateRegistry } from '../src/agents/registry-runtime.js';
 import { teammateInboundLayer } from '../src/memory/teammate-inbound-layer.js';
 

--- a/packages/cli/test/teammate-inbox-layer.test.ts
+++ b/packages/cli/test/teammate-inbox-layer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import type { ExecutionContext, Item, ItemLog } from '@noetic-tools/core';
 import { createLocalFsAdapter, createLocalShellAdapter } from '@noetic/platform-node';
+import type { ExecutionContext, Item, ItemLog } from '@noetic-tools/core';
 import { TeammateRegistry } from '../src/agents/registry-runtime.js';
 import { teammateInboxLayer } from '../src/memory/teammate-inbox-layer.js';
 

--- a/packages/code-agent/src/agents/plan.ts
+++ b/packages/code-agent/src/agents/plan.ts
@@ -9,8 +9,23 @@
  * act sub-agent.
  */
 
-import type { AskUserInput, AskUserOutput, Context, ContextMemory, Step, Tool } from '@noetic-tools/core';
-import { AskUserOutputSchema, branch, loop, spawn, step, tool, until } from '@noetic-tools/core/portable';
+import type {
+  AskUserInput,
+  AskUserOutput,
+  Context,
+  ContextMemory,
+  Step,
+  Tool,
+} from '@noetic-tools/core';
+import {
+  AskUserOutputSchema,
+  branch,
+  loop,
+  spawn,
+  step,
+  tool,
+  until,
+} from '@noetic-tools/core/portable';
 import { frameworkCast } from '@noetic-tools/core/unstable';
 import { z } from 'zod';
 import type { CodeAgentFlowState } from './flow-state.js';

--- a/packages/code-agent/src/tools/agent.ts
+++ b/packages/code-agent/src/tools/agent.ts
@@ -24,9 +24,9 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { createLocalFsAdapter } from '@noetic/platform-node';
 import type { ContextMemory, DetachedHandle, MemoryLayer, Tool } from '@noetic-tools/core';
 import { historyWindow, NoeticConfigError, react, spawn, step, tool } from '@noetic-tools/core';
-import { createLocalFsAdapter } from '@noetic/platform-node';
 import { retargetCwdForSpawn } from '@noetic-tools/core/unstable';
 import { z } from 'zod';
 

--- a/packages/code-agent/src/tools/bash.ts
+++ b/packages/code-agent/src/tools/bash.ts
@@ -9,7 +9,12 @@ import { createWriteStream } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { ShellAdapter, Tool, ToolExecutionContext } from '@noetic-tools/core';
-import { getToolCwd, setToolCwd, TIMEOUT_ERROR_PREFIX, toolWithGenerator } from '@noetic-tools/core';
+import {
+  getToolCwd,
+  setToolCwd,
+  TIMEOUT_ERROR_PREFIX,
+  toolWithGenerator,
+} from '@noetic-tools/core';
 import { z } from 'zod';
 import { handleCd, isPlainCdCommand, parseCdArg } from './cd-helper.js';
 import type { MutationPolicy } from './mutation-policy.js';

--- a/packages/code-agent/src/tools/index.ts
+++ b/packages/code-agent/src/tools/index.ts
@@ -10,7 +10,11 @@
  */
 
 import type { FsAdapter, ShellAdapter, Tool } from '@noetic-tools/core';
-import { createInMemoryFsAdapter, createInMemoryShellAdapter, tool } from '@noetic-tools/core/portable';
+import {
+  createInMemoryFsAdapter,
+  createInMemoryShellAdapter,
+  tool,
+} from '@noetic-tools/core/portable';
 import { z } from 'zod';
 import type { LspService } from '../lsp/service.js';
 import { createUnsupportedResult, detectRuntimeCapabilities } from '../runtime-capabilities.js';

--- a/packages/code-agent/src/tools/node-factory/core-tools.ts
+++ b/packages/code-agent/src/tools/node-factory/core-tools.ts
@@ -1,5 +1,5 @@
-import type { FsAdapter, ShellAdapter, Tool } from '@noetic-tools/core';
 import { createLocalFsAdapter, createLocalShellAdapter } from '@noetic/platform-node';
+import type { FsAdapter, ShellAdapter, Tool } from '@noetic-tools/core';
 import type { LspService } from '../../lsp/service.js';
 import type { AskUserService } from '../ask-user.js';
 import { createAskUserTool } from '../ask-user.js';

--- a/packages/code-agent/test/core-tools-availability.test.ts
+++ b/packages/code-agent/test/core-tools-availability.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import {
-  createCodingTools,
-  createReadOnlyTools,
-} from '../src/tools/node-factory/core-tools.js';
+import { createCodingTools, createReadOnlyTools } from '../src/tools/node-factory/core-tools.js';
 
 describe('createCodingTools — availableTools gating', () => {
   it('registers every tool by default', () => {

--- a/packages/core/test/schemas/workflow.test.ts
+++ b/packages/core/test/schemas/workflow.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'bun:test';
+import type { WorkflowNode } from '../../src/schemas/workflow';
 import {
   UntilPredicateSchema,
   validateWorkflow,
   WorkflowDocumentSchema,
-  type WorkflowNode,
   WorkflowNodeSchema,
   walkWorkflow,
   workflowDepth,

--- a/packages/platform-node/test/agent-ipc-client-durable.test.ts
+++ b/packages/platform-node/test/agent-ipc-client-durable.test.ts
@@ -12,7 +12,8 @@ import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { AgentIpcClient } from '../src/agent-ipc-client';
-import { encodeFrame, type ServerFrame } from '../src/agent-ipc-protocol';
+import type { ServerFrame } from '../src/agent-ipc-protocol';
+import { encodeFrame } from '../src/agent-ipc-protocol';
 
 let root: string;
 let server: Server;

--- a/packages/platform-node/test/ipc-durable-resume.test.ts
+++ b/packages/platform-node/test/ipc-durable-resume.test.ts
@@ -12,22 +12,16 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-
-import {
-  createInMemoryStorage,
-  type HarnessStatus,
-  type Item,
-  type StreamEvent,
-  type StreamingItem,
-} from '@noetic-tools/core';
+import type { HarnessStatus, Item, StreamEvent, StreamingItem } from '@noetic-tools/core';
+import { createInMemoryStorage } from '@noetic-tools/core';
 import { AgentIpcClient } from '../src/agent-ipc-client';
-import {
-  AgentIpcServer,
-  type ChatHistoryStore,
-  type IpcAskUserService,
-  type IpcHarness,
-  type TaskLogger,
+import type {
+  ChatHistoryStore,
+  IpcAskUserService,
+  IpcHarness,
+  TaskLogger,
 } from '../src/agent-ipc-server';
+import { AgentIpcServer } from '../src/agent-ipc-server';
 import { createLocalFsAdapter } from '../src/local-fs-adapter';
 
 //#region Test helpers

--- a/packages/platform-node/test/local-adapter-local-executor.test.ts
+++ b/packages/platform-node/test/local-adapter-local-executor.test.ts
@@ -61,7 +61,13 @@ describe('local adapter in-process step dispatch', () => {
     expect(settled?.status).toBe('failed');
     const error = settled?.metadata?.error;
     expect(typeof error).toBe('object');
-    expect((error as { message: string }).message).toBe('boom');
+    expect(
+      (
+        error as {
+          message: string;
+        }
+      ).message,
+    ).toBe('boom');
   });
 
   it('still rejects step requests when neither registryEntry nor _localExecutor is provided', async () => {

--- a/packages/platform-node/test/local-adapter-local-executor.test.ts
+++ b/packages/platform-node/test/local-adapter-local-executor.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import assert from 'node:assert';
 import type { StepSubprocessRequest } from '@noetic-tools/core';
 import { createLocalSubprocessAdapter } from '../src/local-subprocess-adapter';
 
@@ -60,14 +61,9 @@ describe('local adapter in-process step dispatch', () => {
     }
     expect(settled?.status).toBe('failed');
     const error = settled?.metadata?.error;
-    expect(typeof error).toBe('object');
-    expect(
-      (
-        error as {
-          message: string;
-        }
-      ).message,
-    ).toBe('boom');
+    expect(error).toBeInstanceOf(Object);
+    assert(error && typeof error === 'object' && 'message' in error);
+    expect(error.message).toBe('boom');
   });
 
   it('still rejects step requests when neither registryEntry nor _localExecutor is provided', async () => {

--- a/packages/platform-node/test/local-adapter-reattach.test.ts
+++ b/packages/platform-node/test/local-adapter-reattach.test.ts
@@ -12,8 +12,12 @@
  */
 
 import { afterEach, describe, expect, it } from 'bun:test';
-import { createInMemoryStorage, type SubprocessHandle } from '@noetic-tools/core';
-import { createLocalSubprocessAdapter, defaultProcessSignaller } from '../src/local-subprocess-adapter';
+import type { SubprocessHandle } from '@noetic-tools/core';
+import { createInMemoryStorage } from '@noetic-tools/core';
+import {
+  createLocalSubprocessAdapter,
+  defaultProcessSignaller,
+} from '../src/local-subprocess-adapter';
 
 const spawnedPids = new Set<number>();
 

--- a/packages/web/app/docs/layout.tsx
+++ b/packages/web/app/docs/layout.tsx
@@ -1,4 +1,5 @@
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
+import Link from 'next/link';
 import { MobileSectionTitle } from '@/components/docs/mobile-section-title';
 import { source } from '@/lib/source';
 
@@ -10,6 +11,13 @@ export default function Layout({ children }: { children: React.ReactNode }): Rea
         title: 'NOETIC',
         url: '/',
         children: <MobileSectionTitle />,
+      }}
+      sidebar={{
+        banner: (
+          <Link href="/docs" className="docs-index-link">
+            ← Docs index
+          </Link>
+        ),
       }}
     >
       {children}

--- a/packages/web/app/docs/layout.tsx
+++ b/packages/web/app/docs/layout.tsx
@@ -7,7 +7,7 @@ export default function Layout({ children }: { children: React.ReactNode }): Rea
     <DocsLayout
       tree={source.pageTree}
       nav={{
-        title: 'Noetic',
+        title: 'NOETIC',
         url: '/',
         children: <MobileSectionTitle />,
       }}

--- a/packages/web/app/docs/layout.tsx
+++ b/packages/web/app/docs/layout.tsx
@@ -1,5 +1,5 @@
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
-import Link from 'next/link';
+import { DocsIndexLink } from '@/components/docs/docs-index-link';
 import { MobileSectionTitle } from '@/components/docs/mobile-section-title';
 import { source } from '@/lib/source';
 
@@ -13,11 +13,7 @@ export default function Layout({ children }: { children: React.ReactNode }): Rea
         children: <MobileSectionTitle />,
       }}
       sidebar={{
-        banner: (
-          <Link href="/docs" className="docs-index-link">
-            ← Docs index
-          </Link>
-        ),
+        banner: <DocsIndexLink />,
       }}
     >
       {children}

--- a/packages/web/app/docs/layout.tsx
+++ b/packages/web/app/docs/layout.tsx
@@ -1,6 +1,16 @@
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
+import { MobileSectionTitle } from '@/components/docs/mobile-section-title';
 import { source } from '@/lib/source';
 
 export default function Layout({ children }: { children: React.ReactNode }): React.ReactNode {
-  return <DocsLayout tree={source.pageTree}>{children}</DocsLayout>;
+  return (
+    <DocsLayout
+      tree={source.pageTree}
+      nav={{
+        title: <MobileSectionTitle />,
+      }}
+    >
+      {children}
+    </DocsLayout>
+  );
 }

--- a/packages/web/app/docs/layout.tsx
+++ b/packages/web/app/docs/layout.tsx
@@ -7,7 +7,9 @@ export default function Layout({ children }: { children: React.ReactNode }): Rea
     <DocsLayout
       tree={source.pageTree}
       nav={{
-        title: <MobileSectionTitle />,
+        title: 'Noetic',
+        url: '/',
+        children: <MobileSectionTitle />,
       }}
     >
       {children}

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -809,13 +809,12 @@
 /* Mobile: 'Noetic' stays on the left (default brand title slot, links
    to nav.url '/'). The dynamic section name lives in nav.children, which
    fumadocs renders inside a `flex-1` div between the title and the
-   search button. Right-align that div so the section name sits next to
-   the search icon. */
+   search button. Left-align that div so the section name sits next to
+   Noetic (breadcrumb pattern: `Noetic > Framework`). */
 @media (max-width: 767px) {
   #nd-subnav > div.flex-1 {
     display: flex;
-    justify-content: flex-end;
+    justify-content: flex-start;
     align-items: center;
-    padding-right: 8px;
   }
 }

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -806,15 +806,29 @@
   }
 }
 
-/* Mobile: 'Noetic' stays on the left (default brand title slot, links
-   to nav.url '/'). The dynamic section name lives in nav.children, which
-   fumadocs renders inside a `flex-1` div between the title and the
-   search button. Left-align that div so the section name sits next to
-   Noetic (breadcrumb pattern: `Noetic > Framework`). */
+/* Docs header: 'NOETIC / <section>' breadcrumb in both the mobile sticky
+   header (#nd-subnav) and the desktop sidebar title row (#nd-sidebar).
+   Same treatment as the landing-page .nav-brand class. */
+#nd-subnav > a:first-of-type,
+#nd-sidebar a[href='/'] {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  color: var(--color-tui-green);
+  letter-spacing: 0.1em;
+}
+
+/* Grey, slightly muted, the / separator. */
+.docs-section-separator {
+  color: var(--color-tui-muted);
+  font-weight: 400;
+  letter-spacing: 0;
+}
+
+/* Mobile header layout: equal 8px spacing between NOETIC, /, section name. */
 @media (max-width: 767px) {
-  /* Equal spacing between NOETIC, >, and the section name. */
   #nd-subnav {
     gap: 8px;
+    align-items: center;
   }
   #nd-subnav > div.flex-1 {
     display: flex;
@@ -822,11 +836,20 @@
     align-items: center;
     gap: 8px;
   }
-  /* Match the landing-page .nav-brand treatment for the NOETIC wordmark. */
-  #nd-subnav > a:first-of-type {
-    font-family: 'JetBrains Mono', monospace;
-    font-weight: 700;
-    color: var(--color-tui-green);
-    letter-spacing: 0.1em;
+}
+
+/* Desktop sidebar header row: drop fumadocs's `me-auto` push so NOETIC,
+   the separator, and the section name sit adjacent with equal 8px spacing.
+   Collapse button stays on the far right via margin-left:auto. */
+@media (min-width: 768px) {
+  #nd-sidebar a[href='/'] {
+    margin-inline-end: 0;
+  }
+  #nd-sidebar > div:first-child > div.flex:first-child {
+    gap: 8px;
+    align-items: center;
+  }
+  #nd-sidebar button[aria-label='Collapse Sidebar'] {
+    margin-left: auto;
   }
 }

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -812,10 +812,15 @@
    search button. Left-align that div so the section name sits next to
    Noetic (breadcrumb pattern: `Noetic > Framework`). */
 @media (max-width: 767px) {
+  /* Equal spacing between NOETIC, >, and the section name. */
+  #nd-subnav {
+    gap: 8px;
+  }
   #nd-subnav > div.flex-1 {
     display: flex;
     justify-content: flex-start;
     align-items: center;
+    gap: 8px;
   }
   /* Match the landing-page .nav-brand treatment for the NOETIC wordmark. */
   #nd-subnav > a:first-of-type {

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -805,3 +805,11 @@
     font-size: 12px;
   }
 }
+
+/* Mobile: push the brand/section title next to the search icon
+   (fumadocs default puts it on the far left of #nd-subnav). */
+@media (max-width: 767px) {
+  #nd-subnav > a:first-of-type {
+    margin-left: auto;
+  }
+}

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -866,3 +866,17 @@
 .docs-index-link:hover {
   color: var(--color-tui-green);
 }
+
+/* fumadocs renders the banner BELOW the section dropdown; move the
+   dropdown to a later flex order so 'Docs index' lands above it. */
+#nd-sidebar > div:first-child > button[data-state] {
+  order: 1;
+}
+
+/* Desktop sidebar wide enough to fit 'Code Agent CLI' on one line in
+   the section selector dropdown (default 268px clips it). */
+@media (min-width: 768px) {
+  #nd-docs-layout {
+    --fd-sidebar-width: 320px;
+  }
+}

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -853,3 +853,16 @@
     margin-left: auto;
   }
 }
+
+/* "Docs index" affordance in the sidebar/drawer banner slot. */
+.docs-index-link {
+  display: block;
+  padding: 6px 0;
+  color: var(--color-tui-secondary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  text-decoration: none;
+}
+.docs-index-link:hover {
+  color: var(--color-tui-green);
+}

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -806,10 +806,16 @@
   }
 }
 
-/* Mobile: push the brand/section title next to the search icon
-   (fumadocs default puts it on the far left of #nd-subnav). */
+/* Mobile: 'Noetic' stays on the left (default brand title slot, links
+   to nav.url '/'). The dynamic section name lives in nav.children, which
+   fumadocs renders inside a `flex-1` div between the title and the
+   search button. Right-align that div so the section name sits next to
+   the search icon. */
 @media (max-width: 767px) {
-  #nd-subnav > a:first-of-type {
-    margin-left: auto;
+  #nd-subnav > div.flex-1 {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding-right: 8px;
   }
 }

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -781,3 +781,27 @@
     display: none;
   }
 }
+
+/* Docs: smaller type on mobile so headings don't dominate the viewport
+   and copy fits without horizontal clipping. fumadocs renders prose with
+   `.prose` on the article body. */
+@media (max-width: 767px) {
+  .prose {
+    font-size: 14px;
+  }
+  .prose h1 {
+    font-size: 22px;
+  }
+  .prose h2 {
+    font-size: 18px;
+  }
+  .prose h3 {
+    font-size: 16px;
+  }
+  .prose h4 {
+    font-size: 13px;
+  }
+  .prose code {
+    font-size: 12px;
+  }
+}

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -817,4 +817,11 @@
     justify-content: flex-start;
     align-items: center;
   }
+  /* Match the landing-page .nav-brand treatment for the NOETIC wordmark. */
+  #nd-subnav > a:first-of-type {
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 700;
+    color: var(--color-tui-green);
+    letter-spacing: 0.1em;
+  }
 }

--- a/packages/web/app/global.css
+++ b/packages/web/app/global.css
@@ -810,8 +810,8 @@
    header (#nd-subnav) and the desktop sidebar title row (#nd-sidebar).
    Same treatment as the landing-page .nav-brand class. */
 #nd-subnav > a:first-of-type,
-#nd-sidebar a[href='/'] {
-  font-family: 'JetBrains Mono', monospace;
+#nd-sidebar a[href="/"] {
+  font-family: "JetBrains Mono", monospace;
   font-weight: 700;
   color: var(--color-tui-green);
   letter-spacing: 0.1em;
@@ -842,14 +842,14 @@
    the separator, and the section name sit adjacent with equal 8px spacing.
    Collapse button stays on the far right via margin-left:auto. */
 @media (min-width: 768px) {
-  #nd-sidebar a[href='/'] {
+  #nd-sidebar a[href="/"] {
     margin-inline-end: 0;
   }
   #nd-sidebar > div:first-child > div.flex:first-child {
     gap: 8px;
     align-items: center;
   }
-  #nd-sidebar button[aria-label='Collapse Sidebar'] {
+  #nd-sidebar button[aria-label="Collapse Sidebar"] {
     margin-left: auto;
   }
 }
@@ -859,7 +859,7 @@
   display: block;
   padding: 6px 0;
   color: var(--color-tui-secondary);
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 13px;
   text-decoration: none;
 }

--- a/packages/web/components/docs/docs-index-link.tsx
+++ b/packages/web/components/docs/docs-index-link.tsx
@@ -1,0 +1,16 @@
+'use client';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+export function DocsIndexLink(): ReactNode {
+  const pathname = usePathname();
+  if (pathname === '/docs') {
+    return null;
+  }
+  return (
+    <Link href="/docs" className="docs-index-link">
+      ← Docs index
+    </Link>
+  );
+}

--- a/packages/web/components/docs/mobile-section-title.tsx
+++ b/packages/web/components/docs/mobile-section-title.tsx
@@ -22,5 +22,10 @@ export function MobileSectionTitle(): ReactNode {
   if (!section) {
     return null;
   }
-  return <span>{section.name}</span>;
+  return (
+    <span>
+      <span aria-hidden="true"> &gt; </span>
+      {section.name}
+    </span>
+  );
 }

--- a/packages/web/components/docs/mobile-section-title.tsx
+++ b/packages/web/components/docs/mobile-section-title.tsx
@@ -1,0 +1,23 @@
+'use client';
+import { usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+const SECTIONS: Array<{
+  urlPrefix: string;
+  name: string;
+}> = [
+  {
+    urlPrefix: '/docs/framework',
+    name: 'Framework',
+  },
+  {
+    urlPrefix: '/docs/code-agent-cli',
+    name: 'Code Agent CLI',
+  },
+];
+
+export function MobileSectionTitle(): ReactNode {
+  const pathname = usePathname();
+  const section = SECTIONS.find((s) => pathname.startsWith(s.urlPrefix));
+  return <span>{section?.name ?? ''}</span>;
+}

--- a/packages/web/components/docs/mobile-section-title.tsx
+++ b/packages/web/components/docs/mobile-section-title.tsx
@@ -19,15 +19,12 @@ const SECTIONS: Array<{
 export function MobileSectionTitle(): ReactNode {
   const pathname = usePathname();
   const section = SECTIONS.find((s) => pathname.startsWith(s.urlPrefix));
-  if (!section) {
-    return null;
-  }
   return (
     <>
       <span aria-hidden="true" className="docs-section-separator">
         /
       </span>
-      <span>{section.name}</span>
+      <span>{section?.name ?? 'Docs'}</span>
     </>
   );
 }

--- a/packages/web/components/docs/mobile-section-title.tsx
+++ b/packages/web/components/docs/mobile-section-title.tsx
@@ -24,7 +24,9 @@ export function MobileSectionTitle(): ReactNode {
   }
   return (
     <>
-      <span aria-hidden="true">&gt;</span>
+      <span aria-hidden="true" className="docs-section-separator">
+        /
+      </span>
       <span>{section.name}</span>
     </>
   );

--- a/packages/web/components/docs/mobile-section-title.tsx
+++ b/packages/web/components/docs/mobile-section-title.tsx
@@ -19,5 +19,5 @@ const SECTIONS: Array<{
 export function MobileSectionTitle(): ReactNode {
   const pathname = usePathname();
   const section = SECTIONS.find((s) => pathname.startsWith(s.urlPrefix));
-  return <span>{section?.name ?? ''}</span>;
+  return <span>{section?.name ?? 'Noetic'}</span>;
 }

--- a/packages/web/components/docs/mobile-section-title.tsx
+++ b/packages/web/components/docs/mobile-section-title.tsx
@@ -23,9 +23,9 @@ export function MobileSectionTitle(): ReactNode {
     return null;
   }
   return (
-    <span>
-      <span aria-hidden="true"> &gt; </span>
-      {section.name}
-    </span>
+    <>
+      <span aria-hidden="true">&gt;</span>
+      <span>{section.name}</span>
+    </>
   );
 }

--- a/packages/web/components/docs/mobile-section-title.tsx
+++ b/packages/web/components/docs/mobile-section-title.tsx
@@ -19,5 +19,8 @@ const SECTIONS: Array<{
 export function MobileSectionTitle(): ReactNode {
   const pathname = usePathname();
   const section = SECTIONS.find((s) => pathname.startsWith(s.urlPrefix));
-  return <span>{section?.name ?? 'Noetic'}</span>;
+  if (!section) {
+    return null;
+  }
+  return <span>{section.name}</span>;
 }

--- a/packages/web/content/docs/framework/json-runtime.mdx
+++ b/packages/web/content/docs/framework/json-runtime.mdx
@@ -48,10 +48,10 @@ The JSON Workflow Runtime lets you express agent workflows as portable JSON docu
 
 Every workflow document is an envelope with a `version` field and a `root` node:
 
-```ts
+```json
 {
   "version": 1,
-  "root": { /* WorkflowNode */ }
+  "root": { "...": "WorkflowNode" }
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds a section breadcrumb header to the docs site (mobile sticky header and desktop sidebar) and reduces docs prose font sizes on mobile so headings don't dominate the viewport.

## What's in this PR

**Mobile + desktop header/sidebar — same breadcrumb pattern**
- `NOETIC / <section>` where `<section>` is `Docs` on `/docs`, `Framework` on `/docs/framework/*`, `Code Agent CLI` on `/docs/code-agent-cli/*`
- `NOETIC` styled to match the landing-page `.nav-brand` class — JetBrains Mono, weight 700, accent green (`--color-tui-green`), 0.1em letter-spacing — and links to `/`
- `/` separator in muted grey (`--color-tui-muted`)
- Equal 8px gap between all three tokens (vertically centered)

**New "← Docs index" link** in the sidebar / mobile drawer banner slot
- Placed above the section dropdown (via flex `order` on the dropdown button)
- Hides automatically when already on `/docs`

**Mobile prose type scale tightened**
- Body 16→14px, H1 28→22px, H2 22→18px, H3 18→16px, H4 14→13px, inline code 13→12px

**Desktop sidebar width**
- `--fd-sidebar-width` bumped 268→320px (≥768px) so `Code Agent CLI` fits on one line in the section dropdown

## New components

- `packages/web/components/docs/mobile-section-title.tsx` — client component reading pathname, renders the `/ + section name` slot in `nav.children`
- `packages/web/components/docs/docs-index-link.tsx` — client component rendering the `← Docs index` link, returns `null` when on `/docs`

## How it fits with fumadocs

Uses fumadocs's native `nav.title` / `nav.children` / `sidebar.banner` slots — no custom chrome, no replacement of `DocsLayout`. CSS overrides target fumadocs IDs (`#nd-subnav`, `#nd-sidebar`) to apply the brand styling and reorder the banner above the section dropdown.

## Test plan

- [ ] Visual check at 360px / 390px / 768px / 1280px viewports
- [ ] `/docs` shows `NOETIC / Docs`, no Docs-index link in sidebar
- [ ] `/docs/framework/*` shows `NOETIC / Framework`, Docs-index link visible above section dropdown
- [ ] `/docs/code-agent-cli/*` shows `NOETIC / Code Agent CLI` on one line in desktop sidebar
- [ ] Tapping `NOETIC` navigates to `/`
- [ ] Tapping `← Docs index` navigates to `/docs`
- [ ] Mobile body copy is visibly smaller, no horizontal scroll at 360px