### PR TITLE
feat(core): run node, dynamic fork, and server tools in the JSON workflow runtime

### DIFF
--- a/packages/core/schema/noetic-workflow.schema.json
+++ b/packages/core/schema/noetic-workflow.schema.json
@@ -41,7 +41,24 @@
             "tools": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": false
               }
             },
             "params": {
@@ -105,6 +122,65 @@
             "kind",
             "id",
             "toolName"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "run"
+            },
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "execute": {
+              "type": "string",
+              "minLength": 1
+            },
+            "retry": {
+              "type": "object",
+              "properties": {
+                "maxAttempts": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "backoff": {
+                  "type": "string",
+                  "enum": [
+                    "fixed",
+                    "linear",
+                    "exponential"
+                  ]
+                },
+                "initialDelay": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "maxDelay": {
+                  "type": "number",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "maxAttempts",
+                "backoff",
+                "initialDelay"
+              ],
+              "additionalProperties": false
+            },
+            "subprocess": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "kind",
+            "id",
+            "execute"
           ],
           "additionalProperties": false
         },
@@ -177,6 +253,13 @@
                 "$ref": "#/$defs/WorkflowNode"
               }
             },
+            "each": {
+              "$ref": "#/$defs/WorkflowNode"
+            },
+            "over": {
+              "type": "string",
+              "minLength": 1
+            },
             "merge": {
               "type": "string",
               "enum": [
@@ -194,8 +277,7 @@
           "required": [
             "kind",
             "id",
-            "mode",
-            "paths"
+            "mode"
           ],
           "additionalProperties": false
         },

--- a/packages/core/src/builders/step-builders.ts
+++ b/packages/core/src/builders/step-builders.ts
@@ -4,6 +4,7 @@ import type {
   Lazy,
   ModelParams,
   RetryPolicy,
+  ServerToolSpec,
   StepLLM,
   StepRun,
   StepSubHarness,
@@ -39,8 +40,12 @@ interface StepLLMOpts<TMemory, O> {
   model: Lazy<string, TMemory>;
   /** Optional instructions; eager string or `(ctx) => string | undefined` getter. */
   instructions?: Lazy<string | undefined, TMemory>;
-  /** Optional tools; eager array or `(ctx) => Tool[] | undefined` getter. */
-  tools?: Lazy<Tool[] | undefined, TMemory>;
+  /**
+   * Optional tools; eager array or `(ctx) => (...)[] | undefined` getter. Each
+   * entry is either a client `Tool` or an inline `ServerToolSpec` (an OpenRouter
+   * server tool the provider executes, e.g. web search/fetch).
+   */
+  tools?: Lazy<(Tool | ServerToolSpec)[] | undefined, TMemory>;
   output?: ZodType<O>;
   params?: ModelParams;
   emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);

--- a/packages/core/src/builders/workflow-hydrator.ts
+++ b/packages/core/src/builders/workflow-hydrator.ts
@@ -10,15 +10,19 @@ import type { ContextMemory, MemoryLayer } from '@noetic-tools/memory';
 import type {
   Context,
   ExecuteStepFn,
+  ProcessSubprocessRequest,
+  ServerToolSpec,
   Step,
   SubHarness,
   SubHarnessKind,
   SubHarnessSessionPolicy,
   SubHarnessSettings,
+  SubprocessAdapter,
   Tool,
   Until,
 } from '@noetic-tools/types';
-import { frameworkCast, NoeticConfigError } from '@noetic-tools/types';
+import { frameworkCast, isServerToolSpec, NoeticConfigError } from '@noetic-tools/types';
+import { DetachedHandleImpl } from '../runtime/detached-handle';
 import type { UntilPredicate, WorkflowDocument, WorkflowNode } from '../schemas/workflow';
 import { all, any } from '../until/combinators';
 import { until } from '../until/predicates';
@@ -39,6 +43,12 @@ export interface HydrationContext {
   layers?: ReadonlyMap<string, MemoryLayer>;
   /** SubHarness adapters keyed by harness id, resolving `claude-code`/`codex`/… nodes. */
   subHarnesses?: ReadonlyMap<SubHarnessKind, SubHarness>;
+  /**
+   * Resolves a named subprocess adapter ref declared on a `run` node's
+   * `subprocess` field. When a node omits the ref, the step falls back to
+   * `ctx.subprocess` at execution time.
+   */
+  resolveSubprocess?: (ref: string) => SubprocessAdapter | undefined;
 }
 
 interface SubHarnessBuilderOpts {
@@ -104,13 +114,34 @@ function hydrateLlmNode(
     return frameworkCast(undefined);
   }
 
-  const resolvedTools = resolveTools(node.tools, ctx.tools);
+  // Every `tools` entry is an object `{ type, parameters? }`. Partition by the
+  // `type` value: a reserved `openrouter:*` server-tool literal is a SERVER
+  // tool (flows through unchanged); any other `type` is a CLIENT tool whose
+  // `type` is the registered tool NAME (resolved from the registry; a client
+  // entry's `parameters` is ignored). Both kinds are combined back into one
+  // `tools` array; the interpreter partitions them again at execution (server
+  // specs bypass the client-tool machinery and reach the model call's
+  // server-tool channel).
+  const toolNames: string[] = [];
+  const serverSpecs: ServerToolSpec[] = [];
+  for (const entry of node.tools ?? []) {
+    if (isServerToolSpec(entry)) {
+      serverSpecs.push(entry);
+    } else {
+      toolNames.push(entry.type);
+    }
+  }
+  const resolvedTools = resolveTools(toolNames, ctx.tools);
+  const combined: (Tool | ServerToolSpec)[] = [
+    ...resolvedTools,
+    ...serverSpecs,
+  ];
 
   return step.llm({
     id: node.id,
     model: node.model ?? 'openai/gpt-4o',
     instructions: node.instructions,
-    tools: resolvedTools.length > 0 ? resolvedTools : undefined,
+    tools: combined.length > 0 ? combined : undefined,
     params: node.params,
   });
 }
@@ -170,6 +201,37 @@ function hydrateToolNode(
   );
 }
 
+function hydrateRunNode(
+  node: WorkflowNode,
+  ctx: HydrationContext,
+): Step<ContextMemory, string, string> {
+  if (node.kind !== 'run') {
+    return frameworkCast(undefined);
+  }
+  const code = node.execute;
+  const subprocessRef = node.subprocess;
+  return frameworkCast(
+    step.run({
+      id: node.id,
+      retry: node.retry,
+      execute: async (input: string, execCtx: Context) => {
+        const adapter = resolveSubprocessAdapter({
+          ref: subprocessRef,
+          hydrationCtx: ctx,
+          execCtx,
+          nodeId: node.id,
+        });
+        return runCodeViaSubprocess({
+          adapter,
+          nodeId: node.id,
+          code,
+          input: stringifyResult(input),
+        });
+      },
+    }),
+  );
+}
+
 function hydrateBranchNode(
   node: WorkflowNode,
   ctx: HydrationContext,
@@ -212,15 +274,37 @@ function hydrateForkNode(
     return frameworkCast(undefined);
   }
 
-  const hydratedPaths = node.paths.map((p) => hydrateNode(p, ctx));
+  // Static fork: paths are known at hydration time and feed the optimizer.
+  // Dynamic fork (`each`): paths are produced per fork-input at runtime, one
+  // child per array item, so they cannot be pre-computed or optimized.
+  const dynamic = node.each !== undefined;
+  const eachTemplate = node.each;
+  const staticPaths = dynamic ? [] : (node.paths ?? []).map((p) => hydrateNode(p, ctx));
+
+  const pathsFactory = (input: string): Step<ContextMemory, string, string>[] => {
+    if (!dynamic || !eachTemplate) {
+      return staticPaths;
+    }
+    const items = selectArray(input, node.over, node.id);
+    return items.map((item, i) =>
+      buildPerItemStep({
+        forkId: node.id,
+        eachTemplate,
+        item,
+        index: i,
+        ctx,
+      }),
+    );
+  };
+  const optimizable = dynamic ? undefined : frameworkCast<Step<ContextMemory>[]>(staticPaths);
 
   if (node.mode === 'race') {
     return fork({
       id: node.id,
       mode: 'race',
-      paths: () => hydratedPaths,
+      paths: pathsFactory,
       concurrency: node.concurrency,
-      _optimizable: frameworkCast(hydratedPaths),
+      _optimizable: optimizable,
     });
   }
 
@@ -230,23 +314,23 @@ function hydrateForkNode(
     return fork({
       id: node.id,
       mode: 'settle',
-      paths: () => hydratedPaths,
+      paths: pathsFactory,
       merge: (results) => {
         const values = results.filter((r) => r.status === 'fulfilled').map((r) => r.value ?? '');
         return mergeFn(values);
       },
       concurrency: node.concurrency,
-      _optimizable: frameworkCast(hydratedPaths),
+      _optimizable: optimizable,
     });
   }
 
   return fork({
     id: node.id,
     mode: 'all',
-    paths: () => hydratedPaths,
+    paths: pathsFactory,
     merge: mergeFn,
     concurrency: node.concurrency,
-    _optimizable: frameworkCast(hydratedPaths),
+    _optimizable: optimizable,
   });
 }
 
@@ -396,6 +480,7 @@ function hydrateSubHarnessNode(
 const NODE_HYDRATORS: Record<string, NodeHydrator> = {
   llm: hydrateLlmNode,
   tool: hydrateToolNode,
+  run: hydrateRunNode,
   branch: hydrateBranchNode,
   fork: hydrateForkNode,
   spawn: hydrateSpawnNode,
@@ -455,6 +540,178 @@ function stringifyResult(value: unknown): string {
     return '';
   }
   return JSON.stringify(value);
+}
+
+//#endregion
+
+//#region Dynamic Fork Helpers
+
+/**
+ * Parses the fork input (a JSON string) and locates the array to fan out over.
+ * When `over` is set, reads that property off the parsed object; otherwise the
+ * parsed value itself must be an array.
+ */
+function selectArray(input: string, over: string | undefined, nodeId: string): unknown[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch {
+    throw new NoeticConfigError({
+      code: 'INVALID_FORK_INPUT',
+      message: `Dynamic fork '${nodeId}' could not parse its input as JSON.`,
+      hint: 'A dynamic fork (with `each`) expects its input to be a JSON array (or a JSON object when `over` is set).',
+    });
+  }
+  const candidate =
+    over === undefined ? parsed : frameworkCast<Record<string, unknown> | null>(parsed)?.[over];
+  if (!Array.isArray(candidate)) {
+    throw new NoeticConfigError({
+      code: 'INVALID_FORK_INPUT',
+      message: `Dynamic fork '${nodeId}' did not resolve an array${
+        over ? ` at key '${over}'` : ''
+      }.`,
+      hint: over
+        ? `Ensure the input JSON object has an array at '${over}'.`
+        : 'Ensure the input is a JSON array, or set `over` to select an array property.',
+    });
+  }
+  return candidate;
+}
+
+/**
+ * Builds one fork path for a single dynamic-fork item. The item is injected as
+ * the body's input (forks pass the same fork-input to every path), and the
+ * template's node ids are suffixed with `-${i}` so each instantiation has
+ * unique ids for tracing and step-registry uniqueness.
+ */
+function buildPerItemStep(opts: {
+  forkId: string;
+  eachTemplate: WorkflowNode;
+  item: unknown;
+  index: number;
+  ctx: HydrationContext;
+}): Step<ContextMemory, string, string> {
+  const { forkId, eachTemplate, item, index, ctx } = opts;
+  const hydratedEach = hydrateNode(suffixNodeIds(eachTemplate, `-${index}`), ctx);
+  return frameworkCast(
+    step.run({
+      id: `${forkId}-item-${index}`,
+      execute: async (_input: string, execCtx: Context) => {
+        const itemInput = JSON.stringify(item);
+        return stringifyResult(await ctx.executeStep(hydratedEach, itemInput, execCtx));
+      },
+    }),
+  );
+}
+
+/** Keys whose values are opaque data bags, never child workflow nodes. */
+const NON_NODE_KEYS = new Set([
+  'args',
+  'params',
+  'parameters',
+]);
+
+/**
+ * Deep-clones a workflow node template, appending `suffix` to the `id` of every
+ * nested node so a per-item instantiation has globally-unique step ids.
+ */
+function suffixNodeIds(node: WorkflowNode, suffix: string): WorkflowNode {
+  const clone = structuredClone(node);
+  const walk = (value: unknown): void => {
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        walk(entry);
+      }
+      return;
+    }
+    const record = frameworkCast<Record<string, unknown>>(value);
+    if (typeof record.kind === 'string' && typeof record.id === 'string') {
+      record.id = `${record.id}${suffix}`;
+    }
+    for (const [key, child] of Object.entries(record)) {
+      if (NON_NODE_KEYS.has(key)) {
+        continue;
+      }
+      walk(child);
+    }
+  };
+  walk(clone);
+  return clone;
+}
+
+//#endregion
+
+//#region Run Node Helpers
+
+/**
+ * Resolves the subprocess adapter for a `run` node. When the node names an
+ * adapter ref, the host must supply a `resolveSubprocess` resolver; otherwise
+ * the step falls back to the harness adapter on the execution context.
+ */
+function resolveSubprocessAdapter(opts: {
+  ref: string | undefined;
+  hydrationCtx: HydrationContext;
+  execCtx: Context;
+  nodeId: string;
+}): SubprocessAdapter {
+  const { ref, hydrationCtx, execCtx, nodeId } = opts;
+  if (ref === undefined) {
+    return execCtx.subprocess;
+  }
+  const resolved = hydrationCtx.resolveSubprocess?.(ref);
+  if (!resolved) {
+    throw new NoeticConfigError({
+      code: 'UNKNOWN_SUBPROCESS_REFERENCE',
+      message: `Subprocess adapter '${ref}' referenced in run node '${nodeId}' could not be resolved.`,
+      hint: 'Pass a `resolveSubprocess(ref)` mapping in the HydrationContext, or omit `subprocess` to use the harness default (ctx.subprocess).',
+    });
+  }
+  return resolved;
+}
+
+/**
+ * Dispatches a `run` node's code string through a subprocess adapter: ships the
+ * code plus the JSON-stringified input as a process request (input on stdin),
+ * waits for the handle to settle, and returns the captured stdout as the step
+ * output. A non-zero exit / failed handle surfaces as a thrown error.
+ *
+ * The code is never eval'd in-process (Cloudflare Workers forbid eval). The
+ * adapter owns running the code and capturing stdout into `handle.metadata.result`.
+ */
+async function runCodeViaSubprocess(opts: {
+  adapter: SubprocessAdapter;
+  nodeId: string;
+  code: string;
+  input: string;
+}): Promise<string> {
+  const { adapter, nodeId, code, input } = opts;
+  const request: ProcessSubprocessRequest = {
+    kind: 'process',
+    command: 'node',
+    args: [
+      '-e',
+      code,
+    ],
+    stdin: input,
+    metadata: {
+      noeticRun: true,
+      stepId: nodeId,
+      code,
+      input,
+    },
+  };
+  const spawnPromise = adapter.spawn(request);
+  const handle = new DetachedHandleImpl<string>({
+    id: `run-${nodeId}`,
+    stepId: nodeId,
+    adapter,
+    spawnPromise,
+  });
+  const result = await handle.await();
+  return stringifyResult(result);
 }
 
 //#endregion

--- a/packages/core/src/harness/model-call.ts
+++ b/packages/core/src/harness/model-call.ts
@@ -13,6 +13,7 @@ import type {
 import { frameworkCast, NoeticConfigError } from '@noetic-tools/types';
 import type * as OpenRouterAgent from '@openrouter/agent';
 import type { OpenRouter } from '@openrouter/agent';
+import { serverTool } from '@openrouter/agent';
 import type { ZodType } from 'zod';
 import { z } from 'zod';
 import {
@@ -289,16 +290,34 @@ function prepareModelRequest(request: CallModelRequest, agentName: string): Prep
       .join('\n\n') || undefined;
   const broadcaster = getBroadcaster(request.ctx);
   const filteredTools = filterAllowedTools(request);
+  // Client (function) tools convert to SDK tool definitions; OpenRouter server
+  // tools (web_search/web_fetch) are wrapped via the SDK's `serverTool()` so
+  // its convertToolsToAPIFormat accepts them — a raw `{type}` entry crashes it.
+  // `parameters` keys stay camelCase: the SDK's outbound zod schema strips
+  // unknown keys, so snake_case would be silently dropped.
+  const clientSdkTools =
+    filteredTools && filteredTools.length > 0
+      ? convertTools({
+          tools: filteredTools,
+        })
+      : [];
+  const serverSdkTools = (request._serverTools ?? []).map((s) =>
+    serverTool(
+      frameworkCast<Parameters<typeof serverTool>[0]>({
+        type: s.type,
+        parameters: s.parameters,
+      }),
+    ),
+  );
+  const sdkTools = [
+    ...clientSdkTools,
+    ...frameworkCast<typeof clientSdkTools>(serverSdkTools),
+  ];
   return {
     instructions,
     remaining,
     broadcaster,
-    sdkTools:
-      filteredTools && filteredTools.length > 0
-        ? convertTools({
-            tools: filteredTools,
-          })
-        : undefined,
+    sdkTools: sdkTools.length > 0 ? sdkTools : undefined,
     emitIfAllowed(eventType, data) {
       if (!shouldEmit(request.emit, eventType, data)) {
         return;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -295,11 +295,14 @@ export type {
   LlmProviderConfig,
   ModelParams,
   RetryPolicy,
+  ServerToolSpec,
   StepMeta,
   TokenUsage,
   Tool,
   ToolMemoryDeclaration,
 } from '@noetic-tools/types';
+/** @public */
+export { isServerToolSpec } from '@noetic-tools/types';
 
 //#endregion
 

--- a/packages/core/src/interpreter/action-types.ts
+++ b/packages/core/src/interpreter/action-types.ts
@@ -14,6 +14,7 @@ export type {
   ProjectionPolicy,
   RecallLayerOutput,
   RetryPolicy,
+  ServerToolSpec,
   StepLLM,
   StepMeta,
   StepProvide,
@@ -22,4 +23,4 @@ export type {
   StepTool,
   Tool,
 } from '@noetic-tools/types';
-export { SteeringAction } from '@noetic-tools/types';
+export { isServerToolSpec, SteeringAction } from '@noetic-tools/types';

--- a/packages/core/src/interpreter/collect-tools.ts
+++ b/packages/core/src/interpreter/collect-tools.ts
@@ -1,5 +1,5 @@
 import type { Step, Tool } from '@noetic-tools/types';
-import { frameworkCast } from '@noetic-tools/types';
+import { frameworkCast, isServerToolSpec } from '@noetic-tools/types';
 
 /**
  * Recursively walks a step tree and collects all Tool instances
@@ -37,9 +37,14 @@ function walkStep(step: Step, out: Tool[]): void {
       // Skip function-form tools: they're resolved per execution from `ctx`
       // and cannot contribute to the pre-computed unified set. Consumers that
       // need those tools in the pool should register them via
-      // `AgentHarness.tools` instead.
+      // `AgentHarness.tools` instead. Inline server-tool specs (web search/
+      // fetch) are not client `Tool`s — they never enter the unified pool.
       if (Array.isArray(step.tools)) {
-        out.push(...step.tools);
+        for (const entry of step.tools) {
+          if (!isServerToolSpec(entry)) {
+            out.push(entry);
+          }
+        }
       }
       return;
 

--- a/packages/core/src/interpreter/execute-action.ts
+++ b/packages/core/src/interpreter/execute-action.ts
@@ -44,6 +44,7 @@ import type {
   ProjectionPolicy,
   RecallLayerOutput,
   RetryPolicy,
+  ServerToolSpec,
   StepLLM,
   StepMeta,
   StepProvide,
@@ -52,7 +53,7 @@ import type {
   StepTool,
   Tool,
 } from './action-types';
-import { SteeringAction } from './action-types';
+import { isServerToolSpec, SteeringAction } from './action-types';
 import { cloneWithGuard } from './clone-guard';
 import { collectAllTools, deduplicateTools } from './collect-tools';
 import { trackUsage } from './message-helpers';
@@ -287,6 +288,26 @@ export async function executeLLM<TMemory, I, O>(
   const resolvedInstructions = await resolveLazy(step.instructions, ctx);
   const resolvedStepTools = await resolveLazy(step.tools, ctx);
 
+  // `step.tools` is heterogeneous: client `Tool`s plus inline OpenRouter
+  // server-tool specs (web search/fetch). Partition them — client tools flow
+  // through the unified-tool / allowedToolNames / steering machinery as before;
+  // server-tool specs bypass it entirely and are stamped onto the model request
+  // (`_serverTools`) for the model caller to wrap via the SDK's `serverTool()`.
+  // `undefined` (unrestricted) is preserved as-is; only a present array is
+  // partitioned so the `[] = opt-out` semantics of step.tools stay intact.
+  let clientStepTools: Tool[] | undefined;
+  const serverToolSpecs: ServerToolSpec[] = [];
+  if (resolvedStepTools !== undefined) {
+    clientStepTools = [];
+    for (const entry of resolvedStepTools) {
+      if (isServerToolSpec(entry)) {
+        serverToolSpecs.push(entry);
+      } else {
+        clientStepTools.push(entry);
+      }
+    }
+  }
+
   // Append user input — through layer pipeline if layers exist, otherwise direct.
   // The append pipeline may request a context re-render (e.g. a layer that
   // expanded an input reference into new content); applied after recall below.
@@ -304,7 +325,7 @@ export async function executeLLM<TMemory, I, O>(
   }
 
   const { tools: resolvedTools, allowedToolNames } = resolveToolsAndRestrictions(
-    resolvedStepTools,
+    clientStepTools,
     layers,
     baseCtx,
   );
@@ -423,6 +444,7 @@ export async function executeLLM<TMemory, I, O>(
             ];
     }
 
+    const _serverTools = serverToolSpecs.length > 0 ? serverToolSpecs : undefined;
     const request = resolvedTools
       ? {
           model: resolvedModel,
@@ -432,6 +454,7 @@ export async function executeLLM<TMemory, I, O>(
           params: step.params,
           outputSchema: step.output,
           emit: step.emit,
+          _serverTools,
           ctx: baseCtx,
           layers,
           allowedToolNames,
@@ -445,6 +468,7 @@ export async function executeLLM<TMemory, I, O>(
           params: step.params,
           outputSchema: step.output,
           emit: step.emit,
+          _serverTools,
           nodeId: step.id,
           parentSpan: baseCtx.span,
         };

--- a/packages/core/src/schemas/workflow.ts
+++ b/packages/core/src/schemas/workflow.ts
@@ -2,9 +2,11 @@
  * Zod schemas for JSON-serialisable workflow definitions.
  *
  * A `WorkflowDocument` is a portable, JSON-safe representation of a noetic
- * step tree. It covers every step kind except `run` (which carries arbitrary
- * closures). The hydrator in `builders/workflow-hydrator.ts` converts a
- * validated document back into live `Step` objects via the existing builders.
+ * step tree. It covers every step kind. The `run` node carries its body as a
+ * code STRING (not an in-process closure) dispatched through a subprocess
+ * adapter, keeping the document JSON-safe. The hydrator in
+ * `builders/workflow-hydrator.ts` converts a validated document back into live
+ * `Step` objects via the existing builders.
  */
 
 import type { SubHarnessKind } from '@noetic-tools/types';
@@ -156,6 +158,45 @@ const ModelParamsSchema = z.object({
 
 //#endregion
 
+//#region Tool Entries
+
+/**
+ * A uniform tool entry on an `llm` node. Every entry is an object keyed by
+ * `type`:
+ *   - A CLIENT tool is `{ type: "<registered-tool-name>" }`. The hydrator
+ *     resolves `type` against the tool registry; `parameters` (if present) is
+ *     ignored — client tools receive their call args from the model at runtime.
+ *   - A SERVER tool is `{ type: "openrouter:web_search" | "openrouter:web_fetch",
+ *     parameters?: {...} }`. The provider executes it; `parameters` keys are
+ *     camelCase (e.g. `maxResults`, `searchContextSize`) — the SDK re-serialises
+ *     them and silently drops unknown keys.
+ *
+ * Server vs client is decided by the `type` value (a reserved `openrouter:*`
+ * server-tool literal vs an arbitrary tool name), not by the entry's shape.
+ */
+const LlmToolEntrySchema = z.object({
+  type: z.string().min(1),
+  parameters: z.record(z.string(), z.unknown()).optional(),
+});
+
+//#endregion
+
+//#region Retry Policy
+
+/** Retry policy for a `run` node, mirroring `RetryPolicy` in `@noetic-tools/types`. */
+const RetryPolicySchema = z.object({
+  maxAttempts: z.number().int().positive(),
+  backoff: z.enum([
+    'fixed',
+    'linear',
+    'exponential',
+  ]),
+  initialDelay: z.number().nonnegative(),
+  maxDelay: z.number().nonnegative().optional(),
+});
+
+//#endregion
+
 //#region SubHarness Settings
 
 const HarnessSettingsSchema = z.object({
@@ -196,7 +237,14 @@ export interface LlmWorkflowNode extends WorkflowNodeBase {
   kind: 'llm';
   model?: string;
   instructions: string;
-  tools?: string[];
+  /**
+   * Tool entries. Every entry is an object `{ type, parameters? }`. A CLIENT
+   * tool is `{ type: "<registered-tool-name>" }` (resolved from the registry);
+   * a SERVER tool is `{ type: "openrouter:web_search" | "openrouter:web_fetch",
+   * parameters?: {...} }` (executed by the provider). Client vs server is
+   * decided by the `type` value.
+   */
+  tools?: z.infer<typeof LlmToolEntrySchema>[];
   params?: z.infer<typeof ModelParamsSchema>;
 }
 
@@ -204,6 +252,24 @@ export interface ToolWorkflowNode extends WorkflowNodeBase {
   kind: 'tool';
   toolName: string;
   args?: Record<string, unknown>;
+}
+
+/**
+ * A node that runs a serialised code body. Unlike the programmatic `step.run`
+ * (which carries a closure), the JSON form carries `execute` as a code STRING.
+ * The code is never eval'd in-process (Cloudflare Workers forbid eval); it is
+ * dispatched through a subprocess adapter (`ctx.subprocess`, or a named adapter
+ * resolved by ref). Execution therefore requires a subprocess adapter capable
+ * of running the code and returning its stdout.
+ */
+export interface RunWorkflowNode extends WorkflowNodeBase {
+  kind: 'run';
+  /** Source code executed in the subprocess. Receives the step input on stdin. */
+  execute: string;
+  /** Optional retry policy applied to the step. */
+  retry?: z.infer<typeof RetryPolicySchema>;
+  /** Named subprocess adapter ref; defaults to `ctx.subprocess` when omitted. */
+  subprocess?: string;
 }
 
 export interface BranchRoute {
@@ -220,7 +286,22 @@ export interface BranchWorkflowNode extends WorkflowNodeBase {
 export interface ForkWorkflowNode extends WorkflowNodeBase {
   kind: 'fork';
   mode: 'race' | 'all' | 'settle';
-  paths: WorkflowNode[];
+  /**
+   * Static fan-out: one child per entry. Mutually exclusive with `each` —
+   * supply exactly one.
+   */
+  paths?: WorkflowNode[];
+  /**
+   * Dynamic fan-out: instantiate this body template once per item of a
+   * runtime-produced array (data-dependent N). Mutually exclusive with `paths`.
+   */
+  each?: WorkflowNode;
+  /**
+   * Selector key into the fork input (parsed as JSON) locating the array to
+   * fan out over. When omitted, the input string itself is parsed as a JSON
+   * array. Only meaningful with `each`.
+   */
+  over?: string;
   merge?: MergeStrategy;
   concurrency?: number;
 }
@@ -273,6 +354,7 @@ export interface SubHarnessWorkflowNode extends WorkflowNodeBase {
 export type WorkflowNode =
   | LlmWorkflowNode
   | ToolWorkflowNode
+  | RunWorkflowNode
   | BranchWorkflowNode
   | ForkWorkflowNode
   | SpawnWorkflowNode
@@ -297,7 +379,7 @@ const LlmNodeSchema = z.object({
   ...SHARED_FIELDS,
   model: z.string().optional(),
   instructions: z.string(),
-  tools: z.array(z.string()).optional(),
+  tools: z.array(LlmToolEntrySchema).optional(),
   params: ModelParamsSchema.optional(),
 });
 
@@ -306,6 +388,14 @@ const ToolNodeSchema = z.object({
   ...SHARED_FIELDS,
   toolName: z.string().min(1),
   args: z.record(z.string(), z.unknown()).optional(),
+});
+
+const RunNodeSchema = z.object({
+  kind: z.literal('run'),
+  ...SHARED_FIELDS,
+  execute: z.string().min(1),
+  retry: RetryPolicySchema.optional(),
+  subprocess: z.string().min(1).optional(),
 });
 
 const BranchRouteSchema = z.object({
@@ -320,18 +410,24 @@ const BranchNodeSchema = z.object({
   default: WorkflowNodeRef.optional(),
 });
 
-const ForkNodeSchema = z.object({
-  kind: z.literal('fork'),
-  ...SHARED_FIELDS,
-  mode: z.enum([
-    'race',
-    'all',
-    'settle',
-  ]),
-  paths: z.array(WorkflowNodeRef).min(1),
-  merge: MergeStrategySchema.optional(),
-  concurrency: z.number().int().positive().optional(),
-});
+const ForkNodeSchema = z
+  .object({
+    kind: z.literal('fork'),
+    ...SHARED_FIELDS,
+    mode: z.enum([
+      'race',
+      'all',
+      'settle',
+    ]),
+    paths: z.array(WorkflowNodeRef).min(1).optional(),
+    each: WorkflowNodeRef.optional(),
+    over: z.string().min(1).optional(),
+    merge: MergeStrategySchema.optional(),
+    concurrency: z.number().int().positive().optional(),
+  })
+  .refine((node) => (node.paths === undefined) !== (node.each === undefined), {
+    message: "fork node requires exactly one of 'paths' (static) or 'each' (dynamic).",
+  });
 
 const SpawnNodeSchema = z.object({
   kind: z.literal('spawn'),
@@ -396,6 +492,7 @@ export const WorkflowNodeSchema: z.ZodType<WorkflowNode> = z
   .discriminatedUnion('kind', [
     LlmNodeSchema,
     ToolNodeSchema,
+    RunNodeSchema,
     BranchNodeSchema,
     ForkNodeSchema,
     SpawnNodeSchema,
@@ -445,7 +542,12 @@ function childNodes(node: WorkflowNode): WorkflowNode[] {
     case 'sequence':
       return node.steps;
     case 'fork':
-      return node.paths;
+      if (node.each) {
+        return [
+          node.each,
+        ];
+      }
+      return node.paths ?? [];
     case 'spawn':
     case 'provide':
       return [

--- a/packages/core/test/builders/workflow-hydrator.test.ts
+++ b/packages/core/test/builders/workflow-hydrator.test.ts
@@ -1,12 +1,67 @@
 import { describe, expect, test } from 'bun:test';
 import assert from 'node:assert';
 import type { MemoryLayer } from '@noetic-tools/memory';
-import type { SubHarness, SubHarnessKind, Tool } from '@noetic-tools/types';
-import { frameworkCast, isNoeticConfigError } from '@noetic-tools/types';
+import type {
+  ProcessSubprocessRequest,
+  SubHarness,
+  SubHarnessKind,
+  SubprocessAdapter,
+  SubprocessHandle,
+  Tool,
+} from '@noetic-tools/types';
+import { frameworkCast, isNoeticConfigError, isServerToolSpec } from '@noetic-tools/types';
 import type { HydrationContext } from '../../src/builders/workflow-hydrator';
 import { hydrateNode, hydrateWorkflow } from '../../src/builders/workflow-hydrator';
 import type { WorkflowDocument, WorkflowNode } from '../../src/schemas/workflow';
 import { makeMockContext, makeTestTool } from '../_helpers';
+
+/**
+ * Mock subprocess adapter for `run` node tests. Records every process request
+ * and completes each handle with stdout captured into `metadata.result` (or
+ * `metadata.error` when `fail` is set), mirroring the contract
+ * `runCodeViaSubprocess` relies on — without spawning a real process.
+ */
+function makeMockSubprocess(opts?: { fail?: boolean }): {
+  adapter: SubprocessAdapter;
+  calls: ProcessSubprocessRequest[];
+} {
+  const calls: ProcessSubprocessRequest[] = [];
+  const handles = new Map<string, SubprocessHandle>();
+  const adapter = frameworkCast<SubprocessAdapter>({
+    async spawn(request: ProcessSubprocessRequest): Promise<SubprocessHandle> {
+      calls.push(request);
+      const id = `mock-${calls.length}`;
+      const code = String(request.metadata?.code ?? '');
+      const stdin = request.stdin ?? '';
+      handles.set(id, {
+        id,
+        status: opts?.fail ? 'failed' : 'completed',
+        startedAt: 'now',
+        metadata: opts?.fail
+          ? {
+              error: {
+                message: 'subprocess exited non-zero',
+              },
+            }
+          : {
+              result: `OUT:${code}|${stdin}`,
+            },
+      });
+      return {
+        id,
+        status: 'running',
+        startedAt: 'now',
+      };
+    },
+    async get(id: string): Promise<SubprocessHandle | null> {
+      return handles.get(id) ?? null;
+    },
+  });
+  return {
+    adapter,
+    calls,
+  };
+}
 
 function makeHydrationContext(tools: Tool[] = []): HydrationContext {
   const toolMap = new Map(
@@ -42,7 +97,9 @@ describe('hydrateNode — llm', () => {
       id: 'llm-tools',
       instructions: 'Use tools',
       tools: [
-        'test-tool',
+        {
+          type: 'test-tool',
+        },
       ],
     };
     const ctx = makeHydrationContext([
@@ -61,7 +118,9 @@ describe('hydrateNode — llm', () => {
       id: 'llm-bad-tool',
       instructions: 'Use tools',
       tools: [
-        'nonexistent',
+        {
+          type: 'nonexistent',
+        },
       ],
     };
     const ctx = makeHydrationContext();
@@ -537,7 +596,9 @@ describe('hydrateNode — error cases', () => {
       id: 'llm-bad-tool',
       instructions: 'test',
       tools: [
-        'nonexistent',
+        {
+          type: 'nonexistent',
+        },
       ],
     };
     const ctx = makeHydrationContext();
@@ -712,5 +773,269 @@ describe('hydrateNode — harness', () => {
       assert(isNoeticConfigError(e));
       expect(e.code).toBe('UNKNOWN_SUB_HARNESS_REFERENCE');
     }
+  });
+});
+
+describe('hydrateNode — llm server tools (via tools array)', () => {
+  test('carries an inline server-tool spec through tools alongside a client tool', () => {
+    const testTool = makeTestTool();
+    const node: WorkflowNode = {
+      kind: 'llm',
+      id: 'search',
+      instructions: 'Search the web',
+      tools: [
+        {
+          type: 'test-tool',
+        },
+        {
+          type: 'openrouter:web_search',
+          parameters: {
+            maxResults: 6,
+            searchContextSize: 'medium',
+          },
+        },
+      ],
+    };
+    const result = hydrateNode(
+      node,
+      makeHydrationContext([
+        testTool,
+      ]),
+    );
+    assert(result.kind === 'llm');
+    const tools = typeof result.tools === 'function' ? [] : (result.tools ?? []);
+    // Client tool resolved from the registry + inline server-tool spec, in order.
+    expect(tools).toHaveLength(2);
+    expect(isServerToolSpec(tools[0])).toBe(false);
+    expect(tools[1]).toEqual({
+      type: 'openrouter:web_search',
+      parameters: {
+        maxResults: 6,
+        searchContextSize: 'medium',
+      },
+    });
+  });
+
+  test('a tools array of only server specs hydrates with no client tools', () => {
+    const node: WorkflowNode = {
+      kind: 'llm',
+      id: 'fetch',
+      instructions: 'Fetch a URL',
+      tools: [
+        {
+          type: 'openrouter:web_fetch',
+        },
+      ],
+    };
+    const result = hydrateNode(node, makeHydrationContext());
+    assert(result.kind === 'llm');
+    const tools = typeof result.tools === 'function' ? [] : (result.tools ?? []);
+    expect(tools).toHaveLength(1);
+    expect(isServerToolSpec(tools[0])).toBe(true);
+  });
+});
+
+describe('hydrateNode — dynamic fork (each / over)', () => {
+  test('fan-out width follows the input array length (no over)', () => {
+    const node: WorkflowNode = {
+      kind: 'fork',
+      id: 'fan',
+      mode: 'all',
+      each: {
+        kind: 'llm',
+        id: 'worker',
+        instructions: 'process item',
+      },
+      merge: 'concat',
+    };
+    const result = hydrateNode(node, makeHydrationContext());
+    assert(result.kind === 'fork');
+    assert(result.mode === 'all');
+    const ctx = makeMockContext();
+    const three = result.paths(
+      JSON.stringify([
+        'a',
+        'b',
+        'c',
+      ]),
+      ctx,
+    );
+    expect(three).toHaveLength(3);
+    const five = result.paths(
+      JSON.stringify(
+        Array.from(
+          {
+            length: 5,
+          },
+          (_v, i) => i,
+        ),
+      ),
+      ctx,
+    );
+    expect(five).toHaveLength(5);
+    // Each instantiated path carries a unique, item-suffixed id.
+    const ids = three.map((s) => s.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  test('selects the array via `over` from a JSON object input', () => {
+    const node: WorkflowNode = {
+      kind: 'fork',
+      id: 'fan2',
+      mode: 'settle',
+      over: 'items',
+      each: {
+        kind: 'llm',
+        id: 'worker',
+        instructions: 'process item',
+      },
+      merge: 'last',
+    };
+    const result = hydrateNode(node, makeHydrationContext());
+    assert(result.kind === 'fork');
+    const paths = result.paths(
+      JSON.stringify({
+        items: [
+          'x',
+          'y',
+        ],
+      }),
+      makeMockContext(),
+    );
+    expect(paths).toHaveLength(2);
+  });
+
+  test('throws INVALID_FORK_INPUT when the input is not an array', () => {
+    const node: WorkflowNode = {
+      kind: 'fork',
+      id: 'fan3',
+      mode: 'all',
+      each: {
+        kind: 'llm',
+        id: 'worker',
+        instructions: 'process item',
+      },
+      merge: 'concat',
+    };
+    const result = hydrateNode(node, makeHydrationContext());
+    assert(result.kind === 'fork');
+    try {
+      result.paths(
+        JSON.stringify({
+          not: 'an array',
+        }),
+        makeMockContext(),
+      );
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      assert(isNoeticConfigError(e));
+      expect(e.code).toBe('INVALID_FORK_INPUT');
+    }
+  });
+
+  test('static paths fork is unchanged', () => {
+    const node: WorkflowNode = {
+      kind: 'fork',
+      id: 'static',
+      mode: 'all',
+      paths: [
+        {
+          kind: 'llm',
+          id: 'p1',
+          instructions: 'a',
+        },
+        {
+          kind: 'llm',
+          id: 'p2',
+          instructions: 'b',
+        },
+      ],
+      merge: 'concat',
+    };
+    const result = hydrateNode(node, makeHydrationContext());
+    assert(result.kind === 'fork');
+    expect(result.paths(frameworkCast('ignored'), makeMockContext())).toHaveLength(2);
+  });
+});
+
+describe('hydrateNode — run', () => {
+  test('dispatches the code string + input through the subprocess and returns stdout', async () => {
+    const { adapter, calls } = makeMockSubprocess();
+    const node: WorkflowNode = {
+      kind: 'run',
+      id: 'compute',
+      execute: 'process.stdout.write("hi")',
+    };
+    const result = hydrateNode(node, makeHydrationContext());
+    expect(result.kind).toBe('run');
+    assert(result.kind === 'run');
+    const ctx = makeMockContext({
+      subprocess: adapter,
+    });
+    const out = await result.execute('the-input', ctx);
+    // The mock echoes back the dispatched code + stdin, proving both arrived.
+    expect(out).toBe('OUT:process.stdout.write("hi")|the-input');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].kind).toBe('process');
+    expect(calls[0].stdin).toBe('the-input');
+    expect(calls[0].metadata?.code).toBe('process.stdout.write("hi")');
+  });
+
+  test('resolves a named subprocess ref via HydrationContext.resolveSubprocess', async () => {
+    const { adapter, calls } = makeMockSubprocess();
+    const node: WorkflowNode = {
+      kind: 'run',
+      id: 'compute-ref',
+      execute: 'code-body',
+      subprocess: 'sandbox',
+    };
+    const ctx: HydrationContext = {
+      ...makeHydrationContext(),
+      resolveSubprocess: (ref) => (ref === 'sandbox' ? adapter : undefined),
+    };
+    const result = hydrateNode(node, ctx);
+    assert(result.kind === 'run');
+    const out = await result.execute('in', makeMockContext());
+    expect(out).toBe('OUT:code-body|in');
+    expect(calls).toHaveLength(1);
+  });
+
+  test('throws UNKNOWN_SUBPROCESS_REFERENCE when the named ref cannot be resolved', async () => {
+    const node: WorkflowNode = {
+      kind: 'run',
+      id: 'compute-bad',
+      execute: 'code',
+      subprocess: 'missing',
+    };
+    const result = hydrateNode(node, makeHydrationContext());
+    assert(result.kind === 'run');
+    try {
+      await result.execute('in', makeMockContext());
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      assert(isNoeticConfigError(e));
+      expect(e.code).toBe('UNKNOWN_SUBPROCESS_REFERENCE');
+    }
+  });
+
+  test('surfaces a non-zero exit / failed handle as a thrown error', async () => {
+    const { adapter } = makeMockSubprocess({
+      fail: true,
+    });
+    const node: WorkflowNode = {
+      kind: 'run',
+      id: 'compute-fail',
+      execute: 'boom',
+    };
+    const result = hydrateNode(node, makeHydrationContext());
+    assert(result.kind === 'run');
+    await expect(
+      result.execute(
+        'in',
+        makeMockContext({
+          subprocess: adapter,
+        }),
+      ),
+    ).rejects.toThrow('subprocess exited non-zero');
   });
 });

--- a/packages/core/test/schemas/workflow-json-schema.test.ts
+++ b/packages/core/test/schemas/workflow-json-schema.test.ts
@@ -14,6 +14,7 @@ import { validateWorkflow } from '../../src/schemas/workflow';
 const NODE_KINDS = [
   'llm',
   'tool',
+  'run',
   'branch',
   'fork',
   'spawn',

--- a/packages/core/test/schemas/workflow.test.ts
+++ b/packages/core/test/schemas/workflow.test.ts
@@ -70,8 +70,15 @@ describe('WorkflowNodeSchema — llm', () => {
       model: 'openai/gpt-4o',
       instructions: 'do stuff',
       tools: [
-        'search',
-        'calc',
+        {
+          type: 'search',
+        },
+        {
+          type: 'openrouter:web_search',
+          parameters: {
+            maxResults: 5,
+          },
+        },
       ],
       params: {
         temperature: 0.5,

--- a/packages/eval/src/optimization/field-discovery.ts
+++ b/packages/eval/src/optimization/field-discovery.ts
@@ -1,4 +1,5 @@
 import type { Step } from '@noetic-tools/core';
+import { isServerToolSpec } from '@noetic-tools/core';
 
 import { OptimizeScope } from '../types/eval';
 import type { OptimizableField } from '../types/optimizer';
@@ -55,6 +56,10 @@ function extractLlmFields(
     return;
   }
   for (const t of step.tools) {
+    // Server tools (web_search/web_fetch) carry no optimizable name/description.
+    if (isServerToolSpec(t)) {
+      continue;
+    }
     fields.push({
       path: `${path}.tools.${t.name}.description`,
       value: t.description,

--- a/packages/eval/src/optimization/mutator.ts
+++ b/packages/eval/src/optimization/mutator.ts
@@ -1,11 +1,20 @@
-import type { Step, Tool } from '@noetic-tools/core';
+import type { ServerToolSpec, Step, Tool } from '@noetic-tools/core';
+import { isServerToolSpec } from '@noetic-tools/core';
 
 import type { Candidate } from '../types/optimizer';
 
 //#region Helper Functions
 
-function replaceToolListFields(tools: Tool[], candidate: Candidate, path: string): Tool[] {
+function replaceToolListFields(
+  tools: (Tool | ServerToolSpec)[],
+  candidate: Candidate,
+  path: string,
+): (Tool | ServerToolSpec)[] {
   return tools.map((t) => {
+    // Server tools (web_search/web_fetch) have no optimizable fields — pass through.
+    if (isServerToolSpec(t)) {
+      return t;
+    }
     const name = candidate[`${path}.tools.${t.name}.name`] ?? t.name;
     const description = candidate[`${path}.tools.${t.name}.description`] ?? t.description;
     return {

--- a/packages/types/src/types/common.ts
+++ b/packages/types/src/types/common.ts
@@ -16,6 +16,42 @@ export interface RetryPolicy {
 }
 
 /**
+ * Declares an OpenRouter server-executed tool on an LLM step. OpenRouter runs
+ * the tool (web search, web fetch) provider-side and returns the result item in
+ * the response — no client-side execute function is involved.
+ *
+ * `parameters` keys are camelCase (e.g. `maxResults`, `searchContextSize`); the
+ * SDK re-serialises them to the wire format and silently drops unknown keys.
+ * @public
+ */
+export interface ServerToolSpec {
+  /** Server tool discriminator. */
+  type: 'openrouter:web_search' | 'openrouter:web_fetch';
+  /** Optional provider config forwarded to the tool (camelCase keys). */
+  parameters?: Record<string, unknown>;
+}
+
+/**
+ * Distinguishes an inline `ServerToolSpec` from a client `Tool` in a
+ * heterogeneous `tools` list. A server-tool spec carries a server-tool `type`
+ * discriminator and, unlike a `Tool`, has no `execute` method.
+ * @public
+ */
+export function isServerToolSpec(value: unknown): value is ServerToolSpec {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  if ('execute' in value) {
+    return false;
+  }
+  if (!('type' in value)) {
+    return false;
+  }
+  const { type } = value;
+  return type === 'openrouter:web_search' || type === 'openrouter:web_fetch';
+}
+
+/**
  * Optional parameters forwarded to the model provider during an LLM step.
  * @public
  */

--- a/packages/types/src/types/runtime.ts
+++ b/packages/types/src/types/runtime.ts
@@ -1,6 +1,6 @@
 import type { ZodType } from 'zod';
 import type { Channel, ChannelHandle, ExternalChannel } from './channel';
-import type { LLMResponse, ModelParams } from './common';
+import type { LLMResponse, ModelParams, ServerToolSpec } from './common';
 import type { Context, CwdState } from './context';
 import type { DetachedHandle } from './detached';
 import type { FsAdapter } from './fs-adapter';
@@ -64,6 +64,16 @@ interface CallModelRequestBase {
   outputSchema?: ZodType;
   /** Controls framework event emission. Defaults to `true`. Passed through from `StepLLM.emit`. */
   emit?: boolean | ((eventType: string, data: Record<string, unknown>) => boolean);
+  /**
+   * @internal
+   * Framework-internal carrier for OpenRouter server tools (web search/fetch).
+   * Server tools are an authoring concept inside `StepLLM.tools` — the
+   * interpreter partitions those entries out of the client `tools` list and
+   * stamps the specs here so the model caller can wrap them via the SDK's
+   * `serverTool()` and append them to the SDK tools array. NOT an authored
+   * field: public callers declare server tools as `tools` entries, never here.
+   */
+  _serverTools?: ServerToolSpec[];
   /** Optional signal for cancelling the in-flight call (used by session abort). */
   signal?: AbortSignal;
   /**

--- a/packages/types/src/types/step.ts
+++ b/packages/types/src/types/step.ts
@@ -1,6 +1,6 @@
 import type { ZodType } from 'zod';
 import type { Channel } from './channel';
-import type { ModelParams, RetryPolicy, StepMeta } from './common';
+import type { ModelParams, RetryPolicy, ServerToolSpec, StepMeta } from './common';
 import type { Context } from './context';
 import type { NoeticError } from './error';
 import type { ContextMemory, MemoryConfig, MemoryLayer, ProjectionPolicy } from './memory';
@@ -117,8 +117,14 @@ export interface StepLLM<TMemory = ContextMemory, _I = unknown, O = unknown> {
   model: Lazy<string, TMemory>;
   /** System instructions. Eager string or `(ctx) => string | undefined` getter. */
   instructions?: Lazy<string | undefined, TMemory>;
-  /** Tools exposed to the LLM. Eager array or `(ctx) => Tool[] | undefined` getter. Function-form tools do not contribute to the pre-computed `ctx.unifiedTools`; they are resolved per execution. */
-  tools?: Lazy<Tool[] | undefined, TMemory>;
+  /**
+   * Tools exposed to the LLM. Eager array or `(ctx) => (...)[] | undefined` getter.
+   * Entries are either a client `Tool` or an inline `ServerToolSpec` (an
+   * OpenRouter server tool the provider executes, e.g. web search/fetch).
+   * Function-form tools do not contribute to the pre-computed `ctx.unifiedTools`;
+   * they are resolved per execution.
+   */
+  tools?: Lazy<(Tool | ServerToolSpec)[] | undefined, TMemory>;
   output?: ZodType<O>;
   params?: ModelParams;
   /** Controls framework event emission for this step. Defaults to `true`. Set `false` to suppress all framework events. A filter function receives `(eventType, data)` and returns `boolean`. */

--- a/packages/web/content/docs/framework/json-runtime.mdx
+++ b/packages/web/content/docs/framework/json-runtime.mdx
@@ -81,11 +81,11 @@ Point your editor or validator at the bundled file (resolve it from the package,
 
 ## Node Kinds
 
-Nine node kinds are available. Leaf nodes (`llm`, `tool`) perform work; structural nodes (`sequence`, `fork`, `branch`, `loop`, `spawn`, `provide`, `every`) compose them into trees.
+Ten node kinds are available. Leaf nodes (`llm`, `tool`, `run`) perform work; structural nodes (`sequence`, `fork`, `branch`, `loop`, `spawn`, `provide`, `every`) compose them into trees.
 
 ### llm
 
-Call an LLM with instructions and optional tools.
+Call an LLM with instructions and optional tools. Every `tools` entry is a uniform object `{ type, parameters? }`. The `type` value decides the entry: a **registered tool name** (a client tool resolved from the tool registry) or a reserved **server-tool** type the provider executes itself (web search, web fetch).
 
 ```json
 {
@@ -93,7 +93,10 @@ Call an LLM with instructions and optional tools.
   "id": "summarize",
   "model": "openai/gpt-4o",
   "instructions": "Summarize the input text in three bullet points",
-  "tools": ["webSearch"],
+  "tools": [
+    { "type": "myClientTool" },
+    { "type": "openrouter:web_search", "parameters": { "maxResults": 6, "searchContextSize": "medium" } }
+  ],
   "params": { "temperature": 0.3, "maxTokens": 1024 }
 }
 ```
@@ -103,8 +106,31 @@ Call an LLM with instructions and optional tools.
 | `id` | `string` | required | Unique step identifier. |
 | `model` | `string` | `'openai/gpt-4o'` | Model identifier (OpenRouter format). |
 | `instructions` | `string` | required | System/user prompt for the LLM. |
-| `tools` | `string[]` | `undefined` | Tool names resolved from the tool registry. |
+| `tools` | `{ type: string, parameters?: object }[]` | `undefined` | Uniform tool entries. **Client tool**: `{ "type": "<registered-tool-name>" }` — `type` is resolved against the registry; any `parameters` is ignored (the model supplies call args at runtime). **Server tool**: `{ "type": "openrouter:web_search" \| "openrouter:web_fetch", "parameters"?: {...} }` — run by the provider; `parameters` keys are camelCase (e.g. `maxResults`, `searchContextSize`), unknown keys dropped. Client vs server is decided by the `type` value. |
 | `params` | `object` | `undefined` | Model parameters: `temperature`, `topP`, `maxTokens`, `stopSequences`. |
+
+### run
+
+Run a serialised code body. Unlike the programmatic `step.run` (which carries a closure), the JSON form carries `execute` as a code **string**. The code is never `eval`'d in-process (Cloudflare Workers forbid `eval`); it is dispatched through a [subprocess adapter](/docs/framework/runtime) which runs the code and returns its stdout as the step output. The step input is passed to the subprocess on stdin.
+
+```json
+{
+  "kind": "run",
+  "id": "transform",
+  "execute": "const input = require('fs').readFileSync(0, 'utf8'); process.stdout.write(input.toUpperCase());",
+  "retry": { "maxAttempts": 3, "backoff": "exponential", "initialDelay": 100 },
+  "subprocess": "sandbox"
+}
+```
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `id` | `string` | required | Unique step identifier. |
+| `execute` | `string` | required | Source code dispatched to the subprocess. Receives the step input on stdin; its stdout becomes the step output. |
+| `retry` | `object` | `undefined` | Retry policy: `{ maxAttempts, backoff: 'fixed' \| 'linear' \| 'exponential', initialDelay, maxDelay? }`. |
+| `subprocess` | `string` | `undefined` | Named subprocess adapter ref, resolved via `HydrationContext.resolveSubprocess`. When omitted, the harness default (`ctx.subprocess`) is used. |
+
+> **Execution requires a subprocess adapter.** The `run` node does not execute code in the worker process. The host must supply a subprocess adapter capable of running the code body and capturing its stdout. A non-zero exit (or failed handle) surfaces as a thrown error.
 
 ### tool
 
@@ -147,7 +173,7 @@ Run steps sequentially, threading each output as the next step's input.
 
 ### fork
 
-Run multiple paths concurrently with configurable merge strategy.
+Run multiple paths concurrently with configurable merge strategy. A fork is either **static** (a fixed `paths` array) or **dynamic** (`each`: one child per item of a runtime-produced array). Supply exactly one of `paths` or `each`.
 
 ```json
 {
@@ -163,11 +189,26 @@ Run multiple paths concurrently with configurable merge strategy.
 }
 ```
 
+Dynamic fan-out — one child per array item (data-dependent N):
+
+```json
+{
+  "kind": "fork",
+  "id": "per-item",
+  "mode": "all",
+  "over": "items",
+  "each": { "kind": "llm", "id": "worker", "instructions": "Process this item" },
+  "merge": "concat"
+}
+```
+
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `id` | `string` | required | Unique step identifier. |
 | `mode` | `'all' \| 'race' \| 'settle'` | required | `all` waits for every path; `race` returns the first; `settle` waits for all but tolerates failures. |
-| `paths` | `WorkflowNode[]` | required | Child nodes to execute concurrently. |
+| `paths` | `WorkflowNode[]` | — | Static child nodes to execute concurrently. Mutually exclusive with `each`. |
+| `each` | `WorkflowNode` | — | Dynamic body template instantiated once per input array item. Each item is injected as that child's input; template node ids are suffixed `-<i>` for uniqueness. Mutually exclusive with `paths`. |
+| `over` | `string` | `undefined` | With `each`: selector key into the input JSON object locating the array. When omitted, the input string is parsed as a JSON array directly. |
 | `merge` | `'last' \| 'first' \| 'concat'` | `'last'` | How to combine results. Ignored in `race` mode. |
 | `concurrency` | `number` | `undefined` | Maximum concurrent paths. |
 
@@ -461,6 +502,7 @@ const result = await harness.run(rootStep, 'input text', ctx);
 |---|---|---|
 | `tools` | `ReadonlyMap<string, Tool>` | Tool registry mapping tool names to `Tool` instances. |
 | `executeStep` | `ExecuteStepFn` | Step executor function (typically `harness.run.bind(harness)`). |
+| `resolveSubprocess` | `(ref: string) => SubprocessAdapter \| undefined` | Optional. Resolves a `run` node's named `subprocess` ref to an adapter. When a `run` node omits the ref, the harness default (`ctx.subprocess`) is used at execution time. |
 
 `hydrateWorkflow(doc, ctx)` converts a validated `WorkflowDocument` into its root `Step`. `hydrateNode(node, ctx)` converts a single `WorkflowNode`. Both return `Step<ContextMemory, string, string>` -- indistinguishable from programmatically built steps.
 
@@ -468,7 +510,7 @@ Throws `NoeticConfigError` with code `UNKNOWN_NODE_KIND` if a node kind is unrec
 
 ## Limitations
 
-- **No `step.run` node** -- `run` steps carry arbitrary closures, which are not JSON-serialisable. Use `tool` nodes to invoke registered tools instead.
+- **`run` nodes need a subprocess adapter** -- the JSON `run` node carries its body as a code string and dispatches it through a subprocess adapter (it is never `eval`'d in-process). A host that uses `run` nodes must supply an adapter capable of running the code and capturing its stdout.
 - **Tools resolved by name** -- every tool referenced in the workflow must be passed in the `tools` array. The hydrator looks them up by `tool.name`.
 - **Provide layers not resolved from registry** -- `provide` nodes reference layers by name, but the hydrator does not currently resolve them from a layer registry. The harness's default memory layers are inherited instead.
 - **Branch routing is substring-based** -- branch routes use case-insensitive substring matching on the input string. Complex routing logic requires programmatic `branch()` steps.

--- a/packages/web/public/schema/noetic-workflow.schema.json
+++ b/packages/web/public/schema/noetic-workflow.schema.json
@@ -41,7 +41,24 @@
             "tools": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "propertyNames": {
+                      "type": "string"
+                    },
+                    "additionalProperties": {}
+                  }
+                },
+                "required": [
+                  "type"
+                ],
+                "additionalProperties": false
               }
             },
             "params": {
@@ -105,6 +122,65 @@
             "kind",
             "id",
             "toolName"
+          ],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "run"
+            },
+            "id": {
+              "type": "string",
+              "minLength": 1
+            },
+            "execute": {
+              "type": "string",
+              "minLength": 1
+            },
+            "retry": {
+              "type": "object",
+              "properties": {
+                "maxAttempts": {
+                  "type": "integer",
+                  "exclusiveMinimum": 0,
+                  "maximum": 9007199254740991
+                },
+                "backoff": {
+                  "type": "string",
+                  "enum": [
+                    "fixed",
+                    "linear",
+                    "exponential"
+                  ]
+                },
+                "initialDelay": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "maxDelay": {
+                  "type": "number",
+                  "minimum": 0
+                }
+              },
+              "required": [
+                "maxAttempts",
+                "backoff",
+                "initialDelay"
+              ],
+              "additionalProperties": false
+            },
+            "subprocess": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "required": [
+            "kind",
+            "id",
+            "execute"
           ],
           "additionalProperties": false
         },
@@ -177,6 +253,13 @@
                 "$ref": "#/$defs/WorkflowNode"
               }
             },
+            "each": {
+              "$ref": "#/$defs/WorkflowNode"
+            },
+            "over": {
+              "type": "string",
+              "minLength": 1
+            },
             "merge": {
               "type": "string",
               "enum": [
@@ -194,8 +277,7 @@
           "required": [
             "kind",
             "id",
-            "mode",
-            "paths"
+            "mode"
           ],
           "additionalProperties": false
         },


### PR DESCRIPTION
## What

Adds three capabilities to the JSON Workflow Runtime (`@noetic-tools/core` + `@noetic-tools/types`) so model-authored / stored-as-JSON workflows can express what previously required the in-memory programmatic builder.

### 1. `run` node — the 1:1 JSON form of `step.run`
Lifts the documented *"No `step.run` node"* limitation. Carries `execute` as a **code string** plus optional `retry`/`subprocess`. The code is **never `eval`'d in-process** (so it's safe on Cloudflare Workers); it's dispatched through a `SubprocessAdapter` — resolved by the host via `HydrationContext.resolveSubprocess(ref)`, falling back to `ctx.subprocess`. The adapter runs the code and returns stdout via `handle.metadata.result`.

```json
{ "kind": "run", "id": "dedup", "execute": "<code>", "retry": { "maxAttempts": 3, "backoff": "exponential", "initialDelay": 100 }, "subprocess": "sandbox" }
```

### 2. Dynamic `fork`
The existing `fork` node gains `each` (a body template instantiated once per runtime array item) + optional `over` (selector into the JSON input). Mutually exclusive with static `paths` (enforced by a zod `.refine()`). Per-item input injection + `suffixNodeIds` for id uniqueness; `_optimizable` disabled on the dynamic path.

```json
{ "kind": "fork", "id": "fan", "mode": "all", "over": "items", "each": { "kind": "llm", "id": "worker", "instructions": "..." }, "merge": "concat" }
```

### 3. `llm.serverTools`
Declare OpenRouter server tools (`openrouter:web_search` / `openrouter:web_fetch`) per `llm` node. Wrapped via the SDK's `serverTool()` before hitting `convertToolsToAPIFormat` (a raw `{type}` entry crashes it); `parameters` kept camelCase (the SDK's outbound schema strips unknown keys). Response items already parse via `isKnownBaseType`.

```json
{ "kind": "llm", "id": "search", "instructions": "...", "serverTools": [ { "type": "openrouter:web_search", "parameters": { "maxResults": 6, "searchContextSize": "medium" } } ] }
```

## Tests / checks
- Typecheck PASS (core + types)
- **1125 core tests + 26 types tests pass**; 9 new hydrator tests (serverTools threading, dynamic fan-out width/`over`/error/static-unchanged, run dispatch/named-ref/unknown-ref/failure) with a mock subprocess adapter
- `gen:schema` regenerated, drift-gate updated, no drift
- Biome clean

## Notes
- The `run` execution contract requires the host's `SubprocessAdapter` to capture stdout into `handle.metadata.result` (and errors into `metadata.error`). Default stdio-ignore adapters won't; documented in `json-runtime.mdx`.