### PR TITLE
fix(core): link llm.call/tool.call spans to their workflow node (NoeticAttr.NODE_ID)

### DIFF
--- a/packages/core/src/harness/model-call.ts
+++ b/packages/core/src/harness/model-call.ts
@@ -25,7 +25,7 @@ import {
   sanitizeToolNameForWire,
 } from '../adapters/openrouter';
 import { isFunctionCall } from '../interpreter/typeguards';
-import { GenAI, ToolAttr } from '../observability/genai-attributes';
+import { GenAI, NoeticAttr, ToolAttr } from '../observability/genai-attributes';
 import { emitFrameworkEvent, getBroadcaster, shouldEmit } from '../runtime/broadcaster-utils';
 import type { EventBroadcaster } from '../runtime/event-broadcaster';
 import type { MessageQueue, QueuedMessage } from '../runtime/message-queue';
@@ -347,13 +347,22 @@ class CallSpanCollector {
     private readonly harness: AgentHarnessContract,
     private readonly exporter: TraceExporter,
     private readonly parent: Span | null,
+    private readonly nodeId: string | undefined,
   ) {}
+
+  /** Link a span back to its declared workflow node, when the call carries one. */
+  private stampNode(span: Span): void {
+    if (this.nodeId !== undefined) {
+      span.setAttribute(NoeticAttr.NODE_ID, this.nodeId);
+    }
+  }
 
   /** Open a model-call span stamped with GenAI semantic-convention attributes. */
   startModelSpan(model: string): Span {
     const span = this.harness.createSpan('llm.call', this.parent);
     span.setAttribute(GenAI.SYSTEM, 'openrouter');
     span.setAttribute(GenAI.REQUEST_MODEL, model);
+    this.stampNode(span);
     this.spans.push(span);
     return span;
   }
@@ -380,6 +389,7 @@ class CallSpanCollector {
     const span = this.harness.createSpan('tool.call', parent);
     span.setAttribute(ToolAttr.NAME, toolName);
     span.setAttribute(ToolAttr.NEEDS_APPROVAL, needsApproval);
+    this.stampNode(span);
     span.end();
     this.spans.push(span);
   }
@@ -401,6 +411,7 @@ export class AgentHarnessModelCaller {
       this.opts.harness,
       this.opts.traceExporter,
       request.parentSpan ?? request.ctx?.span ?? null,
+      request.nodeId,
     );
   }
 

--- a/packages/core/src/interpreter/execute-action.ts
+++ b/packages/core/src/interpreter/execute-action.ts
@@ -435,6 +435,7 @@ export async function executeLLM<TMemory, I, O>(
           ctx: baseCtx,
           layers,
           allowedToolNames,
+          nodeId: step.id,
           parentSpan: baseCtx.span,
         }
       : {
@@ -444,6 +445,7 @@ export async function executeLLM<TMemory, I, O>(
           params: step.params,
           outputSchema: step.output,
           emit: step.emit,
+          nodeId: step.id,
           parentSpan: baseCtx.span,
         };
     const response = await baseCtx.harness.callModel(request);

--- a/packages/core/src/observability/genai-attributes.ts
+++ b/packages/core/src/observability/genai-attributes.ts
@@ -25,4 +25,6 @@ export const NoeticAttr = {
   WORKFLOW_NODES: 'noetic.workflow.nodes',
   /** JSON array of `{ from, to }` parent→child edges between declared nodes. */
   WORKFLOW_EDGES: 'noetic.workflow.edges',
+  /** Id of the declared workflow node an `llm.call`/`tool.call` span belongs to. */
+  NODE_ID: 'noetic.node.id',
 } as const;

--- a/packages/core/test/observability/workflow-run-span.test.ts
+++ b/packages/core/test/observability/workflow-run-span.test.ts
@@ -79,5 +79,11 @@ describe('workflow run span (issue #50 follow-up)', () => {
       expect(span.traceId).toBe(runSpan?.traceId ?? 'missing');
       expect(span.parentSpanId).toBe(runSpan?.spanId ?? 'missing');
     }
+
+    // Each model span links back to the llm node that drove it (NoeticAttr.NODE_ID),
+    // using the same id space as the declared DAG nodes above.
+    const nodeIds = modelSpans.map((s) => s.attributes.get(NoeticAttr.NODE_ID));
+    expect(nodeIds).toContain('first');
+    expect(nodeIds).toContain('second');
   });
 });

--- a/packages/types/src/types/runtime.ts
+++ b/packages/types/src/types/runtime.ts
@@ -72,6 +72,13 @@ interface CallModelRequestBase {
    * so model/tool spans nest under the root `workflow.run` span.
    */
   parentSpan?: Span;
+  /**
+   * @internal Id of the workflow node driving this call. Set by
+   * `parseAndRunWorkflow` (from the executing step's id) so the `llm.call` and
+   * `tool.call` spans this request produces carry `NoeticAttr.NODE_ID`, linking
+   * each span back to its node in the declared DAG.
+   */
+  nodeId?: string;
 }
 
 /** @public Request shape when tools are provided — ctx is required for tool execution callbacks. */


### PR DESCRIPTION
## Why

Follow-up to #50. The traceExporter now emits `llm.call`/`tool.call` spans nested under a root `workflow.run` span that carries the declared DAG (`noetic.workflow.nodes`/`edges`). But the call spans carried **no node id**, so a consumer rendering the graph cannot map an executed span back to the DAG node that produced it — making the intended "declared graph with the executed path overlaid" view impossible, and any span→node hover-highlight unreliable (name/tool-name/order heuristics break on branches, loops, and repeated tools).

## What

- Add `NoeticAttr.NODE_ID = 'noetic.node.id'`.
- Add internal `CallModelRequest.nodeId` (alongside the existing internal `parentSpan`).
- `parseAndRunWorkflow`'s step executor passes the executing step's `id` as `nodeId`; the model-call span collector stamps `NoeticAttr.NODE_ID` on every `llm.call` and `tool.call` span.
- Tool spans inherit the driving `llm` node's id (tool calls execute as function calls within that step), so they light up the same node.
- Same id space as `noetic.workflow.nodes`, so spans join cleanly to declared nodes.

## Test

Extends `test/observability/workflow-run-span.test.ts` to assert each model span carries its node id (`first`/`second`). Full core suite green (1119 pass / 0 fail), observability suite 17 pass, biome + typecheck clean.

## Release

`fix:` → patch. semantic-release will publish `@noetic-tools/types` and `@noetic-tools/core` (core pinned to the new types). Consumers on `^1.2.2` pick it up automatically.

This unblocks the trace node-graph UI in noetic-services (exact span→node highlighting).