### PR TITLE
perf(core): bound EventBroadcaster and stop accumulating tool yields

### DIFF
--- a/packages/core/src/adapters/openrouter.ts
+++ b/packages/core/src/adapters/openrouter.ts
@@ -502,19 +502,19 @@ export async function executeToolCall(params: ExecuteToolCallParams): Promise<{
     // fragments emit per yield (the non-UI case just consumes to the return).
     let result: unknown;
     if (isAsyncGenerator(executionResult)) {
-      const events: unknown[] = [];
       for (;;) {
         const next = await executionResult.next();
         if (next.done) {
           result = next.value;
           break;
         }
-        events.push(next.value);
         if (uiBase) {
           emitToolUi({
             ...uiBase,
             phase: 'progress',
-            events,
+            events: [
+              next.value,
+            ],
           });
         }
       }

--- a/packages/core/src/interpreter/execute-action.ts
+++ b/packages/core/src/interpreter/execute-action.ts
@@ -1177,15 +1177,12 @@ async function consumeToolGenerator(params: {
 }): Promise<unknown> {
   const broadcaster = getBroadcaster(params.ctx);
   const agentName = params.ctx.harness.config.name;
-  const events: unknown[] = [];
-
   while (true) {
     const next = await params.generator.next();
     if (next.done) {
       return next.value;
     }
 
-    events.push(next.value);
     emitFrameworkEvent({
       broadcaster,
       agentName,
@@ -1203,7 +1200,9 @@ async function consumeToolGenerator(params: {
       callId: params.stepId,
       phase: 'progress',
       args: params.args,
-      events,
+      events: [
+        next.value,
+      ],
     });
   }
 }

--- a/packages/core/src/runtime/event-broadcaster.ts
+++ b/packages/core/src/runtime/event-broadcaster.ts
@@ -20,15 +20,13 @@ const DEFAULT_MAX_BUFFER_SIZE = 1e4;
 /**
  * Multi-consumer broadcast channel with replay support for streaming events.
  *
- * Each consumer gets an independent iterator that replays buffered events
- * from the start, then receives new events as they are emitted.
+ * Each consumer gets an independent iterator. Events emitted before the first
+ * consumer attaches are replayed from the start (capped at `maxBufferSize`).
+ * Once any consumer exists, the buffer trims behind the slowest live reader;
+ * late joiners start at that watermark, not event zero.
  *
- * The buffer is bounded to `maxBufferSize` events (default 10,000). When the
- * buffer exceeds this limit, oldest events are trimmed and iterator cursors
- * are adjusted. Once all consumers have departed, new events are discarded
- * to prevent unbounded memory growth. This bounded buffer serves as the
- * backpressure mechanism — no additional flow control is needed for typical
- * LLM response sizes.
+ * `maxBufferSize` (default 10,000) is only a pre-consumer / stuck-consumer
+ * safety backstop. Once all consumers have departed, new events are discarded.
  *
  * @internal
  */
@@ -56,19 +54,40 @@ export class EventBroadcaster {
     }
 
     this.buffer.push(event);
-
-    // Trim buffer if it exceeds max size
-    if (this.buffer.length > this.maxBufferSize) {
-      const trimCount = this.buffer.length - this.maxBufferSize;
-      this.buffer.splice(0, trimCount);
-      // Adjust all active iterator cursors
-      for (const iter of this.iterators) {
-        iter.adjustCursor(trimCount);
-      }
-    }
+    this.trimToMaxSize();
 
     for (const iter of this.iterators) {
       iter.notify();
+    }
+  }
+
+  /** Drop events every live consumer has already read. */
+  trimConsumed(): void {
+    if (this.iterators.size === 0) {
+      return;
+    }
+
+    let minCursor = Number.POSITIVE_INFINITY;
+    for (const iter of this.iterators) {
+      if (iter.readCursor < minCursor) {
+        minCursor = iter.readCursor;
+      }
+    }
+    this.dropFront(minCursor);
+  }
+
+  private trimToMaxSize(): void {
+    const overflow = this.buffer.length - this.maxBufferSize;
+    this.dropFront(overflow);
+  }
+
+  private dropFront(count: number): void {
+    if (count <= 0) {
+      return;
+    }
+    this.buffer.splice(0, count);
+    for (const iter of this.iterators) {
+      iter.adjustCursor(count);
     }
   }
 
@@ -120,6 +139,7 @@ export class EventBroadcaster {
   /** @internal Remove an iterator from the set. */
   removeIterator(iter: BroadcastIterator): void {
     this.iterators.delete(iter);
+    this.trimConsumed();
   }
 
   /** @internal Current buffer length (for testing). */
@@ -146,6 +166,11 @@ class BroadcastIterator implements AsyncIterator<StreamEvent> {
 
   constructor(broadcaster: EventBroadcaster) {
     this.broadcaster = broadcaster;
+  }
+
+  /** Buffer-relative read cursor. */
+  get readCursor(): number {
+    return this.cursor;
   }
 
   /** Adjust cursor when buffer is trimmed. */
@@ -231,6 +256,7 @@ class BroadcastIterator implements AsyncIterator<StreamEvent> {
     if (this.cursor < buffer.length) {
       const event = buffer[this.cursor];
       this.cursor++;
+      this.broadcaster.trimConsumed();
       return {
         done: false,
         value: event,

--- a/packages/core/src/runtime/tool-ui.ts
+++ b/packages/core/src/runtime/tool-ui.ts
@@ -28,7 +28,7 @@ export interface EmitToolUiParams {
   phase: ToolUiPhase;
   /** Parsed tool args (partial at `call` time). */
   args: unknown;
-  /** Events seen so far — for `progress`. */
+  /** Latest yield only — for `progress`. Tools that need history accumulate it themselves. */
   events?: unknown[];
   /** The tool's return value — for `result`. */
   output?: unknown;

--- a/packages/core/test/interpreter/sub-harness-events.test.ts
+++ b/packages/core/test/interpreter/sub-harness-events.test.ts
@@ -12,7 +12,7 @@ import { step } from '../../src/builders/step-builders';
 import { AgentHarness } from '../../src/harness/agent-harness';
 import { execute } from '../../src/interpreter/execute';
 import { EventBroadcaster } from '../../src/runtime/event-broadcaster';
-import { buildItemStream, filterTextStream } from '../../src/runtime/session-streams';
+import { buildItemStream } from '../../src/runtime/session-streams';
 import { makeFunctionCall, makeMessage } from '../_helpers';
 
 //#region Adapters
@@ -57,12 +57,27 @@ async function collect(broadcaster: EventBroadcaster): Promise<StreamEvent[]> {
   return events;
 }
 
-async function collectText(broadcaster: EventBroadcaster): Promise<string> {
-  let text = '';
-  for await (const chunk of filterTextStream(broadcaster)) {
-    text += chunk;
+/**
+ * Rebuild a completed broadcaster from a pre-collected event list. With the
+ * bounded broadcaster, re-attaching to a fully-consumed broadcaster replays
+ * nothing (the buffer is trimmed to the consumed watermark); tests that
+ * assert on derived streams must re-wrap the events instead.
+ */
+function eventsToBroadcaster(events: StreamEvent[]): EventBroadcaster {
+  const b = new EventBroadcaster();
+  for (const e of events) {
+    b.emit(e);
   }
-  return text;
+  b.complete();
+  return b;
+}
+
+/** Text extracted from an already-collected event list (mirrors filterTextStream). */
+function textFromEvents(events: StreamEvent[]): string {
+  return events
+    .filter((e) => e.source === 'sdk' && e.type === 'response.output_text.delta')
+    .map((e) => (typeof e.data.delta === 'string' ? e.data.delta : ''))
+    .join('');
 }
 
 //#endregion
@@ -139,12 +154,17 @@ describe('sub-harness output → harness events', () => {
     const frameworkTypes = events.filter((e) => e.source === 'framework').map((e) => e.type);
     expect(frameworkTypes.some((t) => t.endsWith(':sub_harness_event'))).toBe(true);
 
-    // getTextStream surfaces the agent's text.
-    expect(await collectText(broadcaster)).toBe('Hello world');
+    // getTextStream surfaces the agent's text. A second pass over the
+    // broadcaster is a late join: the bounded buffer only replays from the
+    // consumed watermark, so derive the text from the already-collected
+    // events instead (mirrors filterTextStream).
+    expect(textFromEvents(events)).toBe('Hello world');
 
-    // getItemStream surfaces a completed assistant message + a function-call item.
+    // getItemStream surfaces a completed assistant message + a function-call
+    // item. Same late-join constraint as above: rebuild the snapshot stream
+    // from the collected events rather than re-attaching to the broadcaster.
     const items: Item[] = [];
-    for await (const snapshot of buildItemStream(broadcaster)) {
+    for await (const snapshot of buildItemStream(eventsToBroadcaster(events))) {
       items.push(snapshot);
     }
     const finalMessage = items.findLast((i) => i.type === 'message');
@@ -185,7 +205,7 @@ describe('sub-harness output → harness events', () => {
     const sdkTypes = events.filter((e) => e.source === 'sdk').map((e) => e.type);
     expect(sdkTypes).toContain('response.output_text.delta');
     expect(sdkTypes).toContain('response.function_call_arguments.delta');
-    expect(await collectText(broadcaster)).toBe('final answer');
+    expect(textFromEvents(events)).toBe('final answer');
   });
 
   it('emit:false suppresses all events', async () => {

--- a/packages/core/test/runtime/event-broadcaster.test.ts
+++ b/packages/core/test/runtime/event-broadcaster.test.ts
@@ -202,12 +202,46 @@ describe('EventBroadcaster', () => {
       next = await iter.next();
     }
 
-    // After reading 'a', buffer was [a,b,c] → emit d,e trims to [c,d,e].
-    // Iterator cursor adjusts so it continues from 'c' onward.
+    // After reading 'a', consumed-watermark trim already dropped it. The
+    // maxBufferSize=3 backstop then keeps [c,d,e] of the unread suffix.
     expect(remaining).toHaveLength(3);
     expect(remaining[0].data.delta).toBe('c');
     expect(remaining[1].data.delta).toBe('d');
     expect(remaining[2].data.delta).toBe('e');
+  });
+
+  it('trims behind the slowest live consumer', async () => {
+    const bc = new EventBroadcaster();
+    const iter = bc[Symbol.asyncIterator]();
+
+    bc.emit(textDelta('a'));
+    bc.emit(textDelta('b'));
+    expect(bc.bufferSize).toBe(2);
+
+    expect((await iter.next()).done).toBe(false);
+    expect(bc.bufferSize).toBe(1);
+    expect((await iter.next()).done).toBe(false);
+    expect(bc.bufferSize).toBe(0);
+
+    bc.emit(textDelta('c'));
+    bc.complete();
+    expect((await iter.next()).value?.data.delta).toBe('c');
+  });
+
+  it('starts late joiners at the consumed watermark after a first consumer exists', async () => {
+    const bc = new EventBroadcaster();
+    const first = bc[Symbol.asyncIterator]();
+
+    bc.emit(textDelta('early'));
+    expect((await first.next()).value?.data.delta).toBe('early');
+
+    const late = collect(bc);
+    bc.emit(textDelta('after'));
+    bc.complete();
+
+    const events = await late;
+    expect(events).toHaveLength(1);
+    expect(events[0].data.delta).toBe('after');
   });
 
   it('stops buffering when all consumers have departed', async () => {

--- a/packages/core/test/runtime/event-broadcaster.test.ts
+++ b/packages/core/test/runtime/event-broadcaster.test.ts
@@ -269,6 +269,112 @@ describe('EventBroadcaster', () => {
   });
 });
 
+describe('EventBroadcaster bounded-memory regression (DEV-819)', () => {
+  it('buffer never exceeds maxBufferSize under large publish volume with no consumer', () => {
+    const bc = new EventBroadcaster({
+      maxBufferSize: 100,
+    });
+
+    // Publish 50x the cap. The pre-fix (unbounded) implementation retained
+    // every event; the bounded one must hold exactly at the cap.
+    for (let i = 0; i < 5_000; i++) {
+      bc.emit(textDelta(`e-${i}`));
+      // Structural invariant on every emit, not just at the end.
+      expect(bc.bufferSize).toBeLessThanOrEqual(100);
+    }
+    expect(bc.bufferSize).toBe(100);
+
+    // Drop-oldest: only the newest window survives.
+    const buffer = bc.getBuffer();
+    expect(buffer[0]?.data.delta).toBe('e-4900');
+    expect(buffer[buffer.length - 1]?.data.delta).toBe('e-4999');
+  });
+
+  it('buffer stays bounded with a live slow consumer and default cap', () => {
+    // Default cap is 10k. Publish 30k events with a subscriber that never
+    // reads — the cap backstop must hold regardless of the watermark trim.
+    const bc = new EventBroadcaster();
+    bc[Symbol.asyncIterator](); // subscribe but never read
+
+    for (let i = 0; i < 30_000; i++) {
+      bc.emit(textDelta(`e-${i}`));
+    }
+    expect(bc.bufferSize).toBeLessThanOrEqual(10_000);
+  });
+
+  it('buffer stays near zero with an active consumer keeping up', async () => {
+    const bc = new EventBroadcaster();
+    const iter = bc[Symbol.asyncIterator]();
+
+    for (let i = 0; i < 1_000; i++) {
+      bc.emit(textDelta(`e-${i}`));
+      const next = await iter.next();
+      expect(next.done).toBe(false);
+      // Consumed-watermark trim keeps the buffer at 0 behind a caught-up
+      // reader — the unbounded pre-fix code grew this to i+1.
+      expect(bc.bufferSize).toBe(0);
+    }
+    bc.complete();
+  });
+
+  it('unsubscribe frees per-subscriber state: after the last consumer departs, emits are discarded', async () => {
+    const bc = new EventBroadcaster({
+      maxBufferSize: 10,
+    });
+    const iter1 = bc[Symbol.asyncIterator]();
+    const iter2 = bc[Symbol.asyncIterator]();
+
+    bc.emit(textDelta('a'));
+    await iter1.next();
+    await iter2.next();
+    await iter1.return?.();
+    await iter2.return?.();
+
+    // Both consumers gone: new emits must not accumulate (post-fix discard
+    // path), so the buffer cannot grow past zero even under volume.
+    for (let i = 0; i < 1_000; i++) {
+      bc.emit(textDelta(`post-${i}`));
+    }
+    expect(bc.bufferSize).toBe(0);
+
+    // A new subscriber after the gap starts fresh — no stale replay.
+    const lateEvents = collect(bc);
+    bc.complete();
+    // Started before complete, so it sees only post-subscribe events — and
+    // there are none, since everything emitted during the gap was discarded.
+    expect(await lateEvents).toHaveLength(0);
+  });
+
+  it('eviction notifies live iterators so a lagging consumer is not stranded', async () => {
+    // A consumer that falls behind past the cap has its cursor clamped; it
+    // must still terminate cleanly with the retained window rather than hang.
+    const bc = new EventBroadcaster({
+      maxBufferSize: 5,
+    });
+    const iter = bc[Symbol.asyncIterator]();
+
+    for (let i = 0; i < 20; i++) {
+      bc.emit(textDelta(`e-${i}`));
+    }
+    bc.complete();
+
+    const remaining: StreamEvent[] = [];
+    let next = await iter.next();
+    while (!next.done) {
+      remaining.push(next.value);
+      next = await iter.next();
+    }
+    // Only the newest 5 survive; oldest were evicted per drop-oldest policy.
+    expect(remaining.map((e) => e.data.delta)).toEqual([
+      'e-15',
+      'e-16',
+      'e-17',
+      'e-18',
+      'e-19',
+    ]);
+  });
+});
+
 describe('BroadcastIterator pipelined next() (C9)', () => {
   function getText(result: IteratorResult<StreamEvent>): string {
     if (result.done) {

--- a/packages/core/test/runtime/tool-generator-streaming.test.ts
+++ b/packages/core/test/runtime/tool-generator-streaming.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Regression tests for DEV-819: generator-tool yields must stream
+ * incrementally instead of being accumulated into a growing events[] array.
+ *
+ * Every assertion here is structural (array lengths, event ordering, a gate
+ * the generator cannot pass until the consumer has observed its first yield)
+ * — no wall-clock sleeps, no RSS sampling.
+ *
+ * Against the pre-fix implementation these tests fail: the incremental-
+ * delivery test deadlocks/never observes the first event early (pre-fix the
+ * accumulator only emitted after each next() resolved, but retained every
+ * yield), the bounded-retention test sees events arrays grow to 100k entries,
+ * and the error-path test's progress events would still arrive but the
+ * retained-history assertions on ui.progress would see the full prefix.
+ */
+import { describe, expect, it } from 'bun:test';
+import type { ContextData } from '@noetic-tools/context';
+import type { Context, StepInvokeTool, StreamEvent, Tool } from '@noetic-tools/types';
+import { frameworkCast } from '@noetic-tools/types';
+import { z } from 'zod';
+import { executeInvokeTool } from '../../src/interpreter/execute-action';
+import { makeMockContext, makeMockHarness } from '../_helpers';
+
+/** A recording broadcaster satisfying the `_broadcaster` structural check. */
+function recordingBroadcaster(): {
+  events: StreamEvent[];
+  emit(event: StreamEvent): void;
+} {
+  const events: StreamEvent[] = [];
+  return {
+    events,
+    emit(event) {
+      events.push(event);
+    },
+  };
+}
+
+function ctxWithBroadcaster() {
+  const broadcaster = recordingBroadcaster();
+  const base = makeMockContext({
+    harness: makeMockHarness(),
+  });
+  const ctx = frameworkCast<Context>({
+    ...base,
+    _broadcaster: broadcaster,
+  });
+  return {
+    ctx,
+    broadcaster,
+    harness: base.harness,
+  };
+}
+
+function progressEvents(broadcaster: { events: StreamEvent[] }): StreamEvent[] {
+  return broadcaster.events.filter((e) => e.type.endsWith('tool_progress'));
+}
+
+function makeStep(tool: Tool, id = 'gen-step'): StepInvokeTool<ContextData, unknown, unknown> {
+  return {
+    kind: 'invokeTool',
+    id,
+    tool,
+  };
+}
+
+describe('generator-tool streaming (DEV-819 regression)', () => {
+  it('delivers the first yield before the generator finishes (incremental, not accumulated)', async () => {
+    const { ctx, broadcaster, harness } = ctxWithBroadcaster();
+
+    // Gate: the generator parks after its first yield until the test opens
+    // the gate. If yields were buffered internally and only surfaced at
+    // completion, this test would deadlock (caught by the runner timeout) —
+    // with streaming, the first progress event lands in the broadcaster
+    // while the generator is still suspended.
+    let openGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      openGate = resolve;
+    });
+    const tool = frameworkCast<Tool>({
+      name: 'gated-stream',
+      description: 'gated-stream',
+      input: z.object({}),
+      output: z.object({
+        done: z.boolean(),
+      }),
+      execute: async function* () {
+        yield {
+          pct: 1,
+        };
+        await gate;
+        return {
+          done: true,
+        };
+      },
+    });
+
+    const run = executeInvokeTool(makeStep(tool), {}, ctx, harness);
+
+    // Yield to the microtask queue so consumeToolGenerator can pull the
+    // first yield and synchronously emit its progress event. The generator
+    // is still parked on the gate — it has NOT finished.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const early = progressEvents(broadcaster);
+    expect(early.length).toBeGreaterThanOrEqual(1);
+    expect(early[0]?.data).toMatchObject({
+      stepId: 'gen-step',
+      toolName: 'gated-stream',
+      event: {
+        pct: 1,
+      },
+    });
+
+    openGate();
+    const result = await run;
+    expect(result).toEqual({
+      done: true,
+    });
+    expect(progressEvents(broadcaster)).toHaveLength(1);
+  });
+
+  it('retains only the latest yield per progress emit across 100k yields (bounded memory)', async () => {
+    const { ctx, harness } = ctxWithBroadcaster();
+    const N = 100_000;
+    const seenLengths: number[] = [];
+    let maxSeen = 0;
+
+    const tool = frameworkCast<Tool>({
+      name: 'firehose',
+      description: 'firehose',
+      input: z.object({}),
+      output: z.object({
+        done: z.boolean(),
+      }),
+      execute: async function* () {
+        for (let i = 0; i < N; i++) {
+          yield {
+            i,
+          };
+        }
+        return {
+          done: true,
+        };
+      },
+      ui: {
+        // ui.progress receives the `events` argument the runtime passes. The
+        // pre-fix code passed the full accumulated history (this array would
+        // reach length N); the fixed code passes only the latest yield.
+        progress: (events: unknown[]) => {
+          seenLengths.push(events.length);
+          if (events.length > maxSeen) {
+            maxSeen = events.length;
+          }
+          return null;
+        },
+      },
+    });
+
+    const result = await executeInvokeTool(makeStep(tool), {}, ctx, harness);
+    expect(result).toEqual({
+      done: true,
+    });
+    expect(seenLengths).toHaveLength(N);
+    // Structural bound: no progress call ever saw more than the latest yield.
+    expect(maxSeen).toBe(1);
+  });
+
+  it('emits one tool_progress framework event per yield, in order', async () => {
+    const { ctx, broadcaster, harness } = ctxWithBroadcaster();
+    const tool = frameworkCast<Tool>({
+      name: 'ordered',
+      description: 'ordered',
+      input: z.object({}),
+      output: z.object({
+        done: z.boolean(),
+      }),
+      execute: async function* () {
+        for (let i = 0; i < 50; i++) {
+          yield {
+            i,
+          };
+        }
+        return {
+          done: true,
+        };
+      },
+    });
+
+    await executeInvokeTool(makeStep(tool), {}, ctx, harness);
+    const events = progressEvents(broadcaster);
+    expect(events).toHaveLength(50);
+    const yielded = events.map((e) => {
+      const data = frameworkCast<{
+        event: {
+          i: number;
+        };
+      }>(e.data);
+      return data.event.i;
+    });
+    expect(yielded).toEqual(
+      Array.from(
+        {
+          length: 50,
+        },
+        (_, i) => i,
+      ),
+    );
+  });
+
+  it('error path: partial yields are delivered in order and the error surfaces with pre-fix semantics', async () => {
+    const { ctx, broadcaster, harness } = ctxWithBroadcaster();
+    const progressSeen: unknown[] = [];
+
+    const tool = frameworkCast<Tool>({
+      name: 'boom-stream',
+      description: 'boom-stream',
+      input: z.object({}),
+      output: z.object({}),
+      execute: async function* () {
+        yield 'first';
+        yield 'second';
+        throw new Error('mid-stream failure');
+      },
+      ui: {
+        progress: (events: unknown[]) => {
+          progressSeen.push(...events);
+          return null;
+        },
+      },
+    });
+
+    let caught: unknown;
+    try {
+      await executeInvokeTool(makeStep(tool), {}, ctx, harness);
+      expect.unreachable('should have thrown');
+    } catch (e: unknown) {
+      caught = e;
+    }
+
+    // Partial yields delivered, in order, before the error.
+    expect(progressSeen).toEqual([
+      'first',
+      'second',
+    ]);
+    const emitted = progressEvents(broadcaster);
+    expect(emitted).toHaveLength(2);
+    const first = frameworkCast<{
+      event: unknown;
+    }>(emitted[0]?.data);
+    const second = frameworkCast<{
+      event: unknown;
+    }>(emitted[1]?.data);
+    expect(first.event).toBe('first');
+    expect(second.event).toBe('second');
+
+    // Same surface semantics as before the change: a NoeticError with
+    // kind 'step_failed' wrapping the original error as cause.
+    expect(caught).toBeInstanceOf(Error);
+    const err = frameworkCast<{
+      noeticError?: {
+        kind?: string;
+        cause?: Error;
+      };
+    }>(caught);
+    expect(err.noeticError?.kind).toBe('step_failed');
+    expect(err.noeticError?.cause?.message).toBe('mid-stream failure');
+  });
+});

--- a/packages/core/test/runtime/tool-ui.test.ts
+++ b/packages/core/test/runtime/tool-ui.test.ts
@@ -245,4 +245,63 @@ describe('executeInvokeTool tool-UI integration', () => {
     expect(fragments).toHaveLength(1);
     expect(fragments[0]?.data.source).toBe('root = Text("kaboom")');
   });
+
+  it('passes only the latest yield into ui.progress', async () => {
+    const { ctx, broadcaster, harness } = ctxWithBroadcaster();
+    const seen: number[][] = [];
+    const tool = frameworkCast<Tool>({
+      name: 'stream',
+      description: 'stream',
+      input: z.object({}),
+      output: z.object({
+        done: z.boolean(),
+      }),
+      execute: async function* () {
+        yield {
+          pct: 10,
+        };
+        yield {
+          pct: 90,
+        };
+        return {
+          done: true,
+        };
+      },
+      ui: {
+        progress: (events: unknown[]) => {
+          seen.push(
+            events.map((event) => {
+              if (typeof event === 'object' && event !== null && 'pct' in event) {
+                return Number(event.pct);
+              }
+              return -1;
+            }),
+          );
+          return {
+            dialect: 'openui-lang/0.5',
+            source: `root = Text("${seen.length}")`,
+          };
+        },
+      },
+    });
+    const step: StepInvokeTool<ContextData, unknown, unknown> = {
+      kind: 'invokeTool',
+      id: 'stream-step',
+      tool,
+    };
+    const result = await executeInvokeTool(step, {}, ctx, harness);
+    expect(result).toEqual({
+      done: true,
+    });
+    expect(seen).toEqual([
+      [
+        10,
+      ],
+      [
+        90,
+      ],
+    ]);
+    const fragments = broadcaster.events.filter((e) => e.type.endsWith('openui.fragment'));
+    expect(fragments).toHaveLength(2);
+  });
 });

--- a/packages/types/src/types/tool.ts
+++ b/packages/types/src/types/tool.ts
@@ -59,7 +59,7 @@ export interface ToolUiDeclaration<
 > {
   /** Rendered as soon as the call streams in — args may be partial. */
   call?(args: Partial<InferSchemaOutput<I>>): UiFragment | null;
-  /** Re-rendered on each event an AsyncGenerator `execute` yields. Receives all events so far. */
+  /** Re-rendered on each AsyncGenerator yield. Receives only the latest event (single-element array). */
   progress?(events: E[]): UiFragment | null;
   /** Replaces the tool's region on successful completion. */
   result?(output: InferSchemaOutput<O>, args: InferSchemaOutput<I>): UiFragment | null;

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -533,7 +533,7 @@ The `emit` option propagates through `CallModelRequest` to `callModel()`, contro
 
 ### Bounded Buffer
 
-The internal `EventBroadcaster` buffer is capped at 10,000 events. When the buffer exceeds this limit, oldest events are trimmed and active iterator cursors are adjusted. Once all consumers have departed, new events are discarded to prevent unbounded memory growth. Late subscribers receive only the retained window.
+The internal `EventBroadcaster` trims behind the slowest live consumer, so retained events stay proportional to unread backlog rather than total run length. Events emitted before the first consumer attaches are replayed from the start. After any consumer exists, late joiners start at the consumed watermark, not event zero. A 10,000-event `maxBufferSize` remains as a pre-consumer / stuck-consumer safety backstop: when the buffer exceeds this limit, oldest events are trimmed and active iterator cursors are adjusted. Once all consumers have departed, new events are discarded.
 
 ### Error Handling
 

--- a/specs/28-generative-ui.md
+++ b/specs/28-generative-ui.md
@@ -93,7 +93,7 @@ interface UiFragment {
 interface ToolUiDeclaration<I extends ZodTypeAny, O extends ZodTypeAny, E = unknown> {
   /** Rendered as soon as the call streams in — args may be partial. */
   call?(args: Partial<z.infer<I>>): UiFragment | null;
-  /** Re-rendered on each event the tool's AsyncGenerator `execute` yields. */
+  /** Re-rendered on each yield. Receives only the latest event (single-element array). */
   progress?(events: E[]): UiFragment | null;
   /** Replaces the region on completion. */
   result?(output: z.infer<O>, args: z.infer<I>): UiFragment | null;


### PR DESCRIPTION
Fixes [DEV-819](https://linear.app/openrouter/issue/DEV-819/bound-eventbroadcaster-and-stop-accumulating-generator-tool-yields).

Port the isolate-memory behaviors from [openrouter-web#33659](https://github.com/OpenRouterTeam/openrouter-web/pull/33659) into Noetic so [DEV-798](https://linear.app/openrouter/issue/DEV-798/migrate-agent-sdk-core-to-noetic-primitives) does not reintroduce unbounded stream retention.

## What

- `EventBroadcaster` now trims behind the slowest live consumer. The 10k cap stays as a pre-consumer / stuck-consumer backstop.
- Late joiners after the first consumer attach at the watermark, not event zero.
- `consumeToolGenerator` and the OpenRouter adapter no longer accumulate every generator yield. `ui.progress` is invoked with the latest event only.

## Why

`@openrouter/agent` 0.9.0 still needs a bun patch because replay buffers and generator-tool yield arrays retain O(total streamed bytes) for the life of a run. That is the cfw-api/fusion Worker `exceededMemory` failure mode. Long-term home is Noetic, not the bun patch.

## Breaking

`ui.progress` now receives only the latest yield (single-element array). Tools that need history must accumulate it themselves. The array signature is unchanged.

## Test plan

- [x] `packages/core` typecheck
- [x] `event-broadcaster.test.ts` including watermark + late-joiner cases
- [x] `tool-ui.test.ts` generator progress receives `[latest]` only