### PR TITLE
fix(cli): correct rtk Homebrew tap name in install instructions

### DIFF
--- a/packages/cli/src/setup/binary-manifest.ts
+++ b/packages/cli/src/setup/binary-manifest.ts
@@ -27,7 +27,7 @@ function rtkInstallOptions(
       command: 'brew',
       args: [
         'install',
-        'rtk-ai/rtk/rtk',
+        'rtk-ai/tap/rtk',
       ],
       requiresPackageManager: 'brew',
     });
@@ -65,7 +65,7 @@ function rtkManualInstructions(os: OsKind): string {
   if (os === 'macos') {
     return [
       'Install rtk with one of:',
-      '  brew install rtk-ai/rtk/rtk',
+      '  brew install rtk-ai/tap/rtk',
       `  ${RTK_CURL_SCRIPT}`,
       '  cargo install --git https://github.com/rtk-ai/rtk',
     ].join('\n');
@@ -75,7 +75,7 @@ function rtkManualInstructions(os: OsKind): string {
       'Install rtk with one of:',
       `  ${RTK_CURL_SCRIPT}`,
       '  cargo install --git https://github.com/rtk-ai/rtk',
-      '  brew install rtk-ai/rtk/rtk   (if you have Homebrew on Linux)',
+      '  brew install rtk-ai/tap/rtk   (if you have Homebrew on Linux)',
     ].join('\n');
   }
   if (os === 'windows') {

--- a/packages/cli/test/setup-binary-manifest.test.ts
+++ b/packages/cli/test/setup-binary-manifest.test.ts
@@ -81,7 +81,7 @@ describe('BINARY_MANIFEST.installOptionsFor — agent-browser', () => {
 describe('BINARY_MANIFEST.manualInstructionsFor', () => {
   it('returns OS-specific instructions for rtk on macOS', () => {
     const text = descriptorFor('rtk').manualInstructionsFor('macos');
-    expect(text).toContain('brew install rtk-ai/rtk/rtk');
+    expect(text).toContain('brew install rtk-ai/tap/rtk');
   });
 
   it('returns OS-specific instructions for rtk on Linux', () => {

--- a/packages/web/content/docs/code-agent-cli/configuration.mdx
+++ b/packages/web/content/docs/code-agent-cli/configuration.mdx
@@ -71,7 +71,7 @@ export default {
 | `worktree` | `WorktreeConfig` | — | Sub-agent isolation config — see [Hooks](/docs/code-agent-cli/hooks). |
 | `ui.doublePressWindowMs` | `int` 100–5000 | `800` | Window in ms within which a second `Ctrl+C` / `Ctrl+D` press triggers a graceful exit. |
 | `history.maxItems` | `int` 2–10000 | — | Cap on trailing items projected to the LLM each turn. Storage is untouched — this is a read-side projection only. When unset, history is uncapped. |
-| `shell.useRtk` | `boolean` | `true` | Wrap every command run by the bash tool through [`rtk rewrite`](https://github.com/rtk-ai/rtk) for token-efficient output. When `true` (the default) `rtk` is required on `PATH` — startup fails fast with install instructions if it is missing. Set `false` to opt out and run raw `sh -c` instead. Install rtk via `brew install rtk`, `cargo install --git https://github.com/rtk-ai/rtk`, or the upstream `install.sh`. |
+| `shell.useRtk` | `boolean` | `true` | Wrap every command run by the bash tool through [`rtk rewrite`](https://github.com/rtk-ai/rtk) for token-efficient output. When `true` (the default) `rtk` is required on `PATH` — startup fails fast with install instructions if it is missing. Set `false` to opt out and run raw `sh -c` instead. Install rtk via `brew install rtk-ai/tap/rtk`, `cargo install --git https://github.com/rtk-ai/rtk`, or the upstream `install.sh`. |
 | `agents` | `Record<string, AgentOverride>` | — | Per-sub-agent overrides keyed by `agent-type` (e.g. `explore`, `plan`, `verification`). Each override beats the matching SKILL.md frontmatter. Surfaced via the `/config` TUI editor. |
 
 ### `AgentOverride`


### PR DESCRIPTION
## Why

Running the install command we currently print to users fails:

```
$ brew install rtk-ai/rtk/rtk
==> Tapping rtk-ai/rtk
Cloning into '/opt/homebrew/Library/Taps/rtk-ai/homebrew-rtk'...
remote: Repository not found.
fatal: repository 'https://github.com/rtk-ai/homebrew-rtk/' not found
Error: Failure while executing; `git clone https://github.com/rtk-ai/homebrew-rtk ...` exited with 128.
```

Homebrew's `<user>/<tap>/<formula>` shortcut resolves the middle segment by prepending `homebrew-`. So `rtk-ai/rtk/rtk` looks for `github.com/rtk-ai/homebrew-rtk`, which does not exist (404).

The actual upstream tap lives at [`rtk-ai/homebrew-tap`](https://github.com/rtk-ai/homebrew-tap) and contains `Formula/rtk.rb`. The correct invocation is therefore:

```
brew install rtk-ai/tap/rtk
```

I confirmed this against the GitHub Contents API: `homebrew-tap` exists (HTTP 200) and contains `rtk.rb`; `homebrew-rtk` is 404.

## Summary
- `packages/cli/src/setup/binary-manifest.ts` — fix the Homebrew install option (`rtk-ai/rtk/rtk` → `rtk-ai/tap/rtk`) and the macOS + Linux manual-instructions strings that print the same command.
- `packages/cli/test/setup-binary-manifest.test.ts` — update the matching `toContain` assertion.
- `packages/web/content/docs/code-agent-cli/configuration.mdx` — the configuration docs suggested plain `brew install rtk`, which also wouldn't find the formula without the tap prefix. Updated to `brew install rtk-ai/tap/rtk`.

The cargo and curl install paths were unaffected and remain unchanged.

## Test plan
- [x] `bun test test/setup-binary-manifest.test.ts` passes (10/10)
- [x] `bun run typecheck` clean
- [x] `grep -rn "rtk-ai/rtk/rtk\|brew install rtk[^-]" --include="*.md" --include="*.mdx" --include="*.ts" --include="*.tsx"` returns no matches
- [ ] Manual: run `brew install rtk-ai/tap/rtk` end-to-end on macOS to confirm the corrected command installs the binary