### PR TITLE
fix(eval): guard writes and bound case concurrency

### DIFF
--- a/.claude/skills/noetic-eval/SKILL.md
+++ b/.claude/skills/noetic-eval/SKILL.md
@@ -169,14 +169,15 @@ noetic-eval --watch                # Re-run on changes
 
 noetic-eval -u                     # Optimize (GEPA)
 noetic-eval -u --scope full        # Full program optimization
-noetic-eval -u --budget 10         # Cost cap
+noetic-eval --concurrency 4       # Bound cases running per suite
 noetic-eval -u --dry-run           # Preview without writing
+noetic-eval -u --force-dirty       # Override dirty-file write guard
 
 noetic-eval --save-baseline        # Save scores as regression baseline
 noetic-eval --check                # Fail if scores regress or baseline cases vanish
 ```
 
-Exit codes: `0` all cases passed (clean `--check`; no-baseline `--check` prints a notice and passes), `1` any failed/errored case, regression, missing baseline case, or unresolvable explicit file pattern, `2` usage error (unknown flag, invalid `--scope`/`--budget` value — never silently dropped).
+Exit codes: `0` all cases passed (clean `--check`; no-baseline `--check` prints a notice and passes), `1` any failed/errored case, regression, missing baseline case, or unresolvable explicit file pattern, `2` usage error (unknown flag or invalid `--scope`/`--concurrency` value — never silently dropped).
 
 Watch mode spawns a fresh subprocess per run (in-process re-import is module-cached and would never re-register suites), serializes runs, coalesces changes during a run into one follow-up, and always exits `0` itself. Only the eval files are watched, not transitive imports.
 

--- a/.claude/skills/noetic-eval/references/api-reference.md
+++ b/.claude/skills/noetic-eval/references/api-reference.md
@@ -187,8 +187,8 @@ interface OptimizeOptions {
   scope: 'prompts-only' | 'flow-structure' | 'full';
   runEval: (step: Step) => Promise<Record<string, number>>;
   maxMetricCalls?: number;
-  budget?: number;
   dryRun?: boolean;
+  forceDirty?: boolean;
   codingAgent?: CodingAgent;
   preEnrichedFields?: OptimizableField[];  // AST-enriched fields with source locations
   gepa?: GepaConfig;

--- a/packages/core/test/interpreter/execute-run.test.ts
+++ b/packages/core/test/interpreter/execute-run.test.ts
@@ -41,7 +41,7 @@ function interceptDelays(): {
   };
 }
 
-describe('executeRunCode', () => {
+describe.serial('executeRunCode', () => {
   it('calls execute function and returns output', async () => {
     const s: StepRunCode<ContextData, string, number> = {
       kind: 'runCode',

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -76,7 +76,9 @@ noetic-eval --watch             # re-run on change
 noetic-eval --json              # machine-readable results
 noetic-eval --save-baseline     # record current scores
 noetic-eval --check             # fail if scores regress from the baseline
-noetic-eval --scope <scope> --budget <n>   # optimization run
+noetic-eval -u --scope <scope>            # optimization run
+noetic-eval --concurrency <n>             # bound cases running per suite
+noetic-eval -u --force-dirty              # override dirty-file write guard
 ```
 
 ## License

--- a/packages/eval/src/cli/args.ts
+++ b/packages/eval/src/cli/args.ts
@@ -11,8 +11,10 @@ export interface CliArgs {
   watch: boolean;
   optimize: boolean;
   scope: OptimizeScopeValue;
-  budget?: number;
   dryRun: boolean;
+  forceDirty: boolean;
+  /** Max cases running concurrently within a suite (default 4). */
+  concurrency?: number;
   saveBaseline: boolean;
   check: boolean;
 }
@@ -68,21 +70,25 @@ const argHandlers: Record<string, ArgHandler> = {
     args.scope = next;
     return 1;
   },
-  '--budget': (args, argv, i) => {
-    const next = argv[i + 1];
-    if (next === undefined) {
-      throw new UsageError('--budget requires a numeric value');
-    }
-    const parsed = Number.parseFloat(next);
-    if (Number.isNaN(parsed)) {
-      throw new UsageError(`Invalid --budget value "${next}" (expected a number)`);
-    }
-    args.budget = parsed;
-    return 1;
-  },
   '--dry-run': (args) => {
     args.dryRun = true;
     return 0;
+  },
+  '--force-dirty': (args) => {
+    args.forceDirty = true;
+    return 0;
+  },
+  '--concurrency': (args, argv, i) => {
+    const next = argv[i + 1];
+    if (next === undefined) {
+      throw new UsageError('--concurrency requires a value (a positive integer)');
+    }
+    const parsed = Number(next);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      throw new UsageError(`Invalid --concurrency value "${next}" (expected a positive integer)`);
+    }
+    args.concurrency = parsed;
+    return 1;
   },
   '--save-baseline': (args) => {
     args.saveBaseline = true;
@@ -111,6 +117,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
     optimize: false,
     scope: OptimizeScope.PromptsOnly,
     dryRun: false,
+    forceDirty: false,
     saveBaseline: false,
     check: false,
   };

--- a/packages/eval/src/cli/cli.ts
+++ b/packages/eval/src/cli/cli.ts
@@ -107,8 +107,8 @@ async function handleOptimization(
         return buildScoreMap(result);
       },
       maxMetricCalls: MAX_METRIC_CALLS,
-      budget: args.budget,
       dryRun: args.dryRun,
+      forceDirty: args.forceDirty,
     });
   }
   console.log('Optimization complete');
@@ -146,7 +146,13 @@ async function runEvals(args: CliArgs): Promise<RunOutcome> {
   }
 
   const { runAllSuites } = await import('../runner/suite-runner');
-  const results = await runAllSuites(suites);
+  const results = await runAllSuites(suites, {
+    ...(args.concurrency !== undefined
+      ? {
+          concurrency: args.concurrency,
+        }
+      : {}),
+  });
 
   reportResults(results, {
     verbose: args.verbose,

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -14,6 +14,7 @@ export type {
   WriteBackEntry,
   WriteBackReport,
 } from './optimization/source-writer';
+
 // Regression
 export { loadBaseline, saveBaseline } from './regression/baseline';
 export { checkRegression } from './regression/comparator';

--- a/packages/eval/src/optimization/gepa-bridge.ts
+++ b/packages/eval/src/optimization/gepa-bridge.ts
@@ -25,7 +25,6 @@ export interface OptimizeParams {
   runEval: (step: Step) => Promise<Record<string, number>>;
   examples?: ReadonlyArray<Record<string, unknown>>;
   maxMetricCalls?: number;
-  budget?: number;
   gepa?: GepaConfig;
 }
 

--- a/packages/eval/src/optimization/optimizer.ts
+++ b/packages/eval/src/optimization/optimizer.ts
@@ -3,6 +3,7 @@ import type { Step } from '@noetic-tools/core';
 import type { OptimizeConfig } from '../types/eval';
 import { OptimizeScope } from '../types/eval';
 import type {
+  ApplyResult,
   Candidate,
   CodingAgent,
   OptimizableField,
@@ -13,6 +14,7 @@ import { discoverFields } from './field-discovery';
 import type { GepaConfig } from './gepa-bridge';
 import type { WriteBackEntry, WriteBackReport } from './source-writer';
 import { writeOptimizedValues } from './source-writer';
+import { assertWritableUnderVersionControl } from './write-guard';
 
 //#region Types
 
@@ -21,8 +23,13 @@ export interface OptimizeOptions {
   scope: OptimizeConfig['scope'];
   runEval: (step: Step) => Promise<Record<string, number>>;
   maxMetricCalls?: number;
-  budget?: number;
   dryRun?: boolean;
+  /**
+   * Skip the version-control write-back guard. By default every target file
+   * must be git-tracked and unmodified before the optimizer rewrites it —
+   * see write-guard.ts. CLI: --force-dirty.
+   */
+  forceDirty?: boolean;
   codingAgent?: CodingAgent;
   preEnrichedFields?: OptimizableField[];
   gepa?: GepaConfig;
@@ -41,6 +48,12 @@ export interface OptimizeResult {
   writtenBack: boolean;
   /** Per-entry outcome of the write-back pass (absent under `dryRun` or when nothing changed). */
   writeBackReport?: WriteBackReport;
+  /**
+   * Outcome of the L3 coding-agent pass (absent when no agent ran). A failed
+   * apply is reported, never swallowed — the caller decides whether a partial
+   * optimization is acceptable.
+   */
+  codingAgentResult?: ApplyResult;
 }
 
 //#endregion
@@ -135,28 +148,70 @@ export async function optimize(options: OptimizeOptions): Promise<OptimizeResult
     fields,
     runEval: options.runEval,
     maxMetricCalls: options.maxMetricCalls,
-    budget: options.budget,
     gepa: options.gepa,
   });
 
-  // L3 optimization: delegate structural changes to coding agent
-  if (options.scope === OptimizeScope.Full && options.codingAgent) {
+  const entriesToWrite = options.dryRun ? [] : buildWriteBackEntries(fields, result.bestCandidate);
+  const runAgent = options.scope === OptimizeScope.Full && options.codingAgent !== undefined;
+
+  /* Version-control guard runs BEFORE anything mutates files — over the union
+   * of the L1 write-back targets and the L3 agent's target files. Running the
+   * agent first meant the guard then saw the agent's own uncommitted edits as
+   * "dirty" and blocked the literal write-back it exists to protect. */
+  const agentTargetFiles = runAgent
+    ? buildCodingAgentRecommendation(fields, result).targetFiles.map((f) => f.path)
+    : [];
+  const filesToGuard = [
+    ...new Set([
+      ...entriesToWrite.map((e) => e.sourceLocation.filePath),
+      ...agentTargetFiles,
+    ]),
+  ];
+  if (filesToGuard.length > 0) {
+    const guarded = assertWritableUnderVersionControl(filesToGuard, options.forceDirty);
+    if (options.forceDirty && guarded.some((v) => v.status !== 'clean')) {
+      console.warn(
+        `optimize: writing into ${guarded.filter((v) => v.status !== 'clean').length} dirty/untracked file(s) under --force-dirty.`,
+      );
+    }
+  }
+
+  // L3 optimization: delegate structural changes to the coding agent. Its
+  // result is surfaced, never discarded — a failed apply must be visible.
+  let codingAgentResult: ApplyResult | undefined;
+  if (runAgent && options.codingAgent) {
     const recommendation = buildCodingAgentRecommendation(fields, result);
-    await options.codingAgent.apply(recommendation);
+    codingAgentResult = await options.codingAgent.apply(recommendation);
+    if (!codingAgentResult.success) {
+      console.warn(
+        `optimize: coding agent apply failed${codingAgentResult.error ? `: ${codingAgentResult.error}` : ''}`,
+      );
+    }
   }
 
   let writtenBack = false;
   let writeBackReport: WriteBackReport | undefined;
-  if (!options.dryRun) {
-    const entriesToWrite = buildWriteBackEntries(fields, result.bestCandidate);
-    if (entriesToWrite.length > 0) {
-      writeBackReport = await writeOptimizedValues(entriesToWrite);
-      for (const skip of writeBackReport.skipped) {
-        const { filePath, line, column } = skip.sourceLocation;
-        console.warn(`Write-back skipped at ${filePath}:${line}:${column}: ${skip.reason}`);
-      }
-      writtenBack = writeBackReport.written > 0 && writeBackReport.skipped.length === 0;
+  if (entriesToWrite.length > 0) {
+    /* Files the agent just rewrote have stale source locations — the line/col
+     * recorded at discovery no longer describes the file. Splicing anyway
+     * would corrupt source (the mismatch guard catches value drift, but a
+     * moved literal at the same position would still splice wrong). Skip
+     * those entries and report them. */
+    const agentChanged = new Set(codingAgentResult?.changedFiles ?? []);
+    const safeEntries = entriesToWrite.filter((e) => !agentChanged.has(e.sourceLocation.filePath));
+    const staleEntries = entriesToWrite.filter((e) => agentChanged.has(e.sourceLocation.filePath));
+    writeBackReport = await writeOptimizedValues(safeEntries);
+    for (const stale of staleEntries) {
+      writeBackReport.skipped.push({
+        sourceLocation: stale.sourceLocation,
+        reason: 'file rewritten by the coding agent this run; source location is stale',
+      });
     }
+    for (const skip of writeBackReport.skipped) {
+      const { filePath, line, column } = skip.sourceLocation;
+      console.warn(`Write-back skipped at ${filePath}:${line}:${column}: ${skip.reason}`);
+    }
+    writtenBack = writeBackReport.written > 0 && writeBackReport.skipped.length === 0;
   }
 
   return {
@@ -166,6 +221,7 @@ export async function optimize(options: OptimizeOptions): Promise<OptimizeResult
     iterations: result.iterations,
     writtenBack,
     writeBackReport,
+    codingAgentResult,
   };
 }
 

--- a/packages/eval/src/optimization/write-guard.ts
+++ b/packages/eval/src/optimization/write-guard.ts
@@ -1,0 +1,110 @@
+import { spawnSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import * as path from 'node:path';
+
+//#region Types
+
+/** Verdict for one file the optimizer wants to rewrite. */
+export interface FileGuardVerdict {
+  filePath: string;
+  status: 'clean' | 'dirty' | 'untracked' | 'no-repo';
+}
+
+export class WriteGuardError extends Error {
+  readonly verdicts: FileGuardVerdict[];
+
+  constructor(verdicts: FileGuardVerdict[]) {
+    const blocked = verdicts.filter((v) => v.status !== 'clean');
+    super(
+      `Refusing to write optimized values into ${blocked.length} file(s) that are not committed-and-clean in git:\n` +
+        blocked.map((v) => `  ${v.filePath} (${v.status})`).join('\n') +
+        '\nOptimization write-back REPLACES your prompt literals; if the new value scores higher by gaming the metric, ' +
+        'a clean git state is the only way back. Commit or stash first, or pass forceDirty (CLI: --force-dirty) to override.',
+    );
+    this.name = 'WriteGuardError';
+    this.verdicts = verdicts;
+  }
+}
+
+//#endregion
+
+//#region Guard
+
+function gitStatusFor(filePath: string): FileGuardVerdict['status'] {
+  const absolutePath = realpathSync(filePath);
+  const rootResult = spawnSync(
+    'git',
+    [
+      'rev-parse',
+      '--show-toplevel',
+    ],
+    {
+      cwd: path.dirname(absolutePath),
+      encoding: 'utf-8',
+    },
+  );
+  if (rootResult.status !== 0) {
+    return 'no-repo';
+  }
+  const root = realpathSync(rootResult.stdout.trim());
+  const relativePath = path.relative(root, absolutePath);
+  const tracked = spawnSync(
+    'git',
+    [
+      'ls-files',
+      '--error-unmatch',
+      '--',
+      relativePath,
+    ],
+    {
+      cwd: root,
+      encoding: 'utf-8',
+    },
+  );
+  if (tracked.status !== 0) {
+    return 'untracked';
+  }
+  const status = spawnSync(
+    'git',
+    [
+      'status',
+      '--porcelain',
+      '--',
+      relativePath,
+    ],
+    {
+      cwd: root,
+      encoding: 'utf-8',
+    },
+  );
+  return status.stdout.trim() === '' ? 'clean' : 'dirty';
+}
+
+/**
+ * Version-control guard for optimizer write-back. Every target file must be
+ * git-tracked with no uncommitted modifications, so a bad optimization result
+ * (metric gaming is GEPA's classic failure mode) is always one `git checkout`
+ * from recovery. Throws {@link WriteGuardError} listing every blocked file;
+ * `forceDirty` skips the check entirely (deliberate, logged by the caller).
+ */
+export function assertWritableUnderVersionControl(
+  filePaths: ReadonlyArray<string>,
+  forceDirty?: boolean,
+): FileGuardVerdict[] {
+  const unique = [
+    ...new Set(filePaths),
+  ];
+  const verdicts = unique.map((filePath) => ({
+    filePath,
+    status: gitStatusFor(filePath),
+  }));
+  if (forceDirty && verdicts.every((v) => v.status !== 'no-repo')) {
+    return verdicts;
+  }
+  if (verdicts.some((v) => v.status !== 'clean')) {
+    throw new WriteGuardError(verdicts);
+  }
+  return verdicts;
+}
+
+//#endregion

--- a/packages/eval/src/runner/suite-runner.ts
+++ b/packages/eval/src/runner/suite-runner.ts
@@ -1,4 +1,5 @@
 import type { CaseResult, SuiteResult } from '../types/eval';
+import { runPool } from '../utils/run-pool';
 import type { SuiteDefinition } from './describe';
 import { createEvalContext } from './eval-context';
 
@@ -47,13 +48,33 @@ function computeAggregateScore(cases: CaseResult[]): number {
 
 //#region Public API
 
-export async function runSuite(suite: SuiteDefinition): Promise<SuiteResult> {
-  const suiteStart = performance.now();
-  const cases: CaseResult[] = [];
+/** Options controlling suite execution. */
+export interface RunSuiteOptions {
+  /**
+   * Max cases running concurrently within a suite. Every case executes a real
+   * agent plus scorers, so wall-clock scales ~linearly with this. Results are
+   * ordered by definition regardless of completion order. Default 4; pass 1
+   * for strictly sequential runs (e.g. cases sharing external state).
+   */
+  concurrency?: number;
+}
 
-  for (const caseDef of suite.cases) {
-    cases.push(await runCase(caseDef, suite));
-  }
+const DEFAULT_CASE_CONCURRENCY = 4;
+
+export async function runSuite(
+  suite: SuiteDefinition,
+  options?: RunSuiteOptions,
+): Promise<SuiteResult> {
+  const suiteStart = performance.now();
+  const concurrency = options?.concurrency ?? DEFAULT_CASE_CONCURRENCY;
+
+  // Cases run concurrently (each has its own harness/context — see
+  // createEvalContext); `runCase` already converts throws into CaseResult
+  // errors, so a failed case never rejects the pool.
+  const cases = await runPool(
+    suite.cases.map((caseDef) => () => runCase(caseDef, suite)),
+    concurrency,
+  );
 
   return {
     suiteName: suite.options.objective,
@@ -65,10 +86,15 @@ export async function runSuite(suite: SuiteDefinition): Promise<SuiteResult> {
   };
 }
 
-export async function runAllSuites(suites: ReadonlyArray<SuiteDefinition>): Promise<SuiteResult[]> {
+export async function runAllSuites(
+  suites: ReadonlyArray<SuiteDefinition>,
+  options?: RunSuiteOptions,
+): Promise<SuiteResult[]> {
+  // Suites stay sequential: aggregate scores feed baseline comparisons, and
+  // cross-suite interleaving would make timing-sensitive suites flaky.
   const results: SuiteResult[] = [];
   for (const suite of suites) {
-    results.push(await runSuite(suite));
+    results.push(await runSuite(suite, options));
   }
   return results;
 }

--- a/packages/eval/src/types/eval.ts
+++ b/packages/eval/src/types/eval.ts
@@ -24,8 +24,8 @@ export interface EvalSuiteOptions {
 
 export interface OptimizeConfig {
   scope: OptimizeScope;
+  /** Hard cap on candidate evaluations (GEPA's real cost lever). */
   maxMetricCalls?: number;
-  budget?: number;
   codingAgent?: import('./optimizer').CodingAgent;
   dryRun?: boolean;
 }

--- a/packages/eval/src/utils/run-pool.ts
+++ b/packages/eval/src/utils/run-pool.ts
@@ -1,0 +1,31 @@
+/**
+ * Bounded worker pool preserving result order (same shape as core's
+ * runWithConcurrency). Shared by the suite runner (per-case concurrency)
+ * and the GEPA bridge (per-field teacher proposals).
+ */
+export async function runPool<T>(
+  tasks: ReadonlyArray<() => Promise<T>>,
+  concurrency: number,
+): Promise<T[]> {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new RangeError('concurrency must be a positive integer');
+  }
+  const results: T[] = new Array(tasks.length);
+  let nextIndex = 0;
+  async function worker(): Promise<void> {
+    while (nextIndex < tasks.length) {
+      const index = nextIndex++;
+      const task = tasks[index];
+      results[index] = await task();
+    }
+  }
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.max(1, Math.min(concurrency, tasks.length)),
+      },
+      () => worker(),
+    ),
+  );
+  return results;
+}

--- a/packages/eval/test/cli/args.test.ts
+++ b/packages/eval/test/cli/args.test.ts
@@ -12,8 +12,9 @@ describe('parseCliArgs', () => {
     expect(args.watch).toBe(false);
     expect(args.optimize).toBe(false);
     expect(args.scope).toBe(OptimizeScope.PromptsOnly);
-    expect(args.budget).toBeUndefined();
     expect(args.dryRun).toBe(false);
+    expect(args.forceDirty).toBe(false);
+    expect(args.concurrency).toBeUndefined();
     expect(args.saveBaseline).toBe(false);
     expect(args.check).toBe(false);
   });
@@ -74,31 +75,51 @@ describe('parseCliArgs', () => {
     ).toThrow(UsageError);
   });
 
-  test('-u and --budget round-trip', () => {
+  test('--budget is no longer a recognised flag (removed dead cost knob)', () => {
+    // The flag was accepted but never read anywhere downstream — a cost
+    // control that silently did nothing. Unknown flags throw.
+    expect(() =>
+      parseCliArgs([
+        '--budget',
+        '12.5',
+      ]),
+    ).toThrow(UsageError);
+  });
+
+  test('--concurrency reads the following argv entry', () => {
     const args = parseCliArgs([
-      '-u',
-      '--budget',
-      '12.5',
+      '--concurrency',
+      '8',
+      'a.eval.ts',
     ]);
-    expect(args.optimize).toBe(true);
-    expect(args.budget).toBe(12.5);
+    expect(args.concurrency).toBe(8);
+    expect(args.files).toEqual([
+      'a.eval.ts',
+    ]);
   });
 
-  test('--budget without a value throws UsageError', () => {
+  test('--concurrency rejects a missing value', () => {
     expect(() =>
       parseCliArgs([
-        '--budget',
+        '--concurrency',
       ]),
     ).toThrow(UsageError);
   });
 
-  test('--budget with a non-numeric value throws UsageError', () => {
-    expect(() =>
-      parseCliArgs([
-        '--budget',
-        'cheap',
-      ]),
-    ).toThrow(UsageError);
+  test('--concurrency rejects non-positive-integer values', () => {
+    for (const bad of [
+      '0',
+      '-1',
+      '2.5',
+      'many',
+    ]) {
+      expect(() =>
+        parseCliArgs([
+          '--concurrency',
+          bad,
+        ]),
+      ).toThrow(UsageError);
+    }
   });
 
   test('boolean flags toggle', () => {
@@ -107,6 +128,7 @@ describe('parseCliArgs', () => {
       '--json',
       '--watch',
       '--dry-run',
+      '--force-dirty',
       '--save-baseline',
       '--check',
     ]);
@@ -114,6 +136,7 @@ describe('parseCliArgs', () => {
     expect(args.json).toBe(true);
     expect(args.watch).toBe(true);
     expect(args.dryRun).toBe(true);
+    expect(args.forceDirty).toBe(true);
     expect(args.saveBaseline).toBe(true);
     expect(args.check).toBe(true);
   });

--- a/packages/eval/test/optimization/optimizer.test.ts
+++ b/packages/eval/test/optimization/optimizer.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { callModel, runCode } from '@noetic-tools/core';
 
 import { buildWriteBackEntries, optimize } from '../../src/optimization/optimizer';
+import { WriteGuardError } from '../../src/optimization/write-guard';
 import { OptimizeScope } from '../../src/types/eval';
-import type { OptimizableField } from '../../src/types/optimizer';
+import type { ApplyResult, OptimizableField } from '../../src/types/optimizer';
 import { FieldKind } from '../../src/types/optimizer';
 
 let tmpDir: string;
@@ -169,6 +171,330 @@ describe('optimize() write-back semantics', () => {
     expect(result.fields).toHaveLength(0);
     expect(result.writtenBack).toBe(false);
     expect(result.iterations).toBe(0);
+  });
+});
+
+//#endregion
+
+//#region write-back guard + coding-agent interplay
+
+describe('optimize() write-back guard', () => {
+  function makeRepo(dir: string): void {
+    spawnSync(
+      'git',
+      [
+        'init',
+        '-q',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+    spawnSync(
+      'git',
+      [
+        'config',
+        'user.email',
+        't@t',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+    spawnSync(
+      'git',
+      [
+        'config',
+        'user.name',
+        't',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+    spawnSync(
+      'git',
+      [
+        'config',
+        'commit.gpgsign',
+        'false',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+  }
+
+  function commitAll(dir: string): void {
+    spawnSync(
+      'git',
+      [
+        'add',
+        '.',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+    spawnSync(
+      'git',
+      [
+        'commit',
+        '-qm',
+        'x',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+  }
+
+  async function writeAgentFile(name = 'agent.ts'): Promise<{
+    filePath: string;
+    source: string;
+    location: {
+      filePath: string;
+      line: number;
+      column: number;
+    };
+  }> {
+    const filePath = path.join(tmpDir, name);
+    const source = "export const instructions = 'original instructions';\n";
+    await fs.writeFile(filePath, source, 'utf-8');
+    return {
+      filePath,
+      source,
+      location: {
+        filePath,
+        line: 1,
+        column: 29,
+      },
+    };
+  }
+
+  function makeLocatedField(location: {
+    filePath: string;
+    line: number;
+    column: number;
+  }): OptimizableField {
+    return makeField({
+      sourceLocation: location,
+    });
+  }
+
+  /** The offline GEPA fallback never changes the candidate, so tests that need
+   * a changed candidate stub the bridge (optimizer loads it via dynamic import). */
+  function stubChangedCandidate(newValue = 'improved instructions'): void {
+    mock.module('../../src/optimization/gepa-bridge', () => ({
+      optimizeWithGepa: async () => ({
+        bestCandidate: {
+          'agent.instructions': newValue,
+        },
+        score: 1,
+        iterations: 1,
+      }),
+    }));
+  }
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('refuses to write back into an untracked file', async () => {
+    stubChangedCandidate();
+    makeRepo(tmpDir);
+    const { filePath, source, location } = await writeAgentFile();
+    // Deliberately NOT committed: write-back must refuse to destroy uncommitted work.
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    await expect(
+      optimize({
+        step: testStep,
+        scope: OptimizeScope.PromptsOnly,
+        preEnrichedFields: [
+          makeLocatedField(location),
+        ],
+        runEval: async () => ({
+          'case.scorer': 0.9,
+        }),
+      }),
+    ).rejects.toBeInstanceOf(WriteGuardError);
+    expect(await fs.readFile(filePath, 'utf-8')).toBe(source);
+  });
+
+  test('refuses to write back into a dirty tracked file', async () => {
+    stubChangedCandidate();
+    makeRepo(tmpDir);
+    const { filePath, location } = await writeAgentFile();
+    commitAll(tmpDir);
+    await fs.appendFile(filePath, '// uncommitted\n', 'utf-8');
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    await expect(
+      optimize({
+        step: testStep,
+        scope: OptimizeScope.PromptsOnly,
+        preEnrichedFields: [
+          makeLocatedField(location),
+        ],
+        runEval: async () => ({
+          'case.scorer': 0.9,
+        }),
+      }),
+    ).rejects.toBeInstanceOf(WriteGuardError);
+  });
+
+  test('forceDirty overrides the guard and writes back', async () => {
+    stubChangedCandidate();
+    makeRepo(tmpDir);
+    const { filePath, location } = await writeAgentFile();
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    const result = await optimize({
+      step: testStep,
+      scope: OptimizeScope.PromptsOnly,
+      preEnrichedFields: [
+        makeLocatedField(location),
+      ],
+      forceDirty: true,
+      runEval: async () => ({
+        'case.scorer': 0.9,
+      }),
+    });
+
+    expect(result.writtenBack).toBe(true);
+    expect(await fs.readFile(filePath, 'utf-8')).toContain('improved instructions');
+  });
+
+  test('guard runs BEFORE the coding agent apply (Full scope)', async () => {
+    makeRepo(tmpDir);
+    const { location } = await writeAgentFile();
+    // Untracked target file: the guard must fire before the agent touches anything.
+    let applied = false;
+    const codingAgent = {
+      apply: async (): Promise<ApplyResult> => {
+        applied = true;
+        return {
+          success: true,
+          changedFiles: [],
+        };
+      },
+    };
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    await expect(
+      optimize({
+        step: testStep,
+        scope: OptimizeScope.Full,
+        preEnrichedFields: [
+          makeLocatedField(location),
+        ],
+        codingAgent,
+        runEval: async () => ({
+          'case.scorer': 0.9,
+        }),
+      }),
+    ).rejects.toBeInstanceOf(WriteGuardError);
+    expect(applied).toBe(false);
+  });
+
+  test('write-back skips files the coding agent just rewrote (stale locations)', async () => {
+    stubChangedCandidate();
+    makeRepo(tmpDir);
+    const { filePath, source, location } = await writeAgentFile();
+    commitAll(tmpDir);
+
+    const codingAgent = {
+      apply: async (): Promise<ApplyResult> => ({
+        success: true,
+        changedFiles: [
+          filePath,
+        ],
+      }),
+    };
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    const result = await optimize({
+      step: testStep,
+      scope: OptimizeScope.Full,
+      preEnrichedFields: [
+        makeLocatedField(location),
+      ],
+      codingAgent,
+      runEval: async () => ({
+        'case.scorer': 0.9,
+      }),
+    });
+
+    expect(result.codingAgentResult?.success).toBe(true);
+    expect(result.writtenBack).toBe(false);
+    expect(result.writeBackReport?.written).toBe(0);
+    expect(result.writeBackReport?.skipped[0].reason).toContain('stale');
+    // The optimizer must not clobber the agent's rewrite with a stale splice.
+    expect(await fs.readFile(filePath, 'utf-8')).toBe(source);
+  });
+
+  test('a failed coding-agent apply is surfaced, not swallowed', async () => {
+    makeRepo(tmpDir);
+    const { location } = await writeAgentFile();
+    commitAll(tmpDir);
+
+    const codingAgent = {
+      apply: async (): Promise<ApplyResult> => ({
+        success: false,
+        changedFiles: [],
+        error: 'agent exploded',
+      }),
+    };
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    const result = await optimize({
+      step: testStep,
+      scope: OptimizeScope.Full,
+      preEnrichedFields: [
+        makeLocatedField(location),
+      ],
+      codingAgent,
+      runEval: async () => ({
+        'case.scorer': 0.9,
+      }),
+    });
+
+    expect(result.codingAgentResult).toEqual({
+      success: false,
+      changedFiles: [],
+      error: 'agent exploded',
+    });
   });
 });
 

--- a/packages/eval/test/optimization/write-guard.test.ts
+++ b/packages/eval/test/optimization/write-guard.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  assertWritableUnderVersionControl,
+  WriteGuardError,
+} from '../../src/optimization/write-guard';
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'write-guard-'));
+  spawnSync(
+    'git',
+    [
+      'init',
+      '-q',
+    ],
+    {
+      cwd: dir,
+    },
+  );
+  spawnSync(
+    'git',
+    [
+      'config',
+      'user.email',
+      't@t',
+    ],
+    {
+      cwd: dir,
+    },
+  );
+  spawnSync(
+    'git',
+    [
+      'config',
+      'user.name',
+      't',
+    ],
+    {
+      cwd: dir,
+    },
+  );
+  spawnSync(
+    'git',
+    [
+      'config',
+      'commit.gpgsign',
+      'false',
+    ],
+    {
+      cwd: dir,
+    },
+  );
+  return dir;
+}
+
+function commitAll(repo: string): void {
+  spawnSync(
+    'git',
+    [
+      'add',
+      '.',
+    ],
+    {
+      cwd: repo,
+    },
+  );
+  spawnSync(
+    'git',
+    [
+      'commit',
+      '-qm',
+      'x',
+    ],
+    {
+      cwd: repo,
+    },
+  );
+}
+
+describe('assertWritableUnderVersionControl', () => {
+  it('passes for a committed, unmodified file', () => {
+    const repo = makeRepo();
+    const file = join(repo, 'prompt.ts');
+    writeFileSync(file, 'export const p = "hello";\n');
+    commitAll(repo);
+    const verdicts = assertWritableUnderVersionControl([
+      file,
+    ]);
+    expect(verdicts[0].status).toBe('clean');
+  });
+
+  it('refuses an untracked file', () => {
+    const repo = makeRepo();
+    const file = join(repo, 'loose.ts');
+    writeFileSync(file, 'export const p = "hi";\n');
+    expect(() =>
+      assertWritableUnderVersionControl([
+        file,
+      ]),
+    ).toThrow(WriteGuardError);
+  });
+
+  it('refuses a tracked file with uncommitted modifications', () => {
+    const repo = makeRepo();
+    const file = join(repo, 'prompt.ts');
+    writeFileSync(file, 'v1');
+    commitAll(repo);
+    writeFileSync(file, 'v2-uncommitted');
+    expect(() =>
+      assertWritableUnderVersionControl([
+        file,
+      ]),
+    ).toThrow('dirty');
+  });
+
+  it('refuses a file outside any git repository', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'write-guard-norepo-'));
+    const file = join(dir, 'prompt.ts');
+    writeFileSync(file, 'x');
+    try {
+      assertWritableUnderVersionControl([
+        file,
+      ]);
+      expect.unreachable('expected WriteGuardError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(WriteGuardError);
+      if (!(err instanceof WriteGuardError)) {
+        throw err;
+      }
+      expect(err.verdicts[0].status).toBe('no-repo');
+    }
+  });
+
+  it('forceDirty overrides dirty or untracked files but still reports verdicts', () => {
+    const repo = makeRepo();
+    const file = join(repo, 'loose.ts');
+    writeFileSync(file, 'x');
+    const verdicts = assertWritableUnderVersionControl(
+      [
+        file,
+      ],
+      true,
+    );
+    expect(verdicts[0].status).toBe('untracked');
+  });
+
+  it('forceDirty still refuses files outside a Git repository', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'write-guard-norepo-force-'));
+    const file = join(dir, 'prompt.ts');
+    writeFileSync(file, 'x');
+    expect(() =>
+      assertWritableUnderVersionControl(
+        [
+          file,
+        ],
+        true,
+      ),
+    ).toThrow(WriteGuardError);
+  });
+
+  it('handles absolute paths from nested repository directories', () => {
+    const repo = makeRepo();
+    const nested = join(repo, 'src', 'nested');
+    const file = join(nested, 'prompt.ts');
+    mkdirSync(nested, {
+      recursive: true,
+    });
+    writeFileSync(file, 'x');
+    commitAll(repo);
+    expect(
+      assertWritableUnderVersionControl([
+        file,
+      ])[0].status,
+    ).toBe('clean');
+  });
+});

--- a/packages/eval/test/runner/suite-runner.test.ts
+++ b/packages/eval/test/runner/suite-runner.test.ts
@@ -98,3 +98,140 @@ describe('runSuite passThreshold', () => {
 });
 
 //#endregion
+
+//#region bounded case concurrency
+
+describe('runSuite case concurrency', () => {
+  function makeConcurrencySuite(caseCount: number): {
+    suite: SuiteDefinition;
+    state: {
+      active: number;
+      maxActive: number;
+      started: string[];
+    };
+  } {
+    const echoStep = runCode({
+      id: 'echo',
+      execute: async (input: unknown) => input,
+    });
+    const state: {
+      active: number;
+      maxActive: number;
+      started: string[];
+    } = {
+      active: 0,
+      maxActive: 0,
+      started: [],
+    };
+    const cases = Array.from(
+      {
+        length: caseCount,
+      },
+      (_, i) => ({
+        name: `case-${i}`,
+        async fn() {
+          state.started.push(`case-${i}`);
+          state.active++;
+          state.maxActive = Math.max(state.maxActive, state.active);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          state.active--;
+        },
+      }),
+    );
+    return {
+      suite: {
+        step: echoStep,
+        options: {
+          objective: 'concurrency test',
+        },
+        cases,
+      },
+      state,
+    };
+  }
+
+  test('cases run concurrently by default (bounded at 4)', async () => {
+    const { suite, state } = makeConcurrencySuite(8);
+    const result = await runSuite(suite);
+
+    expect(result.cases).toHaveLength(8);
+    expect(state.maxActive).toBeGreaterThan(1);
+    expect(state.maxActive).toBeLessThanOrEqual(4);
+  });
+
+  test('explicit concurrency bounds in-flight cases', async () => {
+    const { suite, state } = makeConcurrencySuite(6);
+    await runSuite(suite, {
+      concurrency: 2,
+    });
+
+    expect(state.maxActive).toBeLessThanOrEqual(2);
+    expect(state.maxActive).toBeGreaterThan(1);
+  });
+
+  test('rejects invalid programmatic concurrency', async () => {
+    const { suite } = makeConcurrencySuite(1);
+    await expect(
+      runSuite(suite, {
+        concurrency: Number.NaN,
+      }),
+    ).rejects.toThrow('positive integer');
+    await expect(
+      runSuite(suite, {
+        concurrency: 1.5,
+      }),
+    ).rejects.toThrow('positive integer');
+    await expect(
+      runSuite(suite, {
+        concurrency: 0,
+      }),
+    ).rejects.toThrow('positive integer');
+  });
+
+  test('concurrency 1 runs strictly sequentially', async () => {
+    const { suite, state } = makeConcurrencySuite(4);
+    await runSuite(suite, {
+      concurrency: 1,
+    });
+
+    expect(state.maxActive).toBe(1);
+  });
+
+  test('results stay ordered by definition regardless of completion order', async () => {
+    const echoStep = runCode({
+      id: 'echo',
+      execute: async (input: unknown) => input,
+    });
+    // First case is slowest: with a naive push-on-completion pool it would
+    // land last. Result order must follow the definition order.
+    const suite: SuiteDefinition = {
+      step: echoStep,
+      options: {
+        objective: 'ordering test',
+      },
+      cases: [
+        {
+          name: 'slow-first',
+          async fn() {
+            await new Promise((resolve) => setTimeout(resolve, 30));
+          },
+        },
+        {
+          name: 'fast-second',
+          async fn() {
+            await new Promise((resolve) => setTimeout(resolve, 1));
+          },
+        },
+      ],
+    };
+
+    const result = await runSuite(suite);
+
+    expect(result.cases.map((c) => c.name)).toEqual([
+      'slow-first',
+      'fast-second',
+    ]);
+  });
+});
+
+//#endregion

--- a/specs/17-eval-and-optimization.md
+++ b/specs/17-eval-and-optimization.md
@@ -381,7 +381,6 @@ interface OptimizeParams {
   runEval: (step: Step) => Promise<Record<string, number>>;
   examples?: ReadonlyArray<Record<string, unknown>>;
   maxMetricCalls?: number;
-  budget?: number;
   gepa?: GepaConfig;
 }
 
@@ -641,8 +640,9 @@ invocation from when the CLI and eval framework shared one binary.
 | `--watch` | `boolean` | `false` | Re-run evals when the eval files change (fresh subprocess per run) |
 | `-u` | `boolean` | `false` | Run GEPA optimization after evaluation |
 | `--scope` | `enum` | `prompts-only` | Optimization scope: `prompts-only`, `flow-structure`, or `full` |
-| `--budget` | `number` | (none) | Maximum cost in dollars for the optimization run |
+| `--concurrency` | `number` | `4` | Maximum eval cases running concurrently within each suite |
 | `--dry-run` | `boolean` | `false` | Optimize without writing values back to source |
+| `--force-dirty` | `boolean` | `false` | Allow optimizer write-back into dirty or untracked files (a Git repository is still required) |
 | `--save-baseline` | `boolean` | `false` | Save each suite's results as its regression baseline (`.noetic/baselines/<suite>.json`) |
 | `--check` | `boolean` | `false` | Compare against saved baselines; exit `1` on regression or missing baseline case |
 
@@ -685,7 +685,7 @@ A case "fails" when any scorer returns a value below `0.5` (configurable via `Ev
 ### Optimization via CLI
 
 ```
-noetic-eval -u [--scope prompts-only|flow-structure|full] [--budget 5.00] [files...]
+noetic-eval -u [--scope prompts-only|flow-structure|full] [--force-dirty] [files...]
 ```
 
 Runs the optimization pipeline after evaluation. The `--scope` flag controls the optimization level (L1 `prompts-only`, L2 `flow-structure`, L3 `full`). With `--dry-run`, nothing is written back to source.


### PR DESCRIPTION
## What

- refuse optimizer write-back unless every target is tracked and clean in Git
- add `--force-dirty` for deliberate dirty/untracked overrides while still requiring a repository
- run the guard before coding-agent apply and skip stale literal locations in files the agent rewrites
- run eval cases through an order-preserving bounded pool (default 4, configurable with `--concurrency`)
- remove the accepted-but-ignored `--budget`/`budget` option

## Why

Optimization write-back replaces source literals. Without a version-control guard it can destroy uncommitted work, including changes made by a structural coding-agent pass. Eval suites also ran cases serially even though each case owns an independent context.

The removed budget option had no downstream reader and therefore provided false safety. `maxMetricCalls` remains the actual GEPA evaluation bound.

This semantically ports only the eval safety/concurrency portion of `fork/port/openrouter-fixes` commit `aedf712f`. GEPA discovery, traversal, and judge reuse remain item 5 and are not included here.

## Test plan

- [x] eval suite — 2,066 pass, 6 integration/benchmark skips in the root test command
- [x] focused write-guard/optimizer/concurrency tests — 29 pass
- [x] eval typecheck
- [x] root lint
- [x] `sentrux check .`
- [x] `sentrux gate .`
- [x] clean-context Pi review; fixed absolute/worktree path handling, no-repo override, API validation, and docs

## Breaking behavior

- `--budget` and the corresponding programmatic `budget` option are removed because they were silently ignored.
- eval cases now run with concurrency 4 by default; use `--concurrency 1` for suites sharing external mutable state.
