### PR TITLE
fix(web): link Platform and Code from the docs sidebar and footer

### DIFF
--- a/packages/web/app/docs/layout.tsx
+++ b/packages/web/app/docs/layout.tsx
@@ -12,6 +12,16 @@ export default function Layout({ children }: { children: React.ReactNode }): Rea
         url: '/',
         children: <MobileSectionTitle />,
       }}
+      links={[
+        {
+          text: 'Platform',
+          url: '/platform',
+        },
+        {
+          text: 'Code',
+          url: '/code',
+        },
+      ]}
       sidebar={{
         banner: <DocsIndexLink />,
       }}

--- a/packages/web/components/landing/footer.tsx
+++ b/packages/web/components/landing/footer.tsx
@@ -108,6 +108,12 @@ export function Footer(): ReactNode {
               gap: '24px',
             }}
           >
+            <Link href="/platform" style={NAV_LINK_STYLE}>
+              Platform
+            </Link>
+            <Link href="/code" style={NAV_LINK_STYLE}>
+              Code
+            </Link>
             <Link href="/docs" style={NAV_LINK_STYLE}>
               Docs
             </Link>


### PR DESCRIPTION
Follow-up to #54.

That PR added the `/platform` page and put **Platform** in the landing nav, but two other navigation surfaces still had no way to reach the product pages:

- **Docs pages** (fumadocs layout) — the sidebar linked only to docs content, so a reader on `/docs/framework` had no path to `/platform` or `/code`.
- **Site footer** — only Docs, GitHub, and npm.

Both now carry **Platform** and **Code**.

## Verified

- `tsc --noEmit` clean, `biome check` clean, `next build` renders all 76 pages.
- Screenshot-checked: docs sidebar links render above the page tree; footer reads Platform · Code · Docs · GitHub · npm; the landing nav (desktop and 390px mobile) already showed Code · Platform · Docs · GitHub from #54.