### PR TITLE
feat(core): detect repeated model tool rounds

### DIFF
--- a/.claude/skills/noetic-agent-builder/references/api-reference.md
+++ b/.claude/skills/noetic-agent-builder/references/api-reference.md
@@ -1253,6 +1253,10 @@ const items = await harness.previewRequestItems({ threadId: 'thread-1' });
 
 Every in-flight provider call is guarded by a stream-idle watchdog with a fixed 120-second window. The watchdog re-arms on every SSE event; if the stream goes silent for the full window, the harness emits `{name}:model_call_stalled` and the surrounding turn fails with `turn_aborted { reason: "model stream idle timeout after <N>ms" }`, so a provider that quietly drops the connection surfaces as an error rather than a hang.
 
+### Doom-Loop Guard
+
+The model loop fingerprints every completed tool round — tool calls (name + canonical arguments) paired with the outputs they produced — and after a streak of consecutive byte-identical rounds emits `{name}:doom_loop_detected` and fails the call with `Doom loop detected: N consecutive rounds of identical tool calls and results (...)`, instead of burning all remaining tool rounds on a dead end. A polling loop whose results evolve never trips; a poll with a genuinely constant result (e.g. always `"pending"`) is indistinguishable from a stuck model and will trip — raise the threshold, disable the guard, or have the tool include something that advances in its output. Configure per call via `CallModelRequest.doomLoopIdenticalRounds`: identical rounds beyond the first, default `3` (4th identical round trips), non-positive disables.
+
 ### Harness-wide Tools
 
 `AgentHarnessOpts.tools?: Tool[]` seeds a tool pool merged with tools collected from `agentGraph` into every context's `ctx.unifiedTools`. Dedupe is **name-based, first-wins** — the merge order is `[...stepCollectedTools, ...harnessTools]`, so on a name collision the step-collected instance wins. This is the supported way to provide tools when the workflow graph is fully static and `callModel.tools` is a `(ctx) => ctx.unifiedTools.filter(...)` getter — function-form `step.tools` cannot be walked by `collectAllTools`, so the harness option is the only way to make those tools visible to the pool.

--- a/packages/core/src/harness/model-call.ts
+++ b/packages/core/src/harness/model-call.ts
@@ -34,6 +34,179 @@ import type { MessageQueue, QueuedMessage } from '../runtime/message-queue';
 import { buildItemSchemaRegistry, createToolResultItem } from './model-schema.js';
 
 const MAX_TOOL_ROUNDS = 32;
+/**
+ * Default consecutive identical tool ROUNDS (beyond the first) that trip the
+ * doom-loop guard — a round being "identical" means the same tool calls *and*
+ * the same tool outputs. Override per call via
+ * `CallModelRequest.doomLoopIdenticalRounds`.
+ */
+const DOOM_LOOP_IDENTICAL_ROUNDS = 3;
+
+/**
+ * Resolve the doom-loop threshold for a call. `undefined` keeps the default;
+ * any non-positive value (including `NaN`, which fails the comparison) disables
+ * the guard entirely rather than tripping it on the first round.
+ */
+function resolveDoomLoopThreshold(request: CallModelRequest): number {
+  const configured = request.doomLoopIdenticalRounds;
+  if (configured === undefined) {
+    return DOOM_LOOP_IDENTICAL_ROUNDS;
+  }
+  return configured > 0 ? configured : 0;
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Sort object keys at every depth. Array order is semantic and is preserved. */
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+  if (!isPlainRecord(value)) {
+    return value;
+  }
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value).sort()) {
+    sorted[key] = sortKeysDeep(value[key]);
+  }
+  return sorted;
+}
+
+/** Canonicalize a JSON string (keys sorted at every depth) so cosmetic key-order
+ *  differences don't defeat the doom-loop fingerprint. Used for both tool
+ *  arguments and tool outputs. Falls back to the raw string for non-JSON and
+ *  scalar payloads. */
+function canonicalizeJson(raw: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+  if (!isPlainRecord(parsed) && !Array.isArray(parsed)) {
+    return raw;
+  }
+  return JSON.stringify(sortKeysDeep(parsed));
+}
+
+/** One tool call's request side: name + canonical args. */
+function fingerprintToolCall(call: { name: string; arguments: string }): string {
+  return `${call.name}(${canonicalizeJson(call.arguments)})`;
+}
+
+/** Fingerprint a round's tool calls: name + canonical args, order-insensitive.
+ *  Request side only — this is what the `doom_loop_detected` event reports, since
+ *  folding whole tool outputs into an event payload would bloat it. */
+function fingerprintToolCalls(
+  calls: ReadonlyArray<{
+    name: string;
+    arguments: string;
+  }>,
+): string {
+  return calls.map(fingerprintToolCall).sort().join('|');
+}
+
+/** A single tool result produced by a round, paired with the call it answers. */
+interface ToolRoundOutput {
+  callId: string;
+  output: string;
+}
+
+/**
+ * Full round fingerprint: each call's request side paired with the OUTPUT it
+ * produced, sorted so provider-side call reordering doesn't matter.
+ *
+ * Folding the results in is what keeps legitimate polling loops alive. A
+ * poll-until-ready tool is identical on the request side by construction, so a
+ * request-only fingerprint cannot tell `check_build({id})` → `{progress: 40%}`
+ * from a model stuck re-asking the same dead question. Pairing call with result
+ * means only a round that repeats the same requests *and* byte-identical
+ * results counts toward the streak.
+ */
+function fingerprintRound(
+  calls: ReadonlyArray<{
+    callId: string;
+    name: string;
+    arguments: string;
+  }>,
+  outputs: ReadonlyArray<ToolRoundOutput>,
+): string {
+  const outputByCallId = new Map(
+    outputs.map((o) => [
+      o.callId,
+      o.output,
+    ]),
+  );
+  return calls
+    .map(
+      (fc) =>
+        `${fingerprintToolCall(fc)}=>${canonicalizeJson(outputByCallId.get(fc.callId) ?? '')}`,
+    )
+    .sort()
+    .join('|');
+}
+
+/** Per-`callModel` doom-loop streak state. Never shared across calls. */
+interface DoomLoopState {
+  /** Request+result fingerprint of the last completed round — the streak key. */
+  lastRoundFingerprint: string;
+  /** Request-side-only fingerprint of the same round, for the event payload. */
+  lastCallFingerprint: string;
+  identicalRounds: number;
+  /** Tool names from the most recent round, for the error/event message. */
+  lastToolNames: ReadonlyArray<string>;
+}
+
+/**
+ * Fold a just-completed round into the streak. Takes the round's tool calls and
+ * the outputs they produced, so the streak key covers both sides — the whole
+ * point of the guard's polling tolerance (see `fingerprintRound`).
+ */
+function recordDoomLoopRound(params: {
+  state: DoomLoopState;
+  calls: ReadonlyArray<{
+    callId: string;
+    name: string;
+    arguments: string;
+  }>;
+  outputs: ReadonlyArray<ToolRoundOutput>;
+}): void {
+  const { state } = params;
+  const fingerprint = fingerprintRound(params.calls, params.outputs);
+  state.identicalRounds =
+    fingerprint === state.lastRoundFingerprint ? state.identicalRounds + 1 : 0;
+  state.lastRoundFingerprint = fingerprint;
+  state.lastCallFingerprint = fingerprintToolCalls(params.calls);
+  state.lastToolNames = params.calls.map((fc) => fc.name);
+}
+
+/**
+ * Trip the doom-loop guard when the streak of byte-identical rounds reaches the
+ * threshold. A threshold of `0` disables the guard.
+ */
+function assertNotDoomLooping(params: {
+  state: DoomLoopState;
+  threshold: number;
+  round: number;
+  emitIfAllowed: (eventType: string, data: Record<string, unknown>) => void;
+}): void {
+  const { state } = params;
+  if (params.threshold <= 0 || state.identicalRounds < params.threshold) {
+    return;
+  }
+  const identicalRounds = state.identicalRounds + 1;
+  params.emitIfAllowed('doom_loop_detected', {
+    round: params.round,
+    fingerprint: state.lastCallFingerprint,
+    identicalRounds,
+  });
+  throw new Error(
+    `Doom loop detected: ${identicalRounds} consecutive rounds of identical tool calls and results (${state.lastToolNames.join(', ')}).`,
+  );
+}
+
 const MAX_RECOVERY_CONTINUATIONS = 3;
 const EPHEMERAL_CONTINUE_INPUT = 'continue';
 
@@ -530,8 +703,30 @@ export class AgentHarnessModelCaller {
     let invalidRecoveryContinuations = 0;
     let toolLimitRecoveryContinuations = 0;
     let useEphemeralContinue = false;
+    // Doom-loop guard: fingerprint each completed round as its tool calls (name
+    // + canonical args) PAIRED WITH the outputs they produced. N identical
+    // consecutive rounds means the model is stuck re-asking a question whose
+    // answer never changes; fail fast instead of burning the remaining
+    // MAX_TOOL_ROUNDS on the same dead end. Because results are part of the
+    // fingerprint, a polling loop whose results evolve never trips.
+    // State is per-call, so it never leaks across turns.
+    const doomLoopThreshold = resolveDoomLoopThreshold(request);
+    const doomLoop: DoomLoopState = {
+      lastRoundFingerprint: '',
+      lastCallFingerprint: '',
+      identicalRounds: 0,
+      lastToolNames: [],
+    };
 
     while (!request.signal?.aborted) {
+      // Verdict on the streak accumulated by previously completed rounds. Sits
+      // ahead of the model call so a confirmed dead end costs no further tokens.
+      assertNotDoomLooping({
+        state: doomLoop,
+        threshold: doomLoopThreshold,
+        round,
+        emitIfAllowed: prepared.emitIfAllowed,
+      });
       const recoveryContinuation = useEphemeralContinue;
       useEphemeralContinue = false;
       if (round > 0 && request.ctx && hasSessionQueue(request.ctx)) {
@@ -684,7 +879,7 @@ export class AgentHarnessModelCaller {
       if (functionCalls.length === 0 || !request.tools) {
         break;
       }
-      await this.executeToolRound({
+      const roundOutputs = await this.executeToolRound({
         functionCalls,
         request,
         allItems,
@@ -693,6 +888,15 @@ export class AgentHarnessModelCaller {
         emitIfAllowed: prepared.emitIfAllowed,
         spans,
         modelSpan,
+      });
+      // Fold the round we just finished — requests AND their outputs — into the
+      // doom-loop streak. The results only exist now, which is why the streak
+      // updates here and the verdict is passed at the top of the next iteration,
+      // before another model call is spent.
+      recordDoomLoopRound({
+        state: doomLoop,
+        calls: functionCalls,
+        outputs: roundOutputs,
       });
 
       round += 1;
@@ -864,7 +1068,7 @@ export class AgentHarnessModelCaller {
     emitIfAllowed: (eventType: string, data: Record<string, unknown>) => void;
     spans: CallSpanCollector;
     modelSpan: Span;
-  }): Promise<void> {
+  }): Promise<ToolRoundOutput[]> {
     const { functionCalls, request, allItems, conversationInput, spans, modelSpan } = params;
     params.emitIfAllowed('tool_round_started', {
       round: params.round,
@@ -879,6 +1083,9 @@ export class AgentHarnessModelCaller {
         arguments: fc.arguments,
       });
     }
+    // Returned to the caller so the doom-loop fingerprint can pair each request
+    // with the result it produced — see `fingerprintRound`.
+    const outputs: ToolRoundOutput[] = [];
     for (const fc of functionCalls) {
       if (request.signal?.aborted) {
         break;
@@ -887,18 +1094,21 @@ export class AgentHarnessModelCaller {
         (tool) => tool.name === fc.name || sanitizeToolNameForWire(tool.name) === fc.name,
       );
       spans.recordToolSpan(modelSpan, fc.name, toolForCall?.needsApproval ?? false);
-      await this.executeFunctionCall({
-        fc,
-        request,
-        allItems,
-        conversationInput,
-        emitIfAllowed: params.emitIfAllowed,
-      });
+      outputs.push(
+        await this.executeFunctionCall({
+          fc,
+          request,
+          allItems,
+          conversationInput,
+          emitIfAllowed: params.emitIfAllowed,
+        }),
+      );
     }
     params.emitIfAllowed('tool_round_completed', {
       round: params.round,
       toolCount: functionCalls.length,
     });
+    return outputs;
   }
 
   private async executeFunctionCall(params: {
@@ -912,7 +1122,7 @@ export class AgentHarnessModelCaller {
     allItems: Item[];
     conversationInput: ReturnType<typeof itemsToInput>;
     emitIfAllowed: (eventType: string, data: Record<string, unknown>) => void;
-  }): Promise<void> {
+  }): Promise<ToolRoundOutput> {
     const { fc, request, allItems, conversationInput } = params;
     params.emitIfAllowed('tool_call_started', {
       name: fc.name,
@@ -922,14 +1132,13 @@ export class AgentHarnessModelCaller {
     try {
       parsedArgs = JSON.parse(fc.arguments);
     } catch {
-      this.recordMalformedToolCall({
+      return this.recordMalformedToolCall({
         fc,
         request,
         allItems,
         conversationInput,
         emitIfAllowed: params.emitIfAllowed,
       });
-      return;
     }
     if (!request.tools) {
       throw new Error(
@@ -973,6 +1182,10 @@ export class AgentHarnessModelCaller {
       callId: fc.callId,
       error: false,
     });
+    return {
+      callId: fc.callId,
+      output: toolResult.output,
+    };
   }
 
   private recordMalformedToolCall(params: {
@@ -986,7 +1199,7 @@ export class AgentHarnessModelCaller {
     allItems: Item[];
     conversationInput: ReturnType<typeof itemsToInput>;
     emitIfAllowed: (eventType: string, data: Record<string, unknown>) => void;
-  }): void {
+  }): ToolRoundOutput {
     const { fc, request, allItems, conversationInput } = params;
     const errorOutput = `Error: malformed JSON in tool arguments: ${fc.arguments}`;
     const toolForCall = request.tools?.find(
@@ -1013,6 +1226,10 @@ export class AgentHarnessModelCaller {
       callId: fc.callId,
       error: true,
     });
+    return {
+      callId: fc.callId,
+      output: errorOutput,
+    };
   }
 
   private handleToolRoundLimit(params: {

--- a/packages/core/test/runtime/harness-result.test.ts
+++ b/packages/core/test/runtime/harness-result.test.ts
@@ -115,7 +115,9 @@ function functionCallResponse(callNumber: number): MockModelResponse {
         type: 'function_call',
         callId,
         name: 'noop',
-        arguments: '{}',
+        // Varied per round: this fixture exercises the tool-round LIMIT path;
+        // identical arguments would (correctly) trip the doom-loop guard first.
+        arguments: `{"step":${callNumber}}`,
       },
     ],
     usage: {
@@ -123,6 +125,62 @@ function functionCallResponse(callNumber: number): MockModelResponse {
       outputTokens: 1,
     },
   });
+}
+
+interface PollingClientConfig {
+  toolName: string;
+  /** Sent verbatim on every round — a poll's request side never varies. */
+  toolArgs: string;
+  /** Round index at which the model stops polling and answers. */
+  stopAfterRounds: number;
+}
+
+/**
+ * A model that polls one tool with BYTE-IDENTICAL arguments every round until
+ * the tool reports ready, then answers. This is the exact shape of a legitimate
+ * wait/poll loop: the request side cannot vary, only the result can.
+ */
+class PollingClient {
+  calls = 0;
+  private readonly config: PollingClientConfig;
+
+  constructor(config: PollingClientConfig) {
+    this.config = config;
+  }
+
+  callModel(): {
+    getFullResponsesStream: () => AsyncIterable<unknown>;
+    getResponse: () => Promise<MockModelResponse>;
+  } {
+    const callNumber = this.calls++;
+    const { toolName, toolArgs, stopAfterRounds } = this.config;
+    return {
+      async *getFullResponsesStream() {},
+      getResponse: async () => {
+        if (callNumber >= stopAfterRounds) {
+          return messageResponse(`resp-final-${callNumber}`, 'build is ready');
+        }
+        return frameworkCast<MockModelResponse>({
+          id: `resp-${callNumber}`,
+          status: 'completed',
+          output: [
+            {
+              id: `fc-${callNumber}`,
+              status: 'completed',
+              type: 'function_call',
+              callId: `call_${callNumber}`,
+              name: toolName,
+              arguments: toolArgs,
+            },
+          ],
+          usage: {
+            inputTokens: 1,
+            outputTokens: 1,
+          },
+        });
+      },
+    };
+  }
 }
 
 class ToolLimitRecoveryClient {
@@ -533,6 +591,463 @@ describe('AgentHarness session accessors', () => {
     expect(
       collected.some((item) => item.type === 'function_call_output' && item.callId === 'call-noop'),
     ).toBe(true);
+  });
+
+  it('throws a structured doom-loop error on repeated identical tool rounds', async () => {
+    class StuckClient {
+      calls = 0;
+      callModel(): {
+        getFullResponsesStream: () => AsyncIterable<unknown>;
+        getResponse: () => Promise<MockModelResponse>;
+      } {
+        const callNumber = this.calls++;
+        return {
+          async *getFullResponsesStream() {},
+          getResponse: async () =>
+            frameworkCast<MockModelResponse>({
+              id: `resp-${callNumber}`,
+              status: 'completed',
+              output: [
+                {
+                  id: `fc-${callNumber}`,
+                  status: 'completed',
+                  type: 'function_call',
+                  callId: `call_${callNumber}`,
+                  name: 'noop',
+                  arguments: '{}', // identical every round — a stuck model
+                },
+              ],
+              usage: {
+                inputTokens: 1,
+                outputTokens: 1,
+              },
+            }),
+        };
+      }
+    }
+    const fakeClient = new StuckClient();
+    const noopTool = tool({
+      name: 'noop',
+      description: 'Always returns ok',
+      input: z.object({}),
+      output: z.object({
+        ok: z.boolean(),
+      }),
+      execute: async () => ({
+        ok: true,
+      }),
+    });
+    const harness = new AgentHarness({
+      name: 'test',
+      params: {},
+    });
+    frameworkCast<{
+      client: StuckClient;
+    }>(harness).client = fakeClient;
+    const ctx = harness.createContext();
+
+    await expect(
+      harness.callModel({
+        model: 'test/model',
+        items: [
+          makeMessage('user', 'go'),
+        ],
+        tools: [
+          noopTool,
+        ],
+        ctx,
+      }),
+    ).rejects.toThrow('Doom loop detected');
+    // Guard trips after 4 identical rounds (1 + DOOM_LOOP_IDENTICAL_ROUNDS),
+    // not after the 32-round limit.
+    expect(fakeClient.calls).toBeLessThan(10);
+  });
+
+  it('does not trip the doom-loop guard when only a nested argument value differs', async () => {
+    // The fingerprint canonicalizes arguments by sorting keys at EVERY depth. A
+    // top-level-only key allowlist would collapse `{"filter":{"page":N}}` to
+    // `{"filter":{}}` for all N and abort this healthy run.
+    class NestedArgsClient {
+      calls = 0;
+      callModel(): {
+        getFullResponsesStream: () => AsyncIterable<unknown>;
+        getResponse: () => Promise<MockModelResponse>;
+      } {
+        const callNumber = this.calls++;
+        return {
+          async *getFullResponsesStream() {},
+          getResponse: async () => {
+            if (callNumber >= 6) {
+              return messageResponse(`resp-final-${callNumber}`, 'done');
+            }
+            return frameworkCast<MockModelResponse>({
+              id: `resp-${callNumber}`,
+              status: 'completed',
+              output: [
+                {
+                  id: `fc-${callNumber}`,
+                  status: 'completed',
+                  type: 'function_call',
+                  callId: `call_${callNumber}`,
+                  name: 'search',
+                  arguments: `{"filter":{"page":${callNumber},"kind":"doc"}}`,
+                },
+              ],
+              usage: {
+                inputTokens: 1,
+                outputTokens: 1,
+              },
+            });
+          },
+        };
+      }
+    }
+    const fakeClient = new NestedArgsClient();
+    const searchTool = tool({
+      name: 'search',
+      description: 'Paginated search',
+      input: z.object({
+        filter: z.object({
+          page: z.number(),
+          kind: z.string(),
+        }),
+      }),
+      output: z.object({
+        ok: z.boolean(),
+      }),
+      execute: async () => ({
+        ok: true,
+      }),
+    });
+    const harness = new AgentHarness({
+      name: 'test',
+      params: {},
+    });
+    frameworkCast<{
+      client: NestedArgsClient;
+    }>(harness).client = fakeClient;
+    const ctx = harness.createContext();
+
+    const response = await harness.callModel({
+      model: 'test/model',
+      items: [
+        makeMessage('user', 'go'),
+      ],
+      tools: [
+        searchTool,
+      ],
+      ctx,
+    });
+
+    // Six distinct tool rounds ran to completion, then the final message.
+    expect(fakeClient.calls).toBe(7);
+    expect(
+      response.items.some((item) => item.type === 'message' && item.role === 'assistant'),
+    ).toBe(true);
+  });
+
+  it('does not trip the doom-loop guard on a polling loop whose tool results evolve', async () => {
+    // The canonical false positive (finding #15): `check_build` is called with
+    // byte-identical arguments on every attempt — that IS what polling looks
+    // like — and only the RESULT advances. A request-only fingerprint aborts
+    // this run on the 4th poll, two polls before the build is ready.
+    const readyOnPoll = 6;
+    const fakeClient = new PollingClient({
+      toolName: 'check_build',
+      toolArgs: '{"id":"build-7"}',
+      stopAfterRounds: readyOnPoll,
+    });
+    let pollsServed = 0;
+    const checkBuildTool = tool({
+      name: 'check_build',
+      description: 'Poll a build until it is ready',
+      input: z.object({
+        id: z.string(),
+      }),
+      output: z.object({
+        status: z.string(),
+        progress: z.number(),
+      }),
+      execute: async () => {
+        pollsServed += 1;
+        // Progress advances on every poll, so consecutive rounds are never
+        // byte-identical on the result side.
+        return pollsServed >= readyOnPoll
+          ? {
+              status: 'ready',
+              progress: 100,
+            }
+          : {
+              status: 'pending',
+              progress: pollsServed * 15,
+            };
+      },
+    });
+    const harness = new AgentHarness({
+      name: 'test',
+      params: {},
+    });
+    frameworkCast<{
+      client: PollingClient;
+    }>(harness).client = fakeClient;
+    const ctx = harness.createContext();
+
+    const response = await harness.callModel({
+      model: 'test/model',
+      items: [
+        makeMessage('user', 'wait for build-7'),
+      ],
+      tools: [
+        checkBuildTool,
+      ],
+      ctx,
+    });
+
+    // Survived well past the 4-round threshold and reached the ready state.
+    expect(pollsServed).toBe(readyOnPoll);
+    expect(fakeClient.calls).toBe(readyOnPoll + 1);
+    expect(
+      response.items.some((item) => item.type === 'message' && item.role === 'assistant'),
+    ).toBe(true);
+  });
+
+  it('still trips the doom-loop guard when request AND result are both identical', async () => {
+    // The other half of the fix: folding results in must not defang the guard.
+    // A tool whose output never changes is indistinguishable from a stuck model.
+    const fakeClient = new PollingClient({
+      toolName: 'check_build',
+      toolArgs: '{"id":"build-7"}',
+      stopAfterRounds: Number.MAX_SAFE_INTEGER,
+    });
+    let pollsServed = 0;
+    const stuckPollTool = tool({
+      name: 'check_build',
+      description: 'Poll a build that never progresses',
+      input: z.object({
+        id: z.string(),
+      }),
+      output: z.object({
+        status: z.string(),
+      }),
+      execute: async () => {
+        pollsServed += 1;
+        return {
+          status: 'pending',
+        };
+      },
+    });
+    const harness = new AgentHarness({
+      name: 'test',
+      params: {},
+    });
+    frameworkCast<{
+      client: PollingClient;
+    }>(harness).client = fakeClient;
+    const ctx = harness.createContext();
+
+    await expect(
+      harness.callModel({
+        model: 'test/model',
+        items: [
+          makeMessage('user', 'wait for build-7'),
+        ],
+        tools: [
+          stuckPollTool,
+        ],
+        ctx,
+      }),
+    ).rejects.toThrow('Doom loop detected');
+    // Four identical rounds ran (1 + DOOM_LOOP_IDENTICAL_ROUNDS), then the
+    // guard tripped at the top of the fifth before spending another call.
+    expect(pollsServed).toBe(4);
+    expect(fakeClient.calls).toBe(4);
+  });
+
+  it('disables the doom-loop guard entirely when doomLoopIdenticalRounds is 0', async () => {
+    // An opt-out for poll-heavy agents whose tool output is genuinely constant.
+    // Without the guard the run instead terminates via the tool-round limit.
+    const fakeClient = new PollingClient({
+      toolName: 'check_build',
+      toolArgs: '{"id":"build-7"}',
+      stopAfterRounds: Number.MAX_SAFE_INTEGER,
+    });
+    const constantPollTool = tool({
+      name: 'check_build',
+      description: 'Poll a build that never progresses',
+      input: z.object({
+        id: z.string(),
+      }),
+      output: z.object({
+        status: z.string(),
+      }),
+      execute: async () => ({
+        status: 'pending',
+      }),
+    });
+    const harness = new AgentHarness({
+      name: 'test',
+      params: {},
+    });
+    frameworkCast<{
+      client: PollingClient;
+    }>(harness).client = fakeClient;
+    const ctx = harness.createContext();
+
+    await expect(
+      harness.callModel({
+        model: 'test/model',
+        items: [
+          makeMessage('user', 'wait for build-7'),
+        ],
+        tools: [
+          constantPollTool,
+        ],
+        ctx,
+        doomLoopIdenticalRounds: 0,
+      }),
+    ).rejects.toThrow('exceeded maximum tool rounds');
+    // Ran far past the 4-round doom threshold — only MAX_TOOL_ROUNDS stopped it.
+    expect(fakeClient.calls).toBeGreaterThan(30);
+  });
+
+  it('respects a custom doomLoopIdenticalRounds threshold', async () => {
+    const fakeClient = new PollingClient({
+      toolName: 'check_build',
+      toolArgs: '{"id":"build-7"}',
+      stopAfterRounds: Number.MAX_SAFE_INTEGER,
+    });
+    const constantPollTool = tool({
+      name: 'check_build',
+      description: 'Poll a build that never progresses',
+      input: z.object({
+        id: z.string(),
+      }),
+      output: z.object({
+        status: z.string(),
+      }),
+      execute: async () => ({
+        status: 'pending',
+      }),
+    });
+    const harness = new AgentHarness({
+      name: 'test',
+      params: {},
+    });
+    frameworkCast<{
+      client: PollingClient;
+    }>(harness).client = fakeClient;
+    const ctx = harness.createContext();
+
+    await expect(
+      harness.callModel({
+        model: 'test/model',
+        items: [
+          makeMessage('user', 'wait for build-7'),
+        ],
+        tools: [
+          constantPollTool,
+        ],
+        ctx,
+        doomLoopIdenticalRounds: 8,
+      }),
+    ).rejects.toThrow('9 consecutive rounds of identical tool calls and results');
+    // Threshold 8 means the 9th identical round trips — nine rounds executed.
+    expect(fakeClient.calls).toBe(9);
+  });
+
+  it('pairs each parallel tool result with its own call, not by position', async () => {
+    // Two parallel reads whose results are stable but DIFFERENT from each other.
+    // A fingerprint that concatenated results positionally instead of joining on
+    // callId would still be stable here, so the real assertion is the negative
+    // one below: swapping which file returns which body must break the streak.
+    class ParallelReadClient {
+      calls = 0;
+      callModel(): {
+        getFullResponsesStream: () => AsyncIterable<unknown>;
+        getResponse: () => Promise<MockModelResponse>;
+      } {
+        const callNumber = this.calls++;
+        return {
+          async *getFullResponsesStream() {},
+          getResponse: async () =>
+            frameworkCast<MockModelResponse>({
+              id: `resp-${callNumber}`,
+              status: 'completed',
+              output: [
+                {
+                  id: `fc-a-${callNumber}`,
+                  status: 'completed',
+                  type: 'function_call',
+                  callId: `call_a_${callNumber}`,
+                  name: 'read_file',
+                  arguments: '{"path":"a.txt"}',
+                },
+                {
+                  id: `fc-b-${callNumber}`,
+                  status: 'completed',
+                  type: 'function_call',
+                  callId: `call_b_${callNumber}`,
+                  name: 'read_file',
+                  arguments: '{"path":"b.txt"}',
+                },
+              ],
+              usage: {
+                inputTokens: 1,
+                outputTokens: 1,
+              },
+            }),
+        };
+      }
+    }
+    const fakeClient = new ParallelReadClient();
+    // Bodies swap between a.txt and b.txt on every round: the multiset of
+    // results is constant, only the call→result pairing changes. Correct
+    // pairing sees two distinct rounds and never trips; positional pairing
+    // would see one repeated round and abort.
+    let roundsServed = 0;
+    const readFileTool = tool({
+      name: 'read_file',
+      description: 'Read a file',
+      input: z.object({
+        path: z.string(),
+      }),
+      output: z.object({
+        body: z.string(),
+      }),
+      execute: async (args) => {
+        // Two calls per round; flip the mapping each round.
+        const swapped = Math.floor(roundsServed / 2) % 2 === 1;
+        roundsServed += 1;
+        const isA = args.path === 'a.txt';
+        return {
+          body: isA === swapped ? 'BODY-B' : 'BODY-A',
+        };
+      },
+    });
+    const harness = new AgentHarness({
+      name: 'test',
+      params: {},
+    });
+    frameworkCast<{
+      client: ParallelReadClient;
+    }>(harness).client = fakeClient;
+    const ctx = harness.createContext();
+
+    await expect(
+      harness.callModel({
+        model: 'test/model',
+        items: [
+          makeMessage('user', 'read both'),
+        ],
+        tools: [
+          readFileTool,
+        ],
+        ctx,
+      }),
+    ).rejects.toThrow('exceeded maximum tool rounds');
+    // Never tripped the doom guard: the alternating pairing kept every
+    // consecutive pair of rounds distinct, so only MAX_TOOL_ROUNDS stopped it.
+    expect(fakeClient.calls).toBeGreaterThan(30);
   });
 
   it('recovers from the tool-round limit with an ephemeral continue retry', async () => {

--- a/packages/types/src/types/runtime.ts
+++ b/packages/types/src/types/runtime.ts
@@ -91,6 +91,23 @@ interface CallModelRequestBase {
   /** Optional signal for cancelling the in-flight call (used by session abort). */
   signal?: AbortSignal;
   /**
+   * Consecutive identical tool rounds (beyond the first) after which the
+   * doom-loop guard aborts the call. Defaults to `3`, i.e. the 4th identical
+   * round trips it. Pass a non-positive value to disable the guard entirely.
+   *
+   * A round counts as identical only when both the tool calls (name + canonical
+   * arguments) and the tool OUTPUTS repeat byte-for-byte, so a polling loop
+   * whose results evolve — a progress counter, a changing status, a timestamp —
+   * never trips the guard however long it runs.
+   *
+   * The caveat is a poll whose result is genuinely constant: a `check_build`
+   * that returns the identical `"pending"` string on every attempt is
+   * indistinguishable from a stuck model and will trip at the threshold. Raise
+   * the threshold or pass `0` for such agents, or have the tool include
+   * something that advances (an attempt count or elapsed time) in its output.
+   */
+  doomLoopIdenticalRounds?: number;
+  /**
    * @internal Parent span for the model-call spans this request produces. When
    * omitted, the caller falls back to `ctx.span`. Set by `parseAndRunWorkflow`
    * so model/tool spans nest under the root `workflow.run` span.

--- a/packages/web/content/docs/framework/runtime.mdx
+++ b/packages/web/content/docs/framework/runtime.mdx
@@ -193,6 +193,7 @@ Framework events emitted during execution:
 | `{name}:tool_call_started` | Before each tool call. |
 | `{name}:tool_call_completed` | After each tool call. |
 | `{name}:tool_round_completed` | After all tool calls in a round. |
+| `{name}:doom_loop_detected` | The doom-loop guard tripped; the call is about to fail. Data: `{ round, fingerprint, identicalRounds }`. |
 | `{name}:model_call_started` | Before each provider call. Data: `{ round, messageCount, toolCount }`. |
 | `{name}:model_call_first_event` | First SDK event received (time-to-first-token marker). Only emitted when a broadcaster is attached to the context. Data: `{ round }`. |
 | `{name}:model_call_completed` | Provider response fully received. Data: `{ round, itemCount }`. |
@@ -203,6 +204,12 @@ callModel steps support an `emit` option to control step/tool framework event em
 ### Stream Idle Timeout
 
 Each provider call is guarded by a watchdog that aborts the round if no SSE event arrives for 120 seconds. The watchdog re-arms on every stream event, so slow-but-alive responses are never cut short. On timeout, `{name}:model_call_stalled` is emitted and the surrounding turn fails with `turn_aborted { reason: "model stream idle timeout after <N>ms" }`, so upstream providers that quietly drop a connection surface as errors rather than hangs.
+
+### Doom-Loop Guard
+
+The model loop fingerprints every completed tool round — its tool calls (name + canonical arguments) paired with the outputs they produced — and fails the call with a `Doom loop detected` error after a configurable streak of consecutive byte-identical rounds, emitting `{name}:doom_loop_detected` first. Because results are part of the fingerprint, a polling loop whose results evolve (a progress counter, a changing status) never trips; a poll whose result is genuinely constant is indistinguishable from a stuck model and will trip.
+
+Configure the streak per call with `doomLoopIdenticalRounds` on the `callModel` request: it counts identical rounds beyond the first, defaults to `3` (the 4th identical round trips), and `0` (or any non-positive value) disables the guard.
 
 ## run()
 

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -469,6 +469,14 @@ Each queued message carries a `DeliveryMode`:
 
 The harness runs a per-round watchdog over each provider call's SSE stream. The idle timeout is fixed at 120 seconds — long enough that slow models are never falsely aborted, short enough that a stalled SSE becomes a visible error rather than a silent hang. The watchdog re-arms on every stream event; if no event arrives within the window, the round is aborted, `{name}:model_call_stalled` is emitted, and the surrounding turn fails with `turn_aborted { reason: "model stream idle timeout after <N>ms" }`. This prevents silent hangs when a provider drops the connection without sending a terminal event.
 
+### Doom-Loop Guard
+
+The model loop fingerprints every completed tool round as its tool calls (name + canonical arguments, keys sorted at every depth, order-insensitive) PAIRED WITH the tool outputs they produced (joined by `callId`, not position). When the streak of consecutive byte-identical rounds reaches the threshold, the loop emits `{name}:doom_loop_detected` and the call fails with a `Doom loop detected: N consecutive rounds of identical tool calls and results (...)` error instead of burning the remaining tool rounds on a dead end. The verdict is passed at the top of the loop iteration, before another provider call is spent.
+
+Because results are part of the fingerprint, a legitimate polling loop — same request, evolving results (a progress counter, a changing status) — never trips the guard. The caveat is a poll whose result is genuinely constant (e.g. a `check_build` that returns the identical `"pending"` string every time): it is indistinguishable from a stuck model and trips at the threshold. Such agents should raise the threshold, disable the guard, or have the tool include something that advances (attempt count, elapsed time) in its output.
+
+The threshold is configured per call via `CallModelRequest.doomLoopIdenticalRounds`: it counts identical rounds BEYOND the first, defaults to `3` (the 4th identical round trips), and any non-positive value disables the guard entirely. State is per-`callModel` call and never leaks across turns.
+
 ### StreamEvent
 
 Events have a `source` discriminant: `'sdk'` for raw OpenResponses SSE events, `'framework'` for Noetic lifecycle events. Framework events use the harness `config.name` as prefix (e.g., `myagent:step_started`).
@@ -506,6 +514,7 @@ interface FrameworkStreamEvent {
 | `{name}:tool_call_started` | Emitted before each tool call. Data: `{ name, callId }` |
 | `{name}:tool_call_completed` | Emitted after each tool call. Data: `{ name, callId, error }` |
 | `{name}:tool_round_completed` | Emitted after all tool calls in a round. Data: `{ round, toolCount }` |
+| `{name}:doom_loop_detected` | Emitted when the doom-loop guard trips, immediately before the call fails. Data: `{ round, fingerprint, identicalRounds }` — `fingerprint` is the request-side tool-call fingerprint (canonical name + args); tool outputs are folded into the streak decision but not into the payload. |
 | `{name}:model_call_started` | Emitted before each provider call in the tool-round loop. Data: `{ round, messageCount, toolCount }` |
 | `{name}:model_call_first_event` | Emitted when the first SDK event for the call arrives. Useful for measuring time-to-first-token. Only emitted when a broadcaster is attached to the context. Data: `{ round }` |
 | `{name}:model_call_completed` | Emitted after the provider's response is fully received. Data: `{ round, itemCount }` |


### PR DESCRIPTION
## What

- fingerprint completed tool rounds by canonicalized calls paired with results
- abort after a configurable number of identical repeats (3 repeats / 4 total rounds by default)
- reset the streak when a polling tool returns progressing output
- emit `{name}:doom_loop_detected` before aborting
- allow non-positive `doomLoopIdenticalRounds` to disable the guard

## Why

A model repeating an identical call/result cycle can consume all 32 tool rounds. Comparing calls alone would incorrectly kill legitimate polling loops, so the guard includes each result by `callId` and only trips when both request and result remain identical.

This semantically ports `fork/port/openrouter-fixes` commits `3fc95caf` and `33f44721` onto current main.

## Test plan

- [x] 38 focused harness-result tests pass
- [x] 7 adversarial guard cases: stuck/evolving/constant polling, disable, custom threshold, parallel pairing, nested canonicalization
- [x] types/core typechecks
- [x] root lint
- [x] `sentrux check .`
- [x] source worker ran full root suite: 2,047 pass, 0 fail
- [x] clean-context Pi review; public disable docs corrected

## Behavior change

Repeated identical tool-call/result rounds now abort before the global tool-round limit. Polling tools with changing results reset the streak; constant-result polling can raise or disable the threshold.
