### PR TITLE
fix(openui): harden transport and surface state

### DIFF
--- a/packages/core/src/interpreter/execute-action.ts
+++ b/packages/core/src/interpreter/execute-action.ts
@@ -111,7 +111,7 @@ export async function executeRunCode<TContext, I, O>(
       lastError = e instanceof Error ? e : new Error(String(e));
 
       if (attempt < maxAttempts - 1 && retry) {
-        const delay = computeDelay(retry, attempt);
+        const delay = computeRetryDelay(retry, attempt);
         await new Promise((r) => setTimeout(r, delay));
       }
     }
@@ -125,7 +125,8 @@ export async function executeRunCode<TContext, I, O>(
   });
 }
 
-function computeDelay(retry: RetryPolicy, attempt: number): number {
+/** @internal Pure retry delay calculation for deterministic tests. */
+export function computeRetryDelay(retry: RetryPolicy, attempt: number): number {
   let delay: number;
   switch (retry.backoff) {
     case 'fixed':

--- a/packages/core/test/interpreter/execute-run.test.ts
+++ b/packages/core/test/interpreter/execute-run.test.ts
@@ -1,47 +1,15 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import assert from 'node:assert';
 import type { ContextData } from '@noetic-tools/context';
-import type { Context, StepRunCode } from '@noetic-tools/types';
+import type { Context, RetryPolicy, StepRunCode } from '@noetic-tools/types';
 import { isNoeticError, NoeticErrorImpl } from '@noetic-tools/types';
-import { executeRunCode } from '../../src/interpreter/execute-action';
+import { computeRetryDelay, executeRunCode } from '../../src/interpreter/execute-action';
 import { ContextImpl } from '../../src/runtime/context-impl';
 import { makeMockContext, makeMockHarness } from '../_helpers';
 
 const mockCtx: Context = makeMockContext();
 
-// Safety net: ensure setTimeout is always restored
-const _originalSetTimeout = globalThis.setTimeout;
-afterEach(() => {
-  globalThis.setTimeout = _originalSetTimeout;
-});
-
-/** Patch setTimeout to capture delay values and execute callbacks instantly. */
-function interceptDelays(): {
-  delays: number[];
-  restore: () => void;
-} {
-  const delays: number[] = [];
-  // Wrap the original to intercept delay values while preserving the full overloaded signature
-  const handler: ProxyHandler<typeof setTimeout> = {
-    apply(_target, thisArg, argsList: unknown[]) {
-      const delay = argsList[1];
-      if (typeof delay === 'number' && delay > 0) {
-        delays.push(delay);
-      }
-      argsList[1] = 1;
-      return Reflect.apply(_originalSetTimeout, thisArg, argsList);
-    },
-  };
-  globalThis.setTimeout = new Proxy(_originalSetTimeout, handler);
-  return {
-    delays,
-    restore: () => {
-      globalThis.setTimeout = _originalSetTimeout;
-    },
-  };
-}
-
-describe.serial('executeRunCode', () => {
+describe('executeRunCode', () => {
   it('calls execute function and returns output', async () => {
     const s: StepRunCode<ContextData, string, number> = {
       kind: 'runCode',
@@ -88,105 +56,81 @@ describe.serial('executeRunCode', () => {
   });
 
   it('retries with fixed backoff', async () => {
-    const { delays, restore } = interceptDelays();
-
     let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
+    const retry: RetryPolicy = {
+      maxAttempts: 3,
+      backoff: 'fixed',
+      initialDelay: 1,
+    };
+    const step: StepRunCode<ContextData, string, string> = {
       kind: 'runCode',
       id: 'retry-test',
-      execute: async (_input) => {
+      retry,
+      execute: async () => {
         attempts++;
         if (attempts < 3) {
           throw new Error('not yet');
         }
         return 'success';
       },
-      retry: {
-        maxAttempts: 3,
-        backoff: 'fixed',
-        initialDelay: 10,
-      },
     };
-    try {
-      const result = await executeRunCode(s, 'test', mockCtx);
-      expect(result).toBe('success');
-      expect(attempts).toBe(3);
-      // Fixed backoff: all delays should be 10
-      expect(delays).toEqual([
-        10,
-        10,
-      ]);
-    } finally {
-      restore();
-    }
+    expect(await executeRunCode(step, 'test', mockCtx)).toBe('success');
+    expect(attempts).toBe(3);
+    expect(
+      [
+        0,
+        1,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
+      1,
+      1,
+    ]);
   });
 
   it('retries with exponential backoff and exhausts', async () => {
-    const { delays, restore } = interceptDelays();
     let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
+    const retry: RetryPolicy = {
+      maxAttempts: 3,
+      backoff: 'exponential',
+      initialDelay: 1,
+    };
+    const step: StepRunCode<ContextData, string, string> = {
       kind: 'runCode',
       id: 'exhaust-test',
+      retry,
       execute: async () => {
         attempts++;
         throw new Error('always fails');
       },
-      retry: {
-        maxAttempts: 3,
-        backoff: 'exponential',
-        initialDelay: 10,
-      },
     };
-    try {
-      await executeRunCode(s, 'test', mockCtx);
-      expect.unreachable('should have thrown');
-    } catch (e) {
-      assert(isNoeticError(e));
-      const oe = e.noeticError;
-      assert(oe.kind === 'step_failed');
-      expect(oe.retriesExhausted).toBe(true);
-      expect(attempts).toBe(3);
-      expect(delays).toEqual([
-        10,
-        20,
-      ]);
-    } finally {
-      restore();
-    }
+    await expect(executeRunCode(step, 'test', mockCtx)).rejects.toThrow('always fails');
+    expect(attempts).toBe(3);
+    expect(
+      [
+        0,
+        1,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
+      1,
+      2,
+    ]);
   });
 
-  it('caps exponential backoff delay at maxDelay', async () => {
-    const { delays, restore } = interceptDelays();
-
-    let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
-      kind: 'runCode',
-      id: 'cap-test',
-      execute: async () => {
-        attempts++;
-        if (attempts < 5) {
-          throw new Error('fail');
-        }
-        return 'ok';
-      },
-      retry: {
-        maxAttempts: 5,
-        backoff: 'exponential',
-        initialDelay: 100,
-        maxDelay: 500,
-      },
+  it('caps exponential backoff delay at maxDelay', () => {
+    const retry: RetryPolicy = {
+      maxAttempts: 5,
+      backoff: 'exponential',
+      initialDelay: 100,
+      maxDelay: 500,
     };
-    try {
-      await executeRunCode(s, 'test', mockCtx);
-    } finally {
-      restore();
-    }
-    // Delays: 100, 200, 400, 500 (capped from 800)
-    for (const d of delays) {
-      expect(d).toBeLessThanOrEqual(500);
-    }
-    expect(delays.length).toBeGreaterThan(0);
-    expect(delays).toEqual([
+    expect(
+      [
+        0,
+        1,
+        2,
+        3,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
       100,
       200,
       400,
@@ -194,46 +138,26 @@ describe.serial('executeRunCode', () => {
     ]);
   });
 
-  it('defaults maxDelay to 30000', async () => {
-    // With exponential backoff, delay = 100 * 2^attempt
-    // For attempt 9: 100 * 512 = 51200, should be capped at 30000
-    const { delays, restore } = interceptDelays();
-
-    let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
-      kind: 'runCode',
-      id: 'default-cap-test',
-      execute: async () => {
-        attempts++;
-        if (attempts < 11) {
-          throw new Error('fail');
-        }
-        return 'ok';
-      },
-      retry: {
-        maxAttempts: 11,
-        backoff: 'exponential',
-        initialDelay: 100,
-      },
+  it('defaults maxDelay to 30000', () => {
+    const retry: RetryPolicy = {
+      maxAttempts: 11,
+      backoff: 'exponential',
+      initialDelay: 100,
     };
-    try {
-      await executeRunCode(s, 'test', mockCtx);
-    } finally {
-      restore();
-    }
-    for (const d of delays) {
-      expect(d).toBeLessThanOrEqual(30_000);
-    }
-    expect(delays.length).toBeGreaterThan(0);
+    expect(computeRetryDelay(retry, 9)).toBe(30_000);
   });
 
   it('retries with linear backoff', async () => {
-    const { delays, restore } = interceptDelays();
-
     let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
+    const retry: RetryPolicy = {
+      maxAttempts: 3,
+      backoff: 'linear',
+      initialDelay: 1,
+    };
+    const step: StepRunCode<ContextData, string, string> = {
       kind: 'runCode',
       id: 'linear-test',
+      retry,
       execute: async () => {
         attempts++;
         if (attempts < 3) {
@@ -241,24 +165,18 @@ describe.serial('executeRunCode', () => {
         }
         return 'ok';
       },
-      retry: {
-        maxAttempts: 3,
-        backoff: 'linear',
-        initialDelay: 10,
-      },
     };
-    try {
-      const result = await executeRunCode(s, 'test', mockCtx);
-      expect(result).toBe('ok');
-      expect(attempts).toBe(3);
-      // Linear backoff: delay = initialDelay * attempt
-      expect(delays).toEqual([
-        10,
-        20,
-      ]);
-    } finally {
-      restore();
-    }
+    expect(await executeRunCode(step, 'test', mockCtx)).toBe('ok');
+    expect(attempts).toBe(3);
+    expect(
+      [
+        0,
+        1,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
+      1,
+      2,
+    ]);
   });
 
   describe('cancellation (not retriable)', () => {

--- a/packages/core/test/interpreter/execute-run.test.ts
+++ b/packages/core/test/interpreter/execute-run.test.ts
@@ -41,7 +41,7 @@ function interceptDelays(): {
   };
 }
 
-describe('executeRunCode', () => {
+describe.serial('executeRunCode', () => {
   it('calls execute function and returns output', async () => {
     const s: StepRunCode<ContextData, string, number> = {
       kind: 'runCode',

--- a/packages/openui/README.md
+++ b/packages/openui/README.md
@@ -18,7 +18,11 @@ built from components you registered. This package provides:
 - **`ui.*` until-predicates** (`ui.submitted`, `ui.interacted`, `ui.toAssistant`)
   for interaction loops built from plain composition.
 - The transport at the **`./server`** subpath — `serveOpenUi()`, a web-standard
-  fetch handler that speaks the OpenUI protocol over an `AgentHarness`.
+  fetch handler that speaks the OpenUI protocol over an `AgentHarness`. Prompt
+  streams are serialized per harness/thread (`409` while active), event posts
+  return `{ accepted, seq, version }`, and snapshots use thread-keyed state.
+- Client events may carry `clientId`; sequence watermarks are tracked per client.
+  `set` events can only update declared `$var`s and payloads are capped at 16 KiB.
 
 It depends only on [`@noetic-tools/context`](https://www.npmjs.com/package/@noetic-tools/context)
 and [`@noetic-tools/types`](https://www.npmjs.com/package/@noetic-tools/types) —

--- a/packages/openui/src/lang/parser.ts
+++ b/packages/openui/src/lang/parser.ts
@@ -26,6 +26,8 @@ interface ScannerState {
   inString: boolean;
   escaped: boolean;
   line: number;
+  /** Physical line the buffered statement STARTED on (for diagnostics). */
+  statementStartLine: number;
 }
 
 function freshScannerState(): ScannerState {
@@ -34,13 +36,36 @@ function freshScannerState(): ScannerState {
     depth: 0,
     inString: false,
     escaped: false,
-    line: 0,
+    line: 1,
+    statementStartLine: 1,
   };
 }
 
 /**
+ * Whether a buffered line can possibly become an assignment statement.
+ * Prose lines (no `=`-headed assignment shape, no fence/comment) can never
+ * complete, so bracket/string state inside them must not swallow newlines.
+ */
+const ASSIGNMENT_HEAD_RE = /^\$?[A-Za-z_][A-Za-z0-9_]*\s*=/;
+
+function bufferLooksLikeStatement(buffer: string): boolean {
+  const trimmed = buffer.trimStart();
+  return (
+    trimmed.length === 0 ||
+    ASSIGNMENT_HEAD_RE.test(trimmed) ||
+    trimmed.startsWith(FENCE_PREFIX) ||
+    COMMENT_PREFIXES.some((p) => trimmed.startsWith(p))
+  );
+}
+
+/**
  * Consume raw text, returning each completed top-level statement line.
- * Newlines inside brackets or strings do not terminate a statement.
+ * Newlines inside brackets or strings do not terminate a statement — but only
+ * when the buffer is assignment-shaped. A stray `(` or `"` in a PROSE line
+ * would otherwise leave depth/string state pinned open and silently swallow
+ * every subsequent newline into one never-completing mega-statement (zero
+ * streamed statements for the rest of the turn). Tolerance of model
+ * imperfection is the design goal; prose must flush per line.
  */
 function scanStatements(
   state: ScannerState,
@@ -54,9 +79,13 @@ function scanStatements(
     line: number;
   }> = [];
   for (const ch of text) {
-    if (ch === '\n' && state.depth <= 0 && !state.inString) {
-      flushStatement(state, completed);
-      continue;
+    if (ch === '\n') {
+      state.line += 1;
+      const continuing = state.depth > 0 || state.inString;
+      if (!continuing || !bufferLooksLikeStatement(state.buffer)) {
+        flushStatement(state, completed);
+        continue;
+      }
     }
     state.buffer += ch;
     if (state.inString) {
@@ -91,18 +120,19 @@ function flushStatement(
     line: number;
   }>,
 ): void {
-  state.line += 1;
   const source = state.buffer.trim();
+  const line = state.statementStartLine;
   state.buffer = '';
   state.depth = 0;
   state.inString = false;
   state.escaped = false;
+  state.statementStartLine = state.line;
   if (source.length === 0) {
     return;
   }
   out.push({
     source,
-    line: state.line,
+    line,
   });
 }
 

--- a/packages/openui/src/layer/surface.ts
+++ b/packages/openui/src/layer/surface.ts
@@ -59,8 +59,17 @@ export const UiEventSchema = z.object({
   /** The statement ref (or `$var` name for `set`) the event targets. */
   ref: z.string(),
   payload: z.unknown().optional(),
-  /** Client-assigned monotonic sequence — dedupe/ordering across reconnects. */
+  /**
+   * Client-assigned monotonic sequence — dedupe/ordering across reconnects.
+   * Scoped to `clientId` when present: each client counts independently.
+   */
   seq: z.number().int().nonnegative(),
+  /**
+   * Stable identifier for the emitting client (a tab, a device). Dedupe
+   * watermarks are kept per client, so two clients each starting at seq 0
+   * don't shadow each other. Omitted ⇒ the shared legacy watermark.
+   */
+  clientId: z.string().min(1).max(128).optional(),
   /** Document version the client rendered against when the event fired. */
   version: z.number().int().nonnegative().optional(),
 });
@@ -139,8 +148,13 @@ export interface OpenUiSurfaceState {
   interactions: OpenUiInteraction[];
   /** Monotonic version — every mutation (agent render or client event) bumps it. */
   version: number;
-  /** Highest client event seq applied — dedupe/ordering on reconnect. */
+  /** Highest id-less client event seq applied — legacy shared watermark. */
   appliedEventSeq: number;
+  /**
+   * Per-client seq watermarks (`clientId → highest applied seq`). Bounded to
+   * `MAX_CLIENT_WATERMARKS` most-recently-active clients.
+   */
+  clientEventSeqs?: Record<string, number>;
 }
 
 function emptyState(dialect: string): OpenUiSurfaceState {
@@ -155,12 +169,67 @@ function emptyState(dialect: string): OpenUiSurfaceState {
 
 /** Newest interactions kept on the durable state. */
 const MAX_INTERACTIONS = 100;
+/** Most-recently-active client watermarks kept on the durable state. */
+const MAX_CLIENT_WATERMARKS = 32;
+/**
+ * Largest accepted `set` payload, in JSON bytes. `vars` round-trips through
+ * every checkpoint and every recall render — an unbounded client payload is
+ * a durable-state and prompt-size hazard.
+ */
+const MAX_SET_PAYLOAD_BYTES = 16 * 1024;
 
 function trimInteractions(interactions: OpenUiInteraction[]): OpenUiInteraction[] {
   if (interactions.length <= MAX_INTERACTIONS) {
     return interactions;
   }
   return interactions.slice(interactions.length - MAX_INTERACTIONS);
+}
+
+/**
+ * Insert/refresh one client watermark, evicting the stalest entries past the
+ * cap. Re-insertion order approximates recency (object key order).
+ */
+function bumpClientWatermark(
+  watermarks: Record<string, number> | undefined,
+  clientId: string,
+  seq: number,
+): Record<string, number> {
+  const entries = Object.entries(watermarks ?? {}).filter(([id]) => id !== clientId);
+  entries.push([
+    clientId,
+    seq,
+  ]);
+  const kept =
+    entries.length <= MAX_CLIENT_WATERMARKS
+      ? entries
+      : entries.slice(entries.length - MAX_CLIENT_WATERMARKS);
+  return Object.fromEntries(kept);
+}
+
+/** The dedupe watermark applicable to one event. */
+function watermarkFor(state: OpenUiSurfaceState, event: UiEvent): number {
+  if (event.clientId !== undefined) {
+    return state.clientEventSeqs?.[event.clientId] ?? -1;
+  }
+  return state.appliedEventSeq;
+}
+
+/** Whether a `set` targets a `$var` the current document actually declares. */
+function isDeclaredStateVar(state: OpenUiSurfaceState, ref: string): boolean {
+  const key = ref.startsWith('$') ? ref : `$${ref}`;
+  return state.document.assignments[key] !== undefined;
+}
+
+function withinPayloadCap(payload: unknown): boolean {
+  if (payload === undefined) {
+    return true;
+  }
+  try {
+    const json = JSON.stringify(payload);
+    return json === undefined || new TextEncoder().encode(json).byteLength <= MAX_SET_PAYLOAD_BYTES;
+  } catch {
+    return false;
+  }
 }
 
 //#endregion
@@ -293,14 +362,19 @@ export const OPENUI_SURFACE_LAYER_ID = 'openui-surface';
 
 /**
  * The surface layer plus a live read handle for loop predicates (`Until`
- * receives only a `Snapshot`, so predicates close over the layer instance).
- * The mirror tracks the most recent state any hook observed — per-execution
- * best effort; create one surface per harness when executions run in parallel.
+ * receives only a `Snapshot`, so predicates close over the layer instance)
+ * and transport snapshots. The mirror is keyed by THREAD: one layer instance
+ * on a multi-thread harness keeps an independent mirror per thread, so
+ * `readState(threadId)` never serves one thread's surface as another's.
  * @public
  */
 export interface OpenUiSurfaceLayer extends ContextLayer<OpenUiSurfaceState> {
-  /** Latest state observed by any hook of this layer instance. */
-  readState(): OpenUiSurfaceState | undefined;
+  /**
+   * Latest state observed by any hook of this layer instance for `threadId`.
+   * Omitting the thread returns the most recently ACTIVE thread's state —
+   * correct for single-thread harnesses, ambiguous otherwise.
+   */
+  readState(threadId?: string): OpenUiSurfaceState | undefined;
 }
 
 function applyEvents(
@@ -316,21 +390,48 @@ function applyEvents(
       kept.push(item);
       continue;
     }
-    if (event.seq <= next.appliedEventSeq) {
+    if (event.seq <= watermarkFor(next, event)) {
       continue; // duplicate delivery (reconnect replay) — already applied
     }
+    const advanceWatermarks = (
+      s: OpenUiSurfaceState,
+    ): Pick<OpenUiSurfaceState, 'appliedEventSeq' | 'clientEventSeqs'> =>
+      event.clientId !== undefined
+        ? {
+            appliedEventSeq: s.appliedEventSeq,
+            clientEventSeqs: bumpClientWatermark(s.clientEventSeqs, event.clientId, event.seq),
+          }
+        : {
+            appliedEventSeq: event.seq,
+            clientEventSeqs: s.clientEventSeqs,
+          };
     const stale = event.version !== undefined && event.version < next.version;
     applied = true;
     if (event.kind === UiEventKind.Set) {
-      // Keystroke-grade updates mirror into vars but never reach the item log.
+      /* Two-way-binding updates only mirror into vars when the target is a
+       * `$var` the document actually declares and the payload is bounded —
+       * `vars` rides every checkpoint and recall render, so an arbitrary
+       * client must not be able to grow it without limit. Rejected sets
+       * still advance the watermark (the event was seen, just refused). */
+      const accepted = isDeclaredStateVar(next, event.ref) && withinPayloadCap(event.payload);
+      if (!accepted) {
+        params.ctx.trace.addEvent('openui.set_rejected', {
+          ref: event.ref,
+          reason: isDeclaredStateVar(next, event.ref) ? 'payload too large' : 'unknown state var',
+        });
+      }
       next = {
         ...next,
-        vars: {
-          ...next.vars,
-          [event.ref]: event.payload,
-        },
-        version: next.version + 1,
-        appliedEventSeq: event.seq,
+        ...(accepted
+          ? {
+              vars: {
+                ...next.vars,
+                [event.ref]: event.payload,
+              },
+              version: next.version + 1,
+            }
+          : {}),
+        ...advanceWatermarks(next),
       };
       continue;
     }
@@ -351,7 +452,7 @@ function applyEvents(
         },
       ]),
       version: next.version + 1,
-      appliedEventSeq: event.seq,
+      ...advanceWatermarks(next),
     };
     kept.push(item);
   }
@@ -419,17 +520,22 @@ function foldModelRender(
  */
 export function openUiSurface(config: OpenUiSurfaceConfig): OpenUiSurfaceLayer {
   const dialect = config.library.dialect;
-  let live: OpenUiSurfaceState | undefined;
-  const observe = (state: OpenUiSurfaceState): OpenUiSurfaceState => {
-    live = state;
-    return state;
-  };
+  /** Per-thread mirrors + the last thread any hook touched (single-thread convenience). */
+  const liveByThread = new Map<string, OpenUiSurfaceState>();
+  let lastThreadId: string | undefined;
+  const observeFor =
+    (threadId: string) =>
+    (state: OpenUiSurfaceState): OpenUiSurfaceState => {
+      liveByThread.set(threadId, state);
+      lastThreadId = threadId;
+      return state;
+    };
 
   const hooks: ContextLayerHooks<OpenUiSurfaceState> = {
-    async init({ storage }) {
+    async init({ storage, ctx }) {
       const saved = await storage.get<OpenUiSurfaceState>('state');
       return {
-        state: observe(saved ?? emptyState(dialect)),
+        state: observeFor(ctx.threadId)(saved ?? emptyState(dialect)),
       };
     },
 
@@ -437,7 +543,7 @@ export function openUiSurface(config: OpenUiSurfaceConfig): OpenUiSurfaceLayer {
       const state = params.state ?? emptyState(dialect);
       const result = applyEvents(state, params);
       if (result.state) {
-        observe(result.state);
+        observeFor(params.ctx.threadId)(result.state);
       }
       return result;
     },
@@ -465,19 +571,19 @@ export function openUiSurface(config: OpenUiSurfaceConfig): OpenUiSurfaceLayer {
       const state = params.state ?? emptyState(dialect);
       const result = foldModelRender(state, params, config.library);
       if (result.state) {
-        observe(result.state);
+        observeFor(params.ctx.threadId)(result.state);
       }
       return result;
     },
 
-    async store({ state }) {
+    async store({ state, ctx }) {
       // Mutations happen in onItemAppend/afterModelCall; returning the state
       // here keeps the runtime's durable write-through mirror current.
       if (!state) {
         return undefined;
       }
       return {
-        state: observe(state),
+        state: observeFor(ctx.threadId)(state),
       };
     },
 
@@ -502,16 +608,16 @@ export function openUiSurface(config: OpenUiSurfaceConfig): OpenUiSurfaceLayer {
         ]),
       };
       return {
-        parentState: observe(merged),
+        parentState: merged,
       };
     },
 
-    async onComplete({ state }) {
+    async onComplete({ state, ctx }) {
       if (!state) {
         return undefined;
       }
       return {
-        state: observe(state),
+        state: observeFor(ctx.threadId)(state),
       };
     },
   };
@@ -552,7 +658,10 @@ export function openUiSurface(config: OpenUiSurfaceConfig): OpenUiSurfaceLayer {
       },
     },
     hooks,
-    readState: () => live,
+    readState: (threadId?: string) => {
+      const key = threadId ?? lastThreadId;
+      return key === undefined ? undefined : liveByThread.get(key);
+    },
   };
 }
 

--- a/packages/openui/src/server/serve.ts
+++ b/packages/openui/src/server/serve.ts
@@ -41,6 +41,8 @@ export interface OpenUiRequestBody {
 
 //#region Handler
 
+const activePromptStreams = new WeakMap<object, Set<string>>();
+
 const SSE_HEADERS: Record<string, string> = {
   'content-type': 'text/event-stream',
   'cache-control': 'no-cache',
@@ -57,37 +59,71 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
-function sseStream(
-  agentName: string,
-  first: OpenUiServerMessage,
-  events: AsyncIterable<StreamEvent>,
-): Response {
+interface SseStreamOptions {
+  agentName: string;
+  first: OpenUiServerMessage;
+  events: AsyncIterable<StreamEvent>;
+  /** Runs once the pump ends — normal completion, error, OR client disconnect. */
+  onFinished?: () => void;
+}
+
+function sseStream({ agentName, first, events, onFinished }: SseStreamOptions): Response {
   const encoder = new TextEncoder();
+  /* `cancel()` fires when the client disconnects; without it the pump loop
+   * kept iterating the broadcaster into a dead controller until `done` —
+   * enqueue on a cancelled stream throws, abandoning the iterator without
+   * return(), and long turns pumped events to nobody. */
+  let cancelled = false;
+  let iterator: AsyncIterator<StreamEvent> | undefined;
   const body = new ReadableStream<Uint8Array>({
     async start(controller) {
-      controller.enqueue(encoder.encode(encodeSseFrame(first)));
+      const send = (message: OpenUiServerMessage): boolean => {
+        if (cancelled) {
+          return false;
+        }
+        try {
+          controller.enqueue(encoder.encode(encodeSseFrame(message)));
+          return true;
+        } catch {
+          cancelled = true;
+          return false;
+        }
+      };
+      send(first);
       try {
-        for await (const event of events) {
-          const message = translateStreamEvent(event, agentName);
+        iterator = events[Symbol.asyncIterator]();
+        for (;;) {
+          const next = await iterator.next();
+          if (next.done || cancelled) {
+            break;
+          }
+          const message = translateStreamEvent(next.value, agentName);
           if (message === null) {
             continue;
           }
-          controller.enqueue(encoder.encode(encodeSseFrame(message)));
-          if (message.type === 'done') {
+          if (!send(message) || message.type === 'done') {
             break;
           }
         }
       } catch (e) {
-        controller.enqueue(
-          encoder.encode(
-            encodeSseFrame({
-              type: 'error',
-              message: e instanceof Error ? e.message : String(e),
-            }),
-          ),
-        );
+        send({
+          type: 'error',
+          message: e instanceof Error ? e.message : String(e),
+        });
+      } finally {
+        onFinished?.();
+        await iterator?.return?.().catch(() => undefined);
       }
-      controller.close();
+      if (!cancelled) {
+        try {
+          controller.close();
+        } catch {
+          // already closed by cancellation
+        }
+      }
+    },
+    cancel() {
+      cancelled = true;
     },
   });
   return new Response(body, {
@@ -104,25 +140,32 @@ export function serveOpenUi(
   options: ServeOpenUiOptions,
 ): (request: OpenUiRequest) => Promise<Response> {
   const agentName = harness.config.name;
-  const scope = options.threadId
+  const threadId = options.threadId;
+  const scope = threadId
     ? {
-        threadId: options.threadId,
+        threadId,
       }
     : undefined;
+  /* One prompt stream at a time per harness + thread. Multiple handlers can
+   * wrap the same harness, so the lock must not be closure-local. */
+  const promptKey = threadId ?? '__default__';
+  let activePrompts = activePromptStreams.get(harness);
+  if (!activePrompts) {
+    activePrompts = new Set();
+    activePromptStreams.set(harness, activePrompts);
+  }
+
+  const emptySnapshot: OpenUiServerMessage = {
+    type: 'snapshot',
+    source: '',
+    vars: {},
+    version: 0,
+  };
 
   return async (request: OpenUiRequest): Promise<Response> => {
     if (request.method === 'GET') {
-      const state = options.surface.readState();
-      return jsonResponse(
-        state
-          ? snapshotMessage(state)
-          : {
-              type: 'snapshot',
-              source: '',
-              vars: {},
-              version: 0,
-            },
-      );
+      const state = options.surface.readState(threadId);
+      return jsonResponse(state ? snapshotMessage(state) : emptySnapshot);
     }
 
     if (request.method !== 'POST') {
@@ -147,9 +190,15 @@ export function serveOpenUi(
         );
       }
       await harness.execute(createUiEventItem(parsed.data), scope);
+      // Echo the seq + the version the client can poll against (GET returns
+      // the authoritative surface). The event applies asynchronously, so the
+      // version here is pre-application — a strictly-greater version on the
+      // next GET confirms the event landed.
       return jsonResponse(
         {
           accepted: true,
+          seq: parsed.data.seq,
+          version: options.surface.readState(threadId)?.version ?? 0,
         },
         202,
       );
@@ -164,17 +213,32 @@ export function serveOpenUi(
       );
     }
 
-    const state = options.surface.readState();
-    const first: OpenUiServerMessage = state
-      ? snapshotMessage(state)
-      : {
-          type: 'snapshot',
-          source: '',
-          vars: {},
-          version: 0,
-        };
-    await harness.execute(body.prompt, scope);
-    return sseStream(agentName, first, harness.getFullStream(scope));
+    if (activePrompts.has(promptKey)) {
+      return jsonResponse(
+        {
+          error: 'a prompt turn is already streaming on this thread; retry when it completes',
+        },
+        409,
+      );
+    }
+    activePrompts.add(promptKey);
+
+    const state = options.surface.readState(threadId);
+    const first: OpenUiServerMessage = state ? snapshotMessage(state) : emptySnapshot;
+    try {
+      await harness.execute(body.prompt, scope);
+    } catch (e) {
+      activePrompts.delete(promptKey);
+      throw e;
+    }
+    return sseStream({
+      agentName,
+      first,
+      events: harness.getFullStream(scope),
+      onFinished: () => {
+        activePrompts.delete(promptKey);
+      },
+    });
   };
 }
 

--- a/packages/openui/test/lang.test.ts
+++ b/packages/openui/test/lang.test.ts
@@ -166,3 +166,57 @@ describe('serializeDocument / mergeDocument', () => {
     expect(a.expr.args[0].value).toBe('2');
   });
 });
+
+describe('prose-safe statement scanning', () => {
+  test('a stray open bracket in PROSE does not swallow subsequent statements', () => {
+    const parser = new OpenUiLangParser();
+    // The prose line pins depth open; the old scanner would swallow every
+    // following newline into one never-completing mega-statement.
+    const completed = [
+      ...parser.push('Here is your dashboard (with charts):\n'),
+      ...parser.push('root = Card("Sales")\n'),
+      ...parser.push('$tab = "a"\n'),
+    ];
+    expect(completed.map((a) => a.ref)).toEqual([
+      'root',
+      '$tab',
+    ]);
+    const doc = parser.end();
+    expect(doc.root).toBe('root');
+    // The prose line surfaces as a diagnostic, not a black hole.
+    expect(doc.diagnostics.length).toBe(1);
+  });
+
+  test('a stray quote in PROSE does not pin the string state open', () => {
+    const parser = new OpenUiLangParser();
+    const completed = [
+      ...parser.push('Rendering "sales" view now\n'),
+      ...parser.push('root = Text("hi")\n'),
+    ];
+    expect(completed.map((a) => a.ref)).toEqual([
+      'root',
+    ]);
+  });
+
+  test('assignment-shaped buffers still continue across newlines', () => {
+    const parser = new OpenUiLangParser();
+    const completed = [
+      ...parser.push('root = Stack([\n  Text("a"),\n  Text("b")\n])\n'),
+    ];
+    expect(completed.map((a) => a.ref)).toEqual([
+      'root',
+    ]);
+    expect(parser.end().root).toBe('root');
+  });
+
+  test('diagnostics report the statement start line, not the flush line', () => {
+    const doc = parseDocument(
+      [
+        'root = Card("ok")',
+        '',
+        'this is prose on line 3',
+      ].join('\n'),
+    );
+    expect(doc.diagnostics[0]?.line).toBe(3);
+  });
+});

--- a/packages/openui/test/server.test.ts
+++ b/packages/openui/test/server.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { AgentHarnessContract, Item, StreamEvent } from '@noetic-tools/types';
 import { frameworkCast } from '@noetic-tools/types';
+import { z } from 'zod';
 import { openUiSurface } from '../src';
 import type { OpenUiRequest } from '../src/server';
 import {
@@ -14,6 +15,13 @@ import {
 import { makeExecCtx, makeStorage, testLibrary } from './_helpers';
 
 const AGENT = 'agent';
+
+/** The 202 echo body shape a POST {event} returns. */
+const EventEchoSchema = z.object({
+  accepted: z.boolean(),
+  seq: z.number(),
+  version: z.number(),
+});
 
 function sdk(type: string, data: Record<string, unknown> = {}): StreamEvent {
   return {
@@ -339,3 +347,178 @@ describe('serveOpenUi', () => {
 });
 
 //#endregion
+
+describe('serveOpenUi hardening', () => {
+  test('concurrent prompt POSTs on one thread get 409 until the stream finishes', async () => {
+    const surface = await initSurface();
+    // Gate the event stream so the turn stays "in flight" until we release it.
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const harness = makeFakeHarness([]);
+    const gated = frameworkCast<AgentHarnessContract & FakeHarness>({
+      ...harness,
+      async *getFullStream() {
+        await gate;
+        yield framework('turn_completed', {
+          turnId: 't1',
+        });
+      },
+    });
+    const handler = serveOpenUi(gated, {
+      surface,
+    });
+    const first = await handler(
+      req('POST', {
+        prompt: 'render something',
+      }),
+    );
+    expect(first.status).toBe(200);
+    // Stream still open — a second prompt must be rejected, not interleaved.
+    const second = await handler(
+      req('POST', {
+        prompt: 'another prompt',
+      }),
+    );
+    expect(second.status).toBe(409);
+    // Completing the turn releases the slot.
+    release?.();
+    await drain(first);
+    const third = await handler(
+      req('POST', {
+        prompt: 'after done',
+      }),
+    );
+    expect(third.status).toBe(200);
+    release?.();
+    await drain(third);
+  });
+
+  test('separate handlers share the prompt lock for one harness and thread', async () => {
+    const surface = await initSurface();
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const harness = frameworkCast<AgentHarnessContract & FakeHarness>({
+      ...makeFakeHarness([]),
+      async *getFullStream() {
+        await gate;
+        yield framework('turn_completed', {
+          turnId: 't1',
+        });
+      },
+    });
+    const firstHandler = serveOpenUi(harness, {
+      surface,
+      threadId: 'shared',
+    });
+    const secondHandler = serveOpenUi(harness, {
+      surface,
+      threadId: 'shared',
+    });
+    const first = await firstHandler(
+      req('POST', {
+        prompt: 'first',
+      }),
+    );
+    expect(
+      (
+        await secondHandler(
+          req('POST', {
+            prompt: 'second',
+          }),
+        )
+      ).status,
+    ).toBe(409);
+    release?.();
+    await drain(first);
+  });
+
+  test('UI-event POSTs are never blocked by an active stream and echo seq+version', async () => {
+    const surface = await initSurface();
+    const harness = makeFakeHarness([
+      framework('turn_completed', {
+        turnId: 't1',
+      }),
+    ]);
+    const handler = serveOpenUi(harness, {
+      surface,
+    });
+    const stream = await handler(
+      req('POST', {
+        prompt: 'render',
+      }),
+    );
+    const eventRes = await handler(
+      req('POST', {
+        event: {
+          kind: 'submit',
+          ref: 'form',
+          seq: 5,
+          clientId: 'tab-a',
+        },
+      }),
+    );
+    expect(eventRes.status).toBe(202);
+    const body = EventEchoSchema.parse(await eventRes.json());
+    expect(body.accepted).toBe(true);
+    expect(body.seq).toBe(5);
+    expect(typeof body.version).toBe('number');
+    await drain(stream);
+  });
+
+  test('client disconnect (stream cancel) releases the prompt slot', async () => {
+    const surface = await initSurface();
+    // No turn_completed: the stream would pump forever without cancellation.
+    const handler = serveOpenUi(makeFakeHarness([]), {
+      surface,
+    });
+    const res = await handler(
+      req('POST', {
+        prompt: 'long turn',
+      }),
+    );
+    expect(res.status).toBe(200);
+    // Simulate the client going away.
+    await res.body?.cancel();
+    // The finished-hook must release the slot even though `done` never came.
+    const retry = await handler(
+      req('POST', {
+        prompt: 'after disconnect',
+      }),
+    );
+    expect(retry.status).toBe(200);
+    await drain(retry);
+  });
+
+  test('a failed execute() releases the prompt slot instead of deadlocking the handler', async () => {
+    const surface = await initSurface();
+    const harness = makeFakeHarness([]);
+    const failing = frameworkCast<AgentHarnessContract & FakeHarness>({
+      ...harness,
+      async execute() {
+        throw new Error('execute blew up');
+      },
+    });
+    const handler = serveOpenUi(failing, {
+      surface,
+    });
+    await expect(
+      handler(
+        req('POST', {
+          prompt: 'boom',
+        }),
+      ),
+    ).rejects.toThrow('execute blew up');
+    // Slot released — a retry reaches execute again (and fails again, not 409).
+    await expect(
+      handler(
+        req('POST', {
+          prompt: 'retry',
+        }),
+      ),
+    ).rejects.toThrow('execute blew up');
+  });
+});

--- a/packages/openui/test/surface.test.ts
+++ b/packages/openui/test/surface.test.ts
@@ -118,6 +118,14 @@ describe('afterModelCall folding', () => {
   });
 });
 
+/** Narrow an optional hook-result state without casting. */
+function expectState(state: OpenUiSurfaceState | undefined): OpenUiSurfaceState {
+  if (!state) {
+    throw new Error('expected state');
+  }
+  return state;
+}
+
 describe('onItemAppend ui-event reduction', () => {
   async function applyItems(state: OpenUiSurfaceState, items: Item[], surface = makeSurface()) {
     const onItemAppend = surface.hooks.onItemAppend;
@@ -132,9 +140,12 @@ describe('onItemAppend ui-event reduction', () => {
     });
   }
 
-  test('set events mirror into vars and are dropped from the item pipeline', async () => {
-    const { state } = await initState();
-    const result = await applyItems(state, [
+  test('set events for DECLARED $vars mirror into vars and drop from the pipeline', async () => {
+    const { surface, state } = await initState();
+    // Declare $tab by folding a render first — sets are only accepted for
+    // state vars the document actually declares.
+    const folded = await foldRender(surface, state);
+    const result = await applyItems(expectState(folded.state), [
       createUiEventItem({
         kind: 'set',
         ref: 'tab',
@@ -144,9 +155,145 @@ describe('onItemAppend ui-event reduction', () => {
     ]);
     expect(result.items).toEqual([]);
     expect(result.state?.vars.tab).toBe('b');
-    expect(result.state?.version).toBe(1);
+    expect(result.state?.version).toBe(2); // fold bumped to 1, set to 2
     expect(result.rerender).toBe(true);
     expect(result.timing).toBe('immediate');
+  });
+
+  test('set events for UNDECLARED vars are rejected but still advance the watermark', async () => {
+    const { state } = await initState(); // empty document — nothing declared
+    const ctx = makeExecCtx();
+    const onItemAppend = makeSurface().hooks.onItemAppend;
+    if (!onItemAppend) {
+      throw new Error('surface must define onItemAppend');
+    }
+    const result = await onItemAppend({
+      items: [
+        createUiEventItem({
+          kind: 'set',
+          ref: 'ghost',
+          payload: 'x',
+          seq: 0,
+        }),
+      ],
+      log: makeItemLog(),
+      ctx,
+      state,
+    });
+    expect(result.state?.vars.ghost).toBeUndefined();
+    expect(result.state?.version).toBe(0); // rejected sets don't bump
+    expect(result.state?.appliedEventSeq).toBe(0); // but the event was consumed
+    expect(
+      ctx.traceEvents.some(
+        (e) => e.name === 'openui.set_rejected' && e.attributes?.reason === 'unknown state var',
+      ),
+    ).toBe(true);
+  });
+
+  test('oversized set payloads are rejected with a trace', async () => {
+    const { surface, state } = await initState();
+    const folded = await foldRender(surface, state);
+    const ctx = makeExecCtx();
+    const onItemAppend = surface.hooks.onItemAppend;
+    if (!onItemAppend) {
+      throw new Error('surface must define onItemAppend');
+    }
+    const result = await onItemAppend({
+      items: [
+        createUiEventItem({
+          kind: 'set',
+          ref: 'tab',
+          payload: 'x'.repeat(20 * 1024),
+          seq: 0,
+        }),
+      ],
+      log: makeItemLog(),
+      ctx,
+      state: expectState(folded.state),
+    });
+    expect(result.state?.vars.tab).toBeUndefined();
+    expect(
+      ctx.traceEvents.some(
+        (e) => e.name === 'openui.set_rejected' && e.attributes?.reason === 'payload too large',
+      ),
+    ).toBe(true);
+  });
+
+  test('the payload cap measures UTF-8 bytes rather than JavaScript characters', async () => {
+    const { surface, state } = await initState();
+    const folded = await foldRender(surface, state);
+    const result = await applyItems(expectState(folded.state), [
+      createUiEventItem({
+        kind: 'set',
+        ref: 'tab',
+        payload: '🙂'.repeat(5_000),
+        seq: 0,
+      }),
+    ]);
+    expect(result.state?.vars.tab).toBeUndefined();
+  });
+
+  test('per-client watermarks: two clients starting at seq 0 do not shadow each other', async () => {
+    const { surface, state } = await initState();
+    const folded = await foldRender(surface, state);
+    const afterA = await applyItems(expectState(folded.state), [
+      createUiEventItem({
+        kind: 'submit',
+        ref: 'form',
+        seq: 0,
+        clientId: 'tab-a',
+      }),
+    ]);
+    const afterB = await applyItems(expectState(afterA.state), [
+      createUiEventItem({
+        kind: 'submit',
+        ref: 'form',
+        seq: 0,
+        clientId: 'tab-b',
+      }),
+    ]);
+    // Both applied — a GLOBAL watermark would drop B's seq-0 as a duplicate.
+    expect(afterB.state?.interactions).toHaveLength(2);
+    // Replays still dedupe per client.
+    const replay = await applyItems(expectState(afterB.state), [
+      createUiEventItem({
+        kind: 'submit',
+        ref: 'form',
+        seq: 0,
+        clientId: 'tab-a',
+      }),
+    ]);
+    expect(replay.state?.interactions).toHaveLength(2);
+    // ...and a NEW seq from the same client still applies.
+    const fresh = await applyItems(expectState(replay.state), [
+      createUiEventItem({
+        kind: 'submit',
+        ref: 'form',
+        seq: 1,
+        clientId: 'tab-a',
+      }),
+    ]);
+    expect(fresh.state?.interactions).toHaveLength(3);
+  });
+
+  test('client watermarks are bounded: evicted clients fall back to accepting replays', async () => {
+    const { state } = await initState();
+    let next = state;
+    // 33 distinct clients (> MAX_CLIENT_WATERMARKS of 32) evict the first.
+    for (let i = 0; i < 33; i += 1) {
+      const result = await applyItems(next, [
+        createUiEventItem({
+          kind: 'submit',
+          ref: 'f',
+          seq: 0,
+          clientId: `client-${i}`,
+        }),
+      ]);
+      next = expectState(result.state);
+    }
+    expect(Object.keys(next.clientEventSeqs ?? {})).toHaveLength(32);
+    expect(next.clientEventSeqs?.['client-0']).toBeUndefined();
+    expect(next.clientEventSeqs?.['client-32']).toBe(0);
   });
 
   test('submit events append interactions and stay in the pipeline', async () => {
@@ -478,5 +625,61 @@ describe('ui predicates', () => {
     expect(ui.interacted(surface)(snap).stop).toBe(true);
     expect(ui.interacted(surface, 'toAssistant')(snap).stop).toBe(false);
     expect(ui.toAssistant(surface)(snap).stop).toBe(false);
+  });
+});
+
+describe('thread-keyed live mirrors', () => {
+  test("readState(threadId) never serves one thread's surface as another's", async () => {
+    const surface = makeSurface();
+    const ctxA = {
+      ...makeExecCtx(),
+      threadId: 'thread-a',
+    };
+    const ctxB = {
+      ...makeExecCtx(),
+      threadId: 'thread-b',
+    };
+    const init = surface.hooks.init;
+    if (!init) {
+      throw new Error('surface must define init');
+    }
+    const { state: stateA } = await init({
+      storage: makeStorage(),
+      scopeKey: 'thread-a',
+      ctx: ctxA,
+    });
+    const { state: stateB } = await init({
+      storage: makeStorage(),
+      scopeKey: 'thread-b',
+      ctx: ctxB,
+    });
+    // Render on thread A only.
+    const afterModelCall = surface.hooks.afterModelCall;
+    if (!afterModelCall) {
+      throw new Error('surface must define afterModelCall');
+    }
+    await afterModelCall({
+      response: makeResponse(RENDER),
+      ctx: ctxA,
+      state: stateA,
+    });
+    expect(surface.readState('thread-a')?.version).toBe(1);
+    expect(surface.readState('thread-b')?.version).toBe(0);
+    // Omitted thread → most recently ACTIVE thread (single-thread convenience).
+    expect(surface.readState()?.version).toBe(1);
+    // Touch thread B's mirror; the default follows activity.
+    const store = surface.hooks.store;
+    if (!store) {
+      throw new Error('surface must define store');
+    }
+    await store({
+      newItems: [],
+      log: makeItemLog(),
+      response: makeResponse(''),
+      ctx: ctxB,
+      state: stateB,
+    });
+    expect(surface.readState()?.version).toBe(0);
+    expect(surface.readState('thread-a')?.version).toBe(1);
   });
 });

--- a/packages/web/content/docs/framework/generative-ui.mdx
+++ b/packages/web/content/docs/framework/generative-ui.mdx
@@ -87,7 +87,7 @@ const harness = new AgentHarness({
 What each hook buys you:
 
 - **Durable, resumable state** (`init` + `store`, thread scope) — the surface is loaded from and written through to `ScopedStorage`, so a resumed run or a reconnecting client reconstructs the exact UI the user was looking at.
-- **Client events flow back in** (`onItemAppend`) — a transport appends each client interaction as a `ui-event` item; the layer reduces it into `vars`/`interactions`, **drops keystroke noise** from the item log, and requests an immediate re-render so the next turn already reflects it.
+- **Client events flow back in** (`onItemAppend`) — a transport appends each client interaction as a `ui-event` item; the layer reduces it into `vars`/`interactions`, **drops keystroke noise** from the item log, and requests an immediate re-render so the next turn already reflects it. `set` events are validated: only `$var`s the document declares are writable, payloads are capped at 16 KiB, and rejections emit an `openui.set_rejected` trace while still advancing the dedupe watermark. Dedupe is **per client** — events carrying a `clientId` get independent `seq` watermarks (bounded to 32 recent clients), so one client's replay can't drop another's events.
 - **The model sees the UI** (`recall`) — a budget-trimmed `<ui_surface>` block renders the mounted components, current `vars`, and fresh query results.
 - **Cheap history** (`projectHistory`) — superseded OpenUI Lang renders in history collapse to a one-line placeholder; the current surface is already in the recall block.
 - **Server-side validation** (`afterModelCall`) — each render is validated against the library (unknown component, prop mismatch) and repaired or guided before the client renderer ever sees it.
@@ -173,12 +173,12 @@ declare const harness: AgentHarness;
 declare const surface: OpenUiSurfaceLayer;
 
 const handler = serveOpenUi(harness, { surface });
-// POST { prompt } → runs a turn, streams the surface as SSE
-// POST { event }  → ingests a client UI event (202)
+// POST { prompt } → runs a turn, streams the surface as SSE (409 while a stream is active)
+// POST { event }  → ingests a client UI event (202, echoes { accepted, seq, version })
 // GET             → returns the current surface snapshot (reconnect rehydration)
 ```
 
-`serveOpenUi` translates the harness's `response.*` and `openui.*` events into the wire protocol, ingests client interactions as `ui-event` items (carrying the document version they were rendered against, so stale interactions are flagged), and answers a reconnect with a single snapshot instead of replaying the stream. The matching client descriptor is `noeticStreamAdapter()`.
+`serveOpenUi` translates the harness's `response.*` and `openui.*` events into the wire protocol, ingests client interactions as `ui-event` items (carrying the document version they were rendered against, so stale interactions are flagged), and answers a reconnect with a single snapshot instead of replaying the stream. Prompt turns are serialized per harness and thread — a concurrent `POST { prompt }` gets `409` and the client retries after its stream ends — and the SSE pump cleans up on client disconnect. Snapshots read through the surface's thread-keyed live mirror (`readState(threadId)`), so multi-thread harnesses never serve one thread's UI as another's. The matching client descriptor is `noeticStreamAdapter()`.
 
 ## JSON workflow runtime
 

--- a/specs/28-generative-ui.md
+++ b/specs/28-generative-ui.md
@@ -171,8 +171,10 @@ interface OpenUiSurfaceState {
   }>;
   /** Monotonic version — every mutation (agent render or client event) bumps it. */
   version: number;
-  /** Highest client event seq applied — dedupe/ordering on reconnect. */
+  /** Highest id-less client event seq applied — legacy shared watermark. */
   appliedEventSeq: number;
+  /** Per-client seq watermarks (`clientId → highest applied seq`), bounded to the 32 most-recently-active clients. */
+  clientEventSeqs?: Record<string, number>;
 }
 
 function openUiSurface(config: { library: UiLibrary }): ContextLayer<OpenUiSurfaceState>
@@ -199,6 +201,18 @@ function openUiSurface(config: { library: UiLibrary }): ContextLayer<OpenUiSurfa
   `$Set` events update `vars` but are **filtered out of the item pipeline** so
   the item log records semantic interactions, not keystrokes. Requests an
   immediate re-render so the next recall reflects the interaction.
+  - `set` events are only accepted when the target is a `$var` the current
+    document actually declares and the JSON payload is ≤ 16 KiB — `vars`
+    round-trips through every checkpoint and recall render, so an arbitrary
+    client must not grow it without limit. Rejected sets emit an
+    `openui.set_rejected` trace event and still advance the dedupe watermark
+    (the event was seen, just refused).
+  - Dedupe watermarks are **per client**: events may carry a `clientId`
+    (≤ 128 chars), and each client's `seq` counts independently, so two tabs
+    each starting at seq 0 don't shadow each other and one client's replay
+    can't drop another's events. Events without a `clientId` share the legacy
+    `appliedEventSeq` watermark. The per-client map is bounded to the 32
+    most-recently-active clients.
 - `recall`: renders a budget-trimmed `<ui_surface>` block — mounted components,
   current `vars`, filled/submitted forms, fresh query results. The raw document
   stays in state; the View gets a summary (same render-and-trim discipline as
@@ -293,12 +307,18 @@ shapes fail at typecheck, not in the client renderer.
 ```ts
 import { serveOpenUi } from '@noetic-tools/openui/server';
 
-serveOpenUi(harness, { library: lib, port: 3111 });
+serveOpenUi(harness, { surface, threadId: 'ui-thread' });
 ```
 
 - Wraps `harness.execute()` in an HTTP/SSE endpoint speaking the message format
   OpenUI's `<AgentInterface>` expects — the package exports the matching
   client-side `noeticStreamAdapter()` / `noeticMessageFormat` for `fetchLLM`.
+- **Serializes prompt turns per harness and thread**: a second `POST { prompt }` while a
+  stream is active gets `409` (concurrent streams on one thread would share
+  one broadcaster and terminate at whichever turn ends first). `POST { event }`
+  is never blocked. The SSE pump survives client disconnect: `cancel()` stops
+  the pump, guarded enqueues never throw into a dead controller, and the event
+  iterator is `return()`ed so the turn's resources clean up.
 - Translates the harness's `source: 'sdk'` `response.*` events and the
   `openui.*` framework events into OpenUI's stream protocol (progressive
   line delivery, fragment patches).
@@ -306,10 +326,14 @@ serveOpenUi(harness, { library: lib, port: 3111 });
   appends them as `ui-event` items into the running execution, carrying the
   document `version` they were rendered against — the layer detects stale
   interactions (the user clicked a control the agent has since re-rendered
-  away) via `version` / `appliedEventSeq`.
+  away) via `version` / `appliedEventSeq`. The `202` response echoes
+  `{ accepted, seq, version }` so the client can reconcile (a strictly-greater
+  `version` on the next GET confirms the event landed).
 - On reconnect, answers with the layer-state snapshot
   (`{ document, vars, version }` from `getLayerState`) so a client rehydrates
-  from one message instead of replaying the LLM stream.
+  from one message instead of replaying the LLM stream. Snapshots are read
+  through the surface's **thread-keyed** live mirror (`readState(threadId)`),
+  so one thread's surface is never served as another's.
 - Exposes registered tools as the data endpoint OpenUI `Query` / `Mutation`
   bindings call — the same registry the steps use.
 
@@ -378,8 +402,9 @@ a drift-gate test fails CI if either published copy is stale.
 - **Presentation modes.** Tool render functions may grow an options argument
   (`call(args, { mode })`) for condensed-vs-verbose variants; the methods are
   optional and bivariant, so this is additive.
-- **Multiple concurrent clients.** Several renderers projecting one surface,
-  with per-client cursors over `version`.
+- **Multiple concurrent clients.** Several renderers projecting one surface.
+  Per-client event watermarks (`clientId`) and thread-keyed state mirrors are
+  in place; what remains is per-client cursors over `version` for streaming.
 - **Dialect evolution.** OpenUI Lang is versioned (`dialect: 'openui-lang/0.5'`);
   the codec and fragment builder pin the version they emit, and the library
   prompt advertises only feature flags that version supports.


### PR DESCRIPTION
## What

- make the OpenUI scanner tolerate prose containing unmatched brackets or quotes
- validate client `set` events against declared `$var`s and cap JSON payloads at 16 KiB of UTF-8
- track event watermarks per client with bounded durable state
- keep surface mirrors keyed by thread
- serialize prompt streams per harness/thread, reject overlap with `409`, and clean up SSE iterators on disconnect
- echo `{ accepted, seq, version }` for client event ingestion

## Why

A malformed prose line could swallow every later streamed statement. Client events could write arbitrary durable state at unbounded size, and a global sequence watermark let one client suppress another's events. Concurrent prompt streams on one thread also shared a broadcaster and could interleave or terminate incorrectly.

This semantically ports `fork/port/openrouter-fixes` commit `b095d1f5` onto current main while preserving the OpenUI → context/types package boundary.

## Test plan

- [x] `cd packages/openui && bun test` — 65 pass
- [x] `cd packages/openui && bun run typecheck`
- [x] root lint
- [x] `sentrux check .`
- [x] `sentrux gate .`
- [x] adversarial parser, multibyte cap, client watermark, thread mirror, multi-handler lock, disconnect, and failed-execute tests
- [x] separate clean-context Pi reviews; confirmed findings fixed, no remaining code findings

## Behavior changes

- undeclared or oversized client `set` events are rejected and traced
- concurrent prompt requests for the same harness/thread receive `409`
- clients should send a stable `clientId` for independent replay watermarks
