### PR TITLE
feat(core): stamp session + resource id on the workflow.run span

### DIFF
--- a/packages/core/src/observability/genai-attributes.ts
+++ b/packages/core/src/observability/genai-attributes.ts
@@ -27,4 +27,12 @@ export const NoeticAttr = {
   WORKFLOW_EDGES: 'noetic.workflow.edges',
   /** Id of the declared workflow node an `llm.call`/`tool.call` span belongs to. */
   NODE_ID: 'noetic.node.id',
+  /**
+   * Conversation/session this run belongs to (the run's `ctx.threadId`). Stamped
+   * on the root `workflow.run` span so every turn of a multi-turn session shares
+   * one id, letting a consumer group per-run traces back into their session.
+   */
+  SESSION_ID: 'noetic.session.id',
+  /** Resource the session is scoped to (the run's `ctx.resourceId`), when set. */
+  RESOURCE_ID: 'noetic.resource.id',
 } as const;

--- a/packages/core/src/patterns/dynamic-workflow.ts
+++ b/packages/core/src/patterns/dynamic-workflow.ts
@@ -211,9 +211,12 @@ export async function parseAndRunWorkflow(opts: ParseAndRunWorkflowOpts): Promis
 
 /**
  * Open the root `workflow.run` span and stamp the static DAG onto it (document,
- * version, node/edge graph). The span is installed on `ctx.span` so the LLM
- * step's model/tool spans nest under it — the trace tree then mirrors the
- * declared workflow graph, with the executed path overlaid (issue #50 follow-up).
+ * version, node/edge graph) plus the session/resource the run belongs to. The
+ * span is installed on `ctx.span` so the LLM step's model/tool spans nest under
+ * it — the trace tree then mirrors the declared workflow graph, with the
+ * executed path overlaid (issue #50 follow-up). The session id (`ctx.threadId`)
+ * is shared by every turn of a conversation, so consumers can group the per-run
+ * traces of one session back together.
  */
 function beginWorkflowRunSpan(
   harness: AgentHarnessContract,
@@ -227,6 +230,10 @@ function beginWorkflowRunSpan(
   span.setAttribute(NoeticAttr.WORKFLOW_NODE_COUNT, graph.nodes.length);
   span.setAttribute(NoeticAttr.WORKFLOW_NODES, JSON.stringify(graph.nodes));
   span.setAttribute(NoeticAttr.WORKFLOW_EDGES, JSON.stringify(graph.edges));
+  span.setAttribute(NoeticAttr.SESSION_ID, ctx.threadId);
+  if (ctx.resourceId !== undefined) {
+    span.setAttribute(NoeticAttr.RESOURCE_ID, ctx.resourceId);
+  }
   installRunSpan(ctx, span);
   return span;
 }

--- a/packages/core/test/observability/workflow-run-span.test.ts
+++ b/packages/core/test/observability/workflow-run-span.test.ts
@@ -86,4 +86,64 @@ describe('workflow run span (issue #50 follow-up)', () => {
     expect(nodeIds).toContain('first');
     expect(nodeIds).toContain('second');
   });
+
+  it('stamps the session (threadId) and resource onto the run span', async () => {
+    const exporter = new InMemoryExporter();
+    const harness = new AgentHarness({
+      name: 'repro',
+      params: {},
+      traceExporter: exporter,
+      _testCallModel: createScriptedCallModel([
+        makeLLMResponse('hi'),
+        makeLLMResponse('bye'),
+      ]),
+    });
+    // The platform pins one DO per session, passing the session id as threadId so
+    // every turn of the conversation shares it; resourceId scopes the agent.
+    const ctx = harness.createContext({
+      threadId: 'session_abc',
+      resourceId: 'acct_1:agent_7',
+    });
+
+    await parseAndRunWorkflow({
+      json: WORKFLOW,
+      harness,
+      ctx,
+      tools: [],
+      input: 'hello',
+    });
+
+    const runSpan = exporter.getSpansByName('workflow.run')[0];
+    expect(runSpan?.attributes.get(NoeticAttr.SESSION_ID)).toBe('session_abc');
+    expect(runSpan?.attributes.get(NoeticAttr.RESOURCE_ID)).toBe('acct_1:agent_7');
+  });
+
+  it('stamps a session id even when no resource is set', async () => {
+    const exporter = new InMemoryExporter();
+    const harness = new AgentHarness({
+      name: 'repro',
+      params: {},
+      traceExporter: exporter,
+      _testCallModel: createScriptedCallModel([
+        makeLLMResponse('hi'),
+        makeLLMResponse('bye'),
+      ]),
+    });
+    const ctx = harness.createContext({
+      threadId: 'session_only',
+    });
+
+    await parseAndRunWorkflow({
+      json: WORKFLOW,
+      harness,
+      ctx,
+      tools: [],
+      input: 'hello',
+    });
+
+    const runSpan = exporter.getSpansByName('workflow.run')[0];
+    expect(runSpan?.attributes.get(NoeticAttr.SESSION_ID)).toBe('session_only');
+    // No resourceId ⇒ the attribute is omitted entirely (not stamped empty).
+    expect(runSpan?.attributes.has(NoeticAttr.RESOURCE_ID)).toBe(false);
+  });
 });


### PR DESCRIPTION
Stamps `noetic.session.id` (= `ctx.threadId`) and `noetic.resource.id` (= `ctx.resourceId`) on the root `workflow.run` span, so every turn of a multi-turn session shares one id and consumers can group per-run traces back into their session.

- `NoeticAttr.SESSION_ID` / `RESOURCE_ID` added in genai-attributes.
- `beginWorkflowRunSpan` stamps them (resource only when set).
- +2 tests in workflow-run-span.test.ts.

Consumed by noetic-services' new Traces → Sessions view.