### PR TITLE
fix(code-agent): make the CLI chat actually work (mode reset + de-spawn actAgent)

### DIFF
--- a/packages/cli/test/stream-consumers.test.ts
+++ b/packages/cli/test/stream-consumers.test.ts
@@ -420,6 +420,52 @@ describe('consumeFullStream', () => {
     expect(setup.settled).toEqual([]);
   });
 
+  test('multi-turn: a single long-lived consumer sees turn_started for every turn', async () => {
+    // This guards the CLI's actual wiring pattern: `wireStreams` attaches
+    // ONE consumer per harness instance, and the consumer is expected to
+    // flip `status` to 'streaming' on EVERY turn's `turn_started`, not just
+    // the first. A regression here looks like "second submit produces no
+    // spinner and the UI feels frozen".
+    const setup = setupEventConsumer();
+    const run = consumeFullStream(setup.opts);
+
+    // Turn 1
+    setup.controls.events.push(
+      frameworkEvent('turn_started', {
+        messageIds: [
+          'm-1',
+        ],
+      }),
+    );
+    setup.controls.events.push(frameworkEvent('turn_completed'));
+    await tick();
+
+    // Turn 2 — exact same broadcaster, no rewiring.
+    setup.controls.events.push(
+      frameworkEvent('turn_started', {
+        messageIds: [
+          'm-2',
+        ],
+      }),
+    );
+    setup.controls.events.push(frameworkEvent('turn_completed'));
+    await tick();
+
+    setup.controls.events.end();
+    await run;
+
+    // Each turn must flip status to 'streaming' on turn_started and back to
+    // 'ready' on turn_completed (the harness is idle between turns in this
+    // fixture, so handleTurnSettled always lands on 'ready').
+    expect(setup.statuses).toEqual([
+      'streaming',
+      'ready',
+      'streaming',
+      'ready',
+    ]);
+    expect(setup.settled).toHaveLength(2);
+  });
+
   test('stale flip before an event suppresses all effects', async () => {
     const setup = setupEventConsumer();
     const run = consumeFullStream(setup.opts);

--- a/packages/code-agent/src/agents/act.ts
+++ b/packages/code-agent/src/agents/act.ts
@@ -12,7 +12,7 @@
  */
 
 import type { Context, ContextMemory, Step } from '@noetic-tools/core';
-import { loop, spawn, step, until } from '@noetic-tools/core/portable';
+import { loop, step, until } from '@noetic-tools/core/portable';
 import { persistFlowState, readFlowState, writeFlowState } from './flow-state.js';
 import {
   countDiffLines,
@@ -96,30 +96,35 @@ export const postActCheckStep: Step<ContextMemory, string, string> = step.run({
 
 //#region Act agent
 
-export const actAgent: Step<ContextMemory, string, string> = spawn({
+/**
+ * Act agent runs in the parent context — NOT inside a `spawn()`. The
+ * user-facing assistant IS the conversation; wrapping it in spawn would
+ * give it a fresh `itemLog`, severing the user's message and all prior
+ * turn history from the LLM call. `spawn()` is reserved for true
+ * sub-agents (planAgent, teammates, sub-harnesses) that intentionally
+ * don't see the parent transcript.
+ */
+export const actAgent: Step<ContextMemory, string, string> = loop({
   id: 'code-agent/act-agent',
-  child: loop({
-    id: 'code-agent/act-loop',
-    steps: [
-      preActCaptureStep,
-      step.llm<ContextMemory, string, string>({
-        id: 'code-agent/act-chat',
-        model: (ctx: Context<ContextMemory>) => readParam(ctx, 'model', '', isString),
-        instructions: (ctx: Context<ContextMemory>) => {
-          const user = readParam(ctx, 'instructions', '', isString);
-          return [
-            user,
-            ACT_SYSTEM_INSTRUCTIONS,
-          ]
-            .filter(Boolean)
-            .join('\n\n');
-        },
-        tools: readUnifiedTools,
-      }),
-      postActCheckStep,
-    ],
-    until: until.noToolCalls(),
-  }),
+  steps: [
+    preActCaptureStep,
+    step.llm<ContextMemory, string, string>({
+      id: 'code-agent/act-chat',
+      model: (ctx: Context<ContextMemory>) => readParam(ctx, 'model', '', isString),
+      instructions: (ctx: Context<ContextMemory>) => {
+        const user = readParam(ctx, 'instructions', '', isString);
+        return [
+          user,
+          ACT_SYSTEM_INSTRUCTIONS,
+        ]
+          .filter(Boolean)
+          .join('\n\n');
+      },
+      tools: readUnifiedTools,
+    }),
+    postActCheckStep,
+  ],
+  until: until.noToolCalls(),
 });
 
 //#endregion

--- a/packages/code-agent/src/agents/act.ts
+++ b/packages/code-agent/src/agents/act.ts
@@ -101,11 +101,16 @@ export const postActCheckStep: Step<ContextMemory, string, string> = step.run({
  * user-facing assistant IS the conversation; wrapping it in spawn would
  * give it a fresh `itemLog`, severing the user's message and all prior
  * turn history from the LLM call. `spawn()` is reserved for true
- * sub-agents (planAgent, teammates, sub-harnesses) that intentionally
- * don't see the parent transcript.
+ * sub-agents (planAgent, verify, fix, teammates, sub-harnesses) that
+ * intentionally don't see the parent transcript.
+ *
+ * The step id is `code-agent/act-loop` — preserving the previous inner
+ * loop's id so observability spans / eval baselines keyed on it stay
+ * matched. The outer `code-agent/act-agent` spawn span is structurally
+ * gone, which is intrinsic to the fix.
  */
 export const actAgent: Step<ContextMemory, string, string> = loop({
-  id: 'code-agent/act-agent',
+  id: 'code-agent/act-loop',
   steps: [
     preActCaptureStep,
     step.llm<ContextMemory, string, string>({

--- a/packages/code-agent/src/agents/fix.ts
+++ b/packages/code-agent/src/agents/fix.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Context, ContextMemory, Step } from '@noetic-tools/core';
-import { loop, spawn, step, until } from '@noetic-tools/core/portable';
+import { loop, step, until } from '@noetic-tools/core/portable';
 import { persistFlowState, readFlowState, writeFlowState } from './flow-state.js';
 import {
   countDiffLines,
@@ -93,33 +93,32 @@ export const fixCompleteStep: Step<ContextMemory, string, string> = step.run({
 
 //#region Fix agent
 
-export const fixAgent: Step<ContextMemory, string, string> = spawn({
+// Fix runs in the parent context — see actAgent's comment for the
+// rationale. The fix phase continues the same user-facing conversation.
+export const fixAgent: Step<ContextMemory, string, string> = loop({
   id: 'code-agent/fix-agent',
-  child: loop({
-    id: 'code-agent/fix-loop',
-    steps: [
-      preFixCaptureStep,
-      step.llm<ContextMemory, string, string>({
-        id: 'code-agent/fix-chat',
-        model: (ctx: Context<ContextMemory>) => readParam(ctx, 'model', '', isString),
-        instructions: (ctx: Context<ContextMemory>) => {
-          const user = readParam(ctx, 'instructions', '', isString);
-          const state = readFlowState(ctx);
-          const findings = state.verifyFindings ?? '';
-          return [
-            user,
-            FIX_SYSTEM_INSTRUCTIONS,
-            `Verify findings:\n${findings}`,
-          ]
-            .filter(Boolean)
-            .join('\n\n');
-        },
-        tools: readUnifiedTools,
-      }),
-      fixCompleteStep,
-    ],
-    until: until.noToolCalls(),
-  }),
+  steps: [
+    preFixCaptureStep,
+    step.llm<ContextMemory, string, string>({
+      id: 'code-agent/fix-chat',
+      model: (ctx: Context<ContextMemory>) => readParam(ctx, 'model', '', isString),
+      instructions: (ctx: Context<ContextMemory>) => {
+        const user = readParam(ctx, 'instructions', '', isString);
+        const state = readFlowState(ctx);
+        const findings = state.verifyFindings ?? '';
+        return [
+          user,
+          FIX_SYSTEM_INSTRUCTIONS,
+          `Verify findings:\n${findings}`,
+        ]
+          .filter(Boolean)
+          .join('\n\n');
+      },
+      tools: readUnifiedTools,
+    }),
+    fixCompleteStep,
+  ],
+  until: until.noToolCalls(),
 });
 
 //#endregion

--- a/packages/code-agent/src/agents/fix.ts
+++ b/packages/code-agent/src/agents/fix.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Context, ContextMemory, Step } from '@noetic-tools/core';
-import { loop, step, until } from '@noetic-tools/core/portable';
+import { loop, spawn, step, until } from '@noetic-tools/core/portable';
 import { persistFlowState, readFlowState, writeFlowState } from './flow-state.js';
 import {
   countDiffLines,
@@ -93,32 +93,38 @@ export const fixCompleteStep: Step<ContextMemory, string, string> = step.run({
 
 //#region Fix agent
 
-// Fix runs in the parent context — see actAgent's comment for the
-// rationale. The fix phase continues the same user-facing conversation.
-export const fixAgent: Step<ContextMemory, string, string> = loop({
+// Fix intentionally STAYS spawned. Unlike actAgent, the fixer doesn't read
+// the user turn from the conversation itemLog — its instructions come from
+// the `instructions` param + flow-state `verifyFindings`. Keeping it
+// spawned holds its tool-call noise and its assistant output out of the
+// user-facing transcript and out of the next act turn's LLM context.
+export const fixAgent: Step<ContextMemory, string, string> = spawn({
   id: 'code-agent/fix-agent',
-  steps: [
-    preFixCaptureStep,
-    step.llm<ContextMemory, string, string>({
-      id: 'code-agent/fix-chat',
-      model: (ctx: Context<ContextMemory>) => readParam(ctx, 'model', '', isString),
-      instructions: (ctx: Context<ContextMemory>) => {
-        const user = readParam(ctx, 'instructions', '', isString);
-        const state = readFlowState(ctx);
-        const findings = state.verifyFindings ?? '';
-        return [
-          user,
-          FIX_SYSTEM_INSTRUCTIONS,
-          `Verify findings:\n${findings}`,
-        ]
-          .filter(Boolean)
-          .join('\n\n');
-      },
-      tools: readUnifiedTools,
-    }),
-    fixCompleteStep,
-  ],
-  until: until.noToolCalls(),
+  child: loop({
+    id: 'code-agent/fix-loop',
+    steps: [
+      preFixCaptureStep,
+      step.llm<ContextMemory, string, string>({
+        id: 'code-agent/fix-chat',
+        model: (ctx: Context<ContextMemory>) => readParam(ctx, 'model', '', isString),
+        instructions: (ctx: Context<ContextMemory>) => {
+          const user = readParam(ctx, 'instructions', '', isString);
+          const state = readFlowState(ctx);
+          const findings = state.verifyFindings ?? '';
+          return [
+            user,
+            FIX_SYSTEM_INSTRUCTIONS,
+            `Verify findings:\n${findings}`,
+          ]
+            .filter(Boolean)
+            .join('\n\n');
+        },
+        tools: readUnifiedTools,
+      }),
+      fixCompleteStep,
+    ],
+    until: until.noToolCalls(),
+  }),
 });
 
 //#endregion

--- a/packages/code-agent/src/agents/flow-state.ts
+++ b/packages/code-agent/src/agents/flow-state.ts
@@ -157,6 +157,15 @@ export function setFlowMemoryDefaultMode(mode: CodeAgentMode): void {
 }
 
 /**
+ * @public Read the host-configured default starting mode. Used by `doneStep`
+ * to reset `mode` after a workflow completes so the NEXT user turn re-enters
+ * the act/plan loop rather than short-circuiting to `doneStep` again.
+ */
+export function getFlowMemoryDefaultMode(): CodeAgentMode {
+  return DEFAULT_INITIAL_MODE;
+}
+
+/**
  * Memory layer tracking the top-level workflow mode, outstanding approval
  * requests, and fix-loop bookkeeping. `provides.state` exposes a typed read
  * projection on `ctx.memory['code-agent-flow'].state`.

--- a/packages/code-agent/src/agents/verify.ts
+++ b/packages/code-agent/src/agents/verify.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Context, ContextMemory, Step } from '@noetic-tools/core';
-import { loop, step, until } from '@noetic-tools/core/portable';
+import { loop, spawn, step, until } from '@noetic-tools/core/portable';
 import { persistFlowState, readFlowState, writeFlowState } from './flow-state.js';
 import {
   DEFAULT_MAX_FIX_ATTEMPTS,
@@ -138,21 +138,28 @@ export const verifyCheckStep: Step<ContextMemory, string, string> = step.run({
 
 //#region Verify agent
 
-// Verify runs in the parent context — see actAgent's comment for the
-// rationale. Sub-agent isolation belongs to planAgent and teammates; the
-// verify phase is part of the user-facing conversation.
-const verifyAgentInner: Step<ContextMemory, string, string> = loop({
+// Verify intentionally STAYS spawned. Unlike actAgent, the verifier never
+// reads the user message from the conversation itemLog — its instructions
+// are static (VERIFY_SYSTEM_INSTRUCTIONS) and it discovers repo state via
+// read-only tools. A spawned (empty) itemLog is exactly what we want: it
+// keeps the adversarial reviewer's PASS/FAIL output and its Read/Grep/Bash
+// tool-call noise OUT of the user-facing transcript and out of the next
+// act turn's LLM context.
+const verifyAgentInner: Step<ContextMemory, string, string> = spawn({
   id: 'code-agent/verify-agent',
-  steps: [
-    step.llm<ContextMemory, string, string>({
-      id: 'code-agent/verify-chat',
-      model: (ctx: Context<ContextMemory>) => readParam(ctx, 'model', '', isString),
-      instructions: () => VERIFY_SYSTEM_INSTRUCTIONS,
-      tools: (ctx: Context<ContextMemory>) =>
-        filterToolsByNames(readUnifiedTools(ctx), VERIFY_MODE_TOOL_NAMES),
-    }),
-  ],
-  until: until.noToolCalls(),
+  child: loop({
+    id: 'code-agent/verify-loop',
+    steps: [
+      step.llm<ContextMemory, string, string>({
+        id: 'code-agent/verify-chat',
+        model: (ctx: Context<ContextMemory>) => readParam(ctx, 'model', '', isString),
+        instructions: () => VERIFY_SYSTEM_INSTRUCTIONS,
+        tools: (ctx: Context<ContextMemory>) =>
+          filterToolsByNames(readUnifiedTools(ctx), VERIFY_MODE_TOOL_NAMES),
+      }),
+    ],
+    until: until.noToolCalls(),
+  }),
 });
 
 /**

--- a/packages/code-agent/src/agents/verify.ts
+++ b/packages/code-agent/src/agents/verify.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Context, ContextMemory, Step } from '@noetic-tools/core';
-import { loop, spawn, step, until } from '@noetic-tools/core/portable';
+import { loop, step, until } from '@noetic-tools/core/portable';
 import { persistFlowState, readFlowState, writeFlowState } from './flow-state.js';
 import {
   DEFAULT_MAX_FIX_ATTEMPTS,
@@ -138,21 +138,21 @@ export const verifyCheckStep: Step<ContextMemory, string, string> = step.run({
 
 //#region Verify agent
 
-const verifyAgentInner: Step<ContextMemory, string, string> = spawn({
+// Verify runs in the parent context — see actAgent's comment for the
+// rationale. Sub-agent isolation belongs to planAgent and teammates; the
+// verify phase is part of the user-facing conversation.
+const verifyAgentInner: Step<ContextMemory, string, string> = loop({
   id: 'code-agent/verify-agent',
-  child: loop({
-    id: 'code-agent/verify-loop',
-    steps: [
-      step.llm<ContextMemory, string, string>({
-        id: 'code-agent/verify-chat',
-        model: (ctx: Context<ContextMemory>) => readParam(ctx, 'model', '', isString),
-        instructions: () => VERIFY_SYSTEM_INSTRUCTIONS,
-        tools: (ctx: Context<ContextMemory>) =>
-          filterToolsByNames(readUnifiedTools(ctx), VERIFY_MODE_TOOL_NAMES),
-      }),
-    ],
-    until: until.noToolCalls(),
-  }),
+  steps: [
+    step.llm<ContextMemory, string, string>({
+      id: 'code-agent/verify-chat',
+      model: (ctx: Context<ContextMemory>) => readParam(ctx, 'model', '', isString),
+      instructions: () => VERIFY_SYSTEM_INSTRUCTIONS,
+      tools: (ctx: Context<ContextMemory>) =>
+        filterToolsByNames(readUnifiedTools(ctx), VERIFY_MODE_TOOL_NAMES),
+    }),
+  ],
+  until: until.noToolCalls(),
 });
 
 /**

--- a/packages/code-agent/src/index.ts
+++ b/packages/code-agent/src/index.ts
@@ -58,6 +58,7 @@ import { fixAgent } from './agents/fix.js';
 import type { CodeAgentMode } from './agents/flow-state.js';
 import {
   flowMemory,
+  getFlowMemoryDefaultMode,
   persistFlowState,
   readFlowState,
   setFlowMemoryDefaultMode,
@@ -537,9 +538,25 @@ function createSubagentController(): SubagentController {
 
 /**
  * Terminal step: clears per-phase ephemeral state (baselines + mutation
- * flags) and returns the sentinel string that the inner loop's
- * `until.outputEquals` recognizes. The sentinel never enters the item log
- * or assistant text — it exists only to transition the loop to its exit.
+ * flags), resets the workflow mode back to the host-configured default, and
+ * returns the sentinel string that the inner loop's `until.outputEquals`
+ * recognizes. The sentinel never enters the item log or assistant text —
+ * it exists only to transition the loop to its exit.
+ *
+ * The mode reset is load-bearing for multi-turn conversations: without it,
+ * the workflow's mode stays at `'done'` after the first user turn settles.
+ * On the NEXT turn the outer dispatch routes to `actVerifyFixWrapper` (any
+ * non-`'plan'` mode), the inner loop dispatch routes to `doneStep` (because
+ * `INNER_MODE_ROUTES['done']` is itself `doneStep`), and the workflow exits
+ * immediately without ever calling the model — producing no assistant
+ * response and no visible TUI activity. Resetting `mode` here returns the
+ * runtime to a clean state so each new user message gets a fresh act-loop.
+ *
+ * Fix-loop bookkeeping (`fixAttempts`, `lastFindingsHash`, `verifyFindings`)
+ * is also cleared so a brand-new act phase doesn't inherit the previous
+ * turn's verify history. `lastUserText` is preserved here because the
+ * outer wrapper reads it AFTER this step returns to surface the response
+ * to the user.
  *
  * Baseline clearing lives here (not in `postActCheckStep` /
  * `fixCompleteStep`) because those check steps run on every inner-loop
@@ -552,14 +569,23 @@ export const doneStep: Step<ContextMemory, string, string> = step.run({
   id: 'code-agent/done',
   async execute(_input, ctx) {
     const state = readFlowState(ctx);
-    if (
+    const defaultMode = getFlowMemoryDefaultMode();
+    const needsReset =
+      state.mode !== defaultMode ||
+      state.fixAttempts !== undefined ||
+      state.lastFindingsHash !== undefined ||
+      state.verifyFindings !== undefined ||
       state.actBaselineLines !== undefined ||
       state.actDidMutateTools !== undefined ||
       state.fixBaselineLines !== undefined ||
-      state.fixDidMutateTools !== undefined
-    ) {
+      state.fixDidMutateTools !== undefined;
+    if (needsReset) {
       writeFlowState(ctx, {
         ...state,
+        mode: defaultMode,
+        fixAttempts: undefined,
+        lastFindingsHash: undefined,
+        verifyFindings: undefined,
         actBaselineLines: undefined,
         actDidMutateTools: undefined,
         fixBaselineLines: undefined,

--- a/packages/code-agent/src/index.ts
+++ b/packages/code-agent/src/index.ts
@@ -568,31 +568,24 @@ function createSubagentController(): SubagentController {
 export const doneStep: Step<ContextMemory, string, string> = step.run({
   id: 'code-agent/done',
   async execute(_input, ctx) {
+    // `doneStep` is only routed to via `INNER_MODE_ROUTES.done`, which is
+    // reached only when `mode === 'done'`. The host default is never
+    // `'done'` (the CLI uses `'act'`, plan-first embedders use `'plan'`),
+    // so the mode reset is always real work — there is no useful
+    // short-circuit to gate it behind.
     const state = readFlowState(ctx);
-    const defaultMode = getFlowMemoryDefaultMode();
-    const needsReset =
-      state.mode !== defaultMode ||
-      state.fixAttempts !== undefined ||
-      state.lastFindingsHash !== undefined ||
-      state.verifyFindings !== undefined ||
-      state.actBaselineLines !== undefined ||
-      state.actDidMutateTools !== undefined ||
-      state.fixBaselineLines !== undefined ||
-      state.fixDidMutateTools !== undefined;
-    if (needsReset) {
-      writeFlowState(ctx, {
-        ...state,
-        mode: defaultMode,
-        fixAttempts: undefined,
-        lastFindingsHash: undefined,
-        verifyFindings: undefined,
-        actBaselineLines: undefined,
-        actDidMutateTools: undefined,
-        fixBaselineLines: undefined,
-        fixDidMutateTools: undefined,
-      });
-      await persistFlowState(ctx);
-    }
+    writeFlowState(ctx, {
+      ...state,
+      mode: getFlowMemoryDefaultMode(),
+      fixAttempts: undefined,
+      lastFindingsHash: undefined,
+      verifyFindings: undefined,
+      actBaselineLines: undefined,
+      actDidMutateTools: undefined,
+      fixBaselineLines: undefined,
+      fixDidMutateTools: undefined,
+    });
+    await persistFlowState(ctx);
     return CODE_AGENT_DONE_SENTINEL;
   },
 });

--- a/packages/code-agent/test/agents/conversation-continuity.test.ts
+++ b/packages/code-agent/test/agents/conversation-continuity.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Regression: the user-facing chat agents (act / verify / fix) must NOT be
+ * wrapped in `spawn()`. A spawn boundary gives the child a fresh `itemLog`
+ * whose only contents come from memory layers' `onSpawn` hooks — and none
+ * of the configured layers in `@noetic-tools/cli` forward conversation
+ * items that way. The net effect of wrapping these agents in spawn was
+ * that the user's `role:'user'` message lived in the parent ctx's itemLog
+ * but the LLM call (inside the spawn child) saw zero user messages,
+ * producing stock "I'm ready to help" greetings instead of engaging with
+ * the user's actual question.
+ *
+ * `spawn()` is correct for genuine sub-agents (planAgent, teammates,
+ * sub-harnesses) that should NOT see the parent transcript. These three
+ * agents are continuations of the same user-facing conversation, so they
+ * must share the parent context.
+ *
+ * These tests are structural — they check the step kind directly. A
+ * behavioral cross-turn test would require a much heavier harness fixture
+ * (real session, mocked LLM client, item-log inspection across runOneTurn
+ * invocations) and is best authored as an evaluation in `@noetic/eval`.
+ * The structural assertion catches the regression at the source: anyone
+ * re-wrapping these agents in `spawn(...)` will see this test fail.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { actAgent } from '../../src/agents/act.js';
+import { fixAgent } from '../../src/agents/fix.js';
+
+describe('user-facing agents run in the parent context (no spawn boundary)', () => {
+  it('actAgent is a loop, not a spawn — user items in parent ctx reach the LLM', () => {
+    expect(actAgent.kind).toBe('loop');
+    expect(actAgent.kind).not.toBe('spawn');
+  });
+
+  it('fixAgent is a loop, not a spawn — fix phase continues the user conversation', () => {
+    expect(fixAgent.kind).toBe('loop');
+    expect(fixAgent.kind).not.toBe('spawn');
+  });
+
+  // verifyAgentInner is not exported (it's wrapped by verifyAndCheck for
+  // outer composition), so the kind invariant is enforced indirectly: the
+  // surrounding tests would fail if a spawn boundary were re-introduced
+  // because the conversation-history tests would silently break again.
+});

--- a/packages/code-agent/test/agents/conversation-continuity.test.ts
+++ b/packages/code-agent/test/agents/conversation-continuity.test.ts
@@ -1,44 +1,49 @@
 /**
- * Regression: the user-facing chat agents (act / verify / fix) must NOT be
- * wrapped in `spawn()`. A spawn boundary gives the child a fresh `itemLog`
- * whose only contents come from memory layers' `onSpawn` hooks — and none
- * of the configured layers in `@noetic-tools/cli` forward conversation
- * items that way. The net effect of wrapping these agents in spawn was
- * that the user's `role:'user'` message lived in the parent ctx's itemLog
- * but the LLM call (inside the spawn child) saw zero user messages,
- * producing stock "I'm ready to help" greetings instead of engaging with
- * the user's actual question.
+ * Regression: lock in the spawn-boundary placement across the three inner
+ * agents. The bug was that `actAgent` was wrapped in `spawn()`: the spawn
+ * gives the child a fresh `itemLog` whose only contents come from memory
+ * layers' `onSpawn` hooks, and no configured layer forwards conversation
+ * items. The user's `role:'user'` message lived in the parent ctx but the
+ * LLM call (inside the spawn child) saw zero user messages — the model
+ * just regurgitated system context.
  *
- * `spawn()` is correct for genuine sub-agents (planAgent, teammates,
- * sub-harnesses) that should NOT see the parent transcript. These three
- * agents are continuations of the same user-facing conversation, so they
- * must share the parent context.
+ * The fix is asymmetric on purpose:
  *
- * These tests are structural — they check the step kind directly. A
- * behavioral cross-turn test would require a much heavier harness fixture
- * (real session, mocked LLM client, item-log inspection across runOneTurn
- * invocations) and is best authored as an evaluation in `@noetic/eval`.
- * The structural assertion catches the regression at the source: anyone
- * re-wrapping these agents in `spawn(...)` will see this test fail.
+ *   - `actAgent`     → NOT spawned. It IS the user-facing conversation;
+ *                       its LLM call MUST see the user message + history.
+ *   - `verifyAgent`  → STAYS spawned. The adversarial reviewer never reads
+ *                       the user turn (static instructions, read-only
+ *                       tools); keeping it isolated holds its PASS/FAIL +
+ *                       tool-call noise out of the user-facing transcript.
+ *   - `fixAgent`     → STAYS spawned. Same rationale — fixer reads from
+ *                       flow-state `verifyFindings`, not the itemLog.
+ *
+ * These structural checks catch any future re-wrap at the source. A
+ * behavioral cross-turn test that drives a real two-turn session through
+ * `AgentHarness.execute` would be the natural complement and is the right
+ * shape for an `@noetic/eval` regression — pilotty verification under
+ * /Users/ian/src/github/mattapperson/noetic/.claude/worktrees/cli-submission-stuck
+ * confirms the chain works end-to-end ("what is 2 + 3?" → "2 + 3 = 5";
+ * "now multiply that by 4" → "5 × 4 = 20"), so the unit-level invariants
+ * here are the long-term guard.
  */
 
 import { describe, expect, it } from 'bun:test';
 import { actAgent } from '../../src/agents/act.js';
 import { fixAgent } from '../../src/agents/fix.js';
+import { verifyAgent } from '../../src/agents/verify.js';
 
-describe('user-facing agents run in the parent context (no spawn boundary)', () => {
+describe('act/verify/fix spawn-boundary invariants', () => {
   it('actAgent is a loop, not a spawn — user items in parent ctx reach the LLM', () => {
     expect(actAgent.kind).toBe('loop');
     expect(actAgent.kind).not.toBe('spawn');
   });
 
-  it('fixAgent is a loop, not a spawn — fix phase continues the user conversation', () => {
-    expect(fixAgent.kind).toBe('loop');
-    expect(fixAgent.kind).not.toBe('spawn');
+  it('verifyAgent stays spawned — adversarial PASS/FAIL output must NOT enter the user transcript', () => {
+    expect(verifyAgent.kind).toBe('spawn');
   });
 
-  // verifyAgentInner is not exported (it's wrapped by verifyAndCheck for
-  // outer composition), so the kind invariant is enforced indirectly: the
-  // surrounding tests would fail if a spawn boundary were re-introduced
-  // because the conversation-history tests would silently break again.
+  it('fixAgent stays spawned — fix tool-call noise must NOT enter the user transcript', () => {
+    expect(fixAgent.kind).toBe('spawn');
+  });
 });

--- a/packages/code-agent/test/agents/done-step.test.ts
+++ b/packages/code-agent/test/agents/done-step.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { getFlowMemoryDefaultMode, setFlowMemoryDefaultMode } from '../../src/agents/flow-state.js';
 import { CODE_AGENT_DONE_SENTINEL } from '../../src/agents/shared.js';
 import { doneStep } from '../../src/index.js';
 import { asRunExecute, buildShortstat, createMockCheckContext } from './_helpers.js';
@@ -6,7 +7,18 @@ import { asRunExecute, buildShortstat, createMockCheckContext } from './_helpers
 const runDone = asRunExecute(doneStep);
 
 describe('doneStep', () => {
+  // Tests mutate the module-level default mode; snapshot + restore so the
+  // tests stay order-independent.
+  let priorDefault: ReturnType<typeof getFlowMemoryDefaultMode>;
+  beforeEach(() => {
+    priorDefault = getFlowMemoryDefaultMode();
+  });
+  afterEach(() => {
+    setFlowMemoryDefaultMode(priorDefault);
+  });
+
   it('clears all four phase baselines on workflow completion', async () => {
+    setFlowMemoryDefaultMode('act');
     const { ctx, getFlowState } = createMockCheckContext({
       diffShortstat: buildShortstat(0),
       flowState: {
@@ -25,11 +37,73 @@ describe('doneStep', () => {
     expect(state.actDidMutateTools).toBeUndefined();
     expect(state.fixBaselineLines).toBeUndefined();
     expect(state.fixDidMutateTools).toBeUndefined();
-    // Does not disturb unrelated state
+    // The outer wrapper reads `lastUserText` AFTER doneStep to surface the
+    // assistant response to the user, so this field must survive the reset.
     expect(state.lastUserText).toBe('summary');
   });
 
-  it('is a no-op when baselines are already clear (no persist)', async () => {
+  it('resets mode to the host-configured default so the next turn re-enters the act loop', async () => {
+    // Repro for the "second submit produces no response" bug: turn 1 ends
+    // with `mode: 'done'` (verify_check's PASS branch). Without this reset,
+    // turn 2 routes outer→actVerifyFixWrapper→inner→INNER_MODE_ROUTES.done
+    // (== doneStep), exits immediately, and no LLM call ever happens.
+    setFlowMemoryDefaultMode('act');
+    const { ctx, getFlowState } = createMockCheckContext({
+      diffShortstat: buildShortstat(0),
+      flowState: {
+        mode: 'done',
+        lastUserText: 'previous turn text',
+      },
+    });
+    await runDone('ignored', ctx);
+    expect(getFlowState().mode).toBe('act');
+  });
+
+  it('respects a host default of plan when resetting mode', async () => {
+    setFlowMemoryDefaultMode('plan');
+    const { ctx, getFlowState } = createMockCheckContext({
+      diffShortstat: buildShortstat(0),
+      flowState: {
+        mode: 'done',
+      },
+    });
+    await runDone('ignored', ctx);
+    expect(getFlowState().mode).toBe('plan');
+  });
+
+  it('clears fix-loop bookkeeping (fixAttempts, lastFindingsHash, verifyFindings)', async () => {
+    setFlowMemoryDefaultMode('act');
+    const { ctx, getFlowState } = createMockCheckContext({
+      diffShortstat: buildShortstat(0),
+      flowState: {
+        mode: 'done',
+        fixAttempts: 2,
+        lastFindingsHash: 'abc123',
+        verifyFindings: 'previous findings',
+      },
+    });
+    await runDone('ignored', ctx);
+    const state = getFlowState();
+    expect(state.fixAttempts).toBeUndefined();
+    expect(state.lastFindingsHash).toBeUndefined();
+    expect(state.verifyFindings).toBeUndefined();
+  });
+
+  it('is a no-op when state already matches the default (no persist)', async () => {
+    setFlowMemoryDefaultMode('act');
+    const { ctx, getStoreCallCount } = createMockCheckContext({
+      diffShortstat: buildShortstat(0),
+      flowState: {
+        mode: 'act',
+        lastUserText: 'summary',
+      },
+    });
+    await runDone('ignored', ctx);
+    expect(getStoreCallCount()).toBe(0);
+  });
+
+  it('persists when mode needs resetting even if baselines are clear', async () => {
+    setFlowMemoryDefaultMode('act');
     const { ctx, getStoreCallCount } = createMockCheckContext({
       diffShortstat: buildShortstat(0),
       flowState: {
@@ -38,6 +112,9 @@ describe('doneStep', () => {
       },
     });
     await runDone('ignored', ctx);
-    expect(getStoreCallCount()).toBe(0);
+    // Persistence is mandatory here: without flushing the mode reset to
+    // durable storage, the next turn would re-hydrate the stale 'done' mode
+    // and the bug would resurface.
+    expect(getStoreCallCount()).toBe(1);
   });
 });

--- a/packages/code-agent/test/agents/done-step.test.ts
+++ b/packages/code-agent/test/agents/done-step.test.ts
@@ -89,17 +89,21 @@ describe('doneStep', () => {
     expect(state.verifyFindings).toBeUndefined();
   });
 
-  it('is a no-op when state already matches the default (no persist)', async () => {
+  it('always persists — there is no short-circuit because doneStep is only reached with mode=done', async () => {
+    // doneStep is only routed to via INNER_MODE_ROUTES.done (i.e. when
+    // mode === 'done'). The host default is never 'done', so the reset
+    // is always real work and the prior "no-op when state matches default"
+    // optimization was illusory. This test pins the documented behavior.
     setFlowMemoryDefaultMode('act');
     const { ctx, getStoreCallCount } = createMockCheckContext({
       diffShortstat: buildShortstat(0),
       flowState: {
-        mode: 'act',
+        mode: 'done',
         lastUserText: 'summary',
       },
     });
     await runDone('ignored', ctx);
-    expect(getStoreCallCount()).toBe(0);
+    expect(getStoreCallCount()).toBe(1);
   });
 
   it('persists when mode needs resetting even if baselines are clear', async () => {


### PR DESCRIPTION
## Summary

Fixes the CLI's chat path end-to-end. Two coupled bugs were preventing it from working:

### Bug A — second submit produces no spinner, no response (`mode='done'` regression)

After turn 1, `verifyCheckStep`'s PASS branch left flow state at `mode: 'done'`. Turn 2 routed outer→`actVerifyFixWrapper`→inner→`INNER_MODE_ROUTES['done']` (which IS `doneStep`), exited immediately, and never called the model.

**Fix:** `doneStep` now resets `mode` to the host-configured default (`getFlowMemoryDefaultMode()`) and clears fix-loop bookkeeping (`fixAttempts`, `lastFindingsHash`, `verifyFindings`) + per-phase baselines. `lastUserText` is preserved so the outer wrapper can still surface the response. The reset is unconditional — `doneStep` is only reached when `mode === 'done'` and the host default is never `'done'`, so there's no useful short-circuit to gate it behind.

### Bug B — model never sees the user's message (spawn isolates the chat)

`actAgent` was wrapped in `spawn(...)`. `executeSpawn` builds a child Context with an empty itemLog whose only contents come from memory layers' `onSpawn` hooks — and none of the configured layers forward conversation items that way (audit: every `onSpawn` returns `{ childState }` only). The user's `role:'user'` message lived in the *parent* ctx via `mergeInputsToItems` → `createContext`, but the LLM call inside the spawn child saw 0 user messages (all 7 inputs were `role:'developer'` memory-layer recalls). The model just regurgitated system context.

**Fix:** unwrap `spawn({ child: loop(...) })` → bare `loop(...)` for `actAgent` only. It runs in the parent ctx where the conversation lives.

The spawn boundary is **asymmetric on purpose** for the three inner agents:

| Agent | Boundary | Why |
|---|---|---|
| `actAgent` | `loop` (not spawned) | User-facing assistant; MUST see the user message + history |
| `verifyAgentInner` | `spawn` | Adversarial reviewer; PASS/FAIL + Read/Grep noise must stay OUT of user transcript |
| `fixAgent` | `spawn` | Reads from `verifyFindings` (flow state), not itemLog; fix tool-call noise stays OUT of user transcript |
| `planAgent` | `spawn` | True sub-agent — separate proposal/approve cycle, returns plan via `onReturn` |

Also: the new loop's id is `code-agent/act-loop` (preserved from the prior inner loop), so observability spans / eval baselines keyed on it stay matched. The outer `code-agent/act-agent` spawn span is structurally gone, which is intrinsic to the fix.

Decision was made via a panel review (architect / pragmatist / layer-purist / adversary) with adversarial verification. Three of four converged on de-spawning the user-facing agent; the adversary's "thread user text as typed input" alternative was rejected because it would re-append a `role:'user'` message every loop iteration (duplicate turns). Review feedback then narrowed scope from de-spawning all three to just `actAgent` since verify/fix don't read from the itemLog.

## End-to-end verification (under pilotty)

```
❯ what is 2 + 3?
⏺ 2 + 3 = 5

❯ now multiply that by 4
⏺ 5 × 4 = 20
```

The model engages with the actual question; turn 2 uses turn 1's result via `session.accumulatedItems` → parent ctx → `actAgent` (loop in parent ctx) → LLM.

## Why not the alternatives (for Bug B)

- **Extend `SpawnParams<TState>` with `parentItems`** — widens a `@public` contract for what is at heart a one-line miscategorization (`actAgent` shouldn't have been spawned).
- **Invert `executeSpawn` isolation default** — silently breaks every legitimate spawn site (planAgent, the `agent` teammate tool, sub-harness adapters), forcing `isolateItems: true` audits across the framework.
- **Pass user text as the workflow's typed `input`** — would cause `runInputPipeline` to re-append `role:'user'` on every iteration of the act loop.
- **De-spawn verify/fix too** — broader than Bug B requires; would fold adversarial PASS/FAIL output and fix tool-call noise into the user-facing transcript. Verify/fix never read from the itemLog, so they have nothing to lose by staying isolated.

## Invariants verified

- `until.noToolCalls()` reads `snap.lastStepMeta?.toolCalls` (per-step meta), NOT an itemLog scan (`packages/core/src/until/predicates.ts`) — loop termination stays per-iteration safe with the now-shared parent itemLog.
- `planAgent`, `verifyAgentInner`, `fixAgent`, and sub-harness spawn isolation untouched.
- `SpawnParams<TState>` contract untouched.
- All five CI checks pass; sentrux structural gate clean.

## Test plan

- [x] `packages/code-agent` — 101 tests pass, including:
   - 6 `doneStep` tests for the mode reset (covers both `'act'` and `'plan'` host defaults, fix-loop bookkeeping cleared, `lastUserText` preserved, unconditional persist).
   - 3 `conversation-continuity` tests pinning the asymmetric design: `actAgent.kind === 'loop'`, `verifyAgent.kind === 'spawn'`, `fixAgent.kind === 'spawn'`. Trips on a re-wrap in either direction.
- [x] `packages/cli` — multi-turn `stream-consumers` test guards that a long-lived consumer sees `turn_started` on every turn.
- [x] `packages/core` — 1108 tests pass / 0 fail.
- [x] `bun run lint` clean.
- [x] `sentrux check .` — quality 4871, all 54 rules pass.
- [x] Pilotty smoke: math chain (`2 + 3` → `5 × 4 = 20`) confirms both bugs fixed.

## Residual blast radius

- The former `code-agent/act-agent` spawn span no longer exists; observability spans keyed on the *inner* loop id (`code-agent/act-loop`) keep working since that id is preserved. Outer-span loss is intrinsic to removing the spawn.
- Layer `onSpawn` hooks attached to the former actAgent spawn boundary no longer fire on that boundary. Only `flowMemory.onSpawn` was on this path; it's a shallow parent-state copy (no-op when running in parent ctx).
- Cross-turn behavioral verification (turn N sees turn N-1's exchange in the LLM input) is best-shaped as an `@noetic/eval` regression. The structural `kind` assertions catch the bug at the source.
- `runTurn` still passes `''` as typed input (`agent-harness.ts`) — now confirmed dead weight since the parent ctx's itemLog carries the content. Cosmetic cleanup candidate, not load-bearing.
- `verifyAndCheck`'s `loop { until: () => ({ stop: true }) }` is a clumsy two-step sequence idiom — candidate for a future `sequence` primitive, out of scope.