### PR TITLE
perf(context): defer observation distillation

### DIFF
--- a/packages/context/src/context/layers/observations.ts
+++ b/packages/context/src/context/layers/observations.ts
@@ -1,4 +1,4 @@
-import type { ContextLayer } from '@noetic-tools/types';
+import type { ContextLayer, ExecutionContext } from '@noetic-tools/types';
 import {
   collectInputText,
   collectOutputText,
@@ -6,6 +6,7 @@ import {
   estimateTokens,
   Slot,
 } from '@noetic-tools/types';
+import { resolveScopeKey } from '../scope';
 
 export interface ObservationsState {
   observations: string[];
@@ -32,6 +33,72 @@ interface AccumulateConfig {
   threshold: number;
   maxObs: number;
   observer?: ObserverFn;
+  /** Background-distillation bucket for the current scope key. */
+  deferred: DeferredDistill;
+}
+
+/**
+ * In-flight background distillations for one scope key. Results drain into
+ * state on the next `store` / `onItemAppend` — distillation is eventually
+ * visible, never turn-blocking. An LLM-backed observer used to add its full
+ * round-trip latency to the user's turn (both hooks awaited it, with 60s
+ * timeouts); now the turn pays only the buffer append.
+ *
+ * Keyed per scope key rather than per layer instance: one layer instance is
+ * shared across every thread/resource on a harness, while its state is stored
+ * per scope, so a single shared bucket would drain resource A's distillation
+ * into resource B's observations.
+ */
+interface DeferredBatch {
+  buffer: string[];
+  result?: string[];
+  failed?: boolean;
+}
+
+interface DeferredDistill {
+  /** Dispatch-ordered batches. Only the settled prefix drains into state. */
+  batches: DeferredBatch[];
+}
+
+/**
+ * Folds completed background batches into `observations` and re-buffers failed
+ * ones (the previous blocking path kept the buffer on observer failure; the
+ * deferred path preserves that no-loss behavior). Returns `s` unchanged
+ * (identity-comparable) when nothing has completed.
+ */
+function drainDeferred(
+  s: ObservationsState,
+  d: DeferredDistill,
+  maxObs: number,
+): ObservationsState {
+  const settled: DeferredBatch[] = [];
+  while (d.batches[0]?.result !== undefined || d.batches[0]?.failed) {
+    const batch = d.batches.shift();
+    if (batch) {
+      settled.push(batch);
+    }
+  }
+  if (settled.length === 0) {
+    return s;
+  }
+  const retries = settled.filter((batch) => batch.failed).flatMap((batch) => batch.buffer);
+  const observations = settled.flatMap((batch) => batch.result ?? []);
+  const buffer =
+    retries.length > 0
+      ? [
+          ...retries,
+          ...s.buffer,
+        ]
+      : s.buffer;
+  return {
+    observations: [
+      ...s.observations,
+      ...observations,
+    ].slice(-maxObs),
+    buffer,
+    bufferTokens: buffer.reduce((sum, t) => sum + estimateTokens(t), 0),
+    version: s.version + 1,
+  };
 }
 
 /**
@@ -39,36 +106,57 @@ interface AccumulateConfig {
  * distills the buffer into observations. Shared by `store` (assistant output) and
  * `onItemAppend` (user/tool input).
  */
-async function accumulate(
+function accumulate(
   s: ObservationsState,
   texts: string[],
   cfg: AccumulateConfig,
-): Promise<ObservationsState> {
+): ObservationsState {
+  const deferred = cfg.deferred;
+  const withReady = drainDeferred(s, deferred, cfg.maxObs);
   const newBuffer = [
-    ...s.buffer,
+    ...withReady.buffer,
     ...texts,
   ];
   const newTokens = texts.reduce((sum, t) => sum + estimateTokens(t), 0);
-  const totalBufferTokens = s.bufferTokens + newTokens;
+  const totalBufferTokens = withReady.bufferTokens + newTokens;
   if (totalBufferTokens >= cfg.threshold) {
-    const distilled = cfg.observer
-      ? await cfg.observer(newBuffer)
-      : [
-          `Processed ${newBuffer.length} items`,
-        ];
-    const newObservations = [
-      ...s.observations,
-      ...distilled,
-    ].slice(-cfg.maxObs);
+    if (cfg.observer) {
+      // Fire-and-collect: the observer runs off the turn path; its result
+      // joins `ready` (or its buffer joins `failed` on rejection) and drains
+      // into state on a later hook. Both handlers resolve, so the derived
+      // promise can never be an unhandled rejection.
+      const batch: DeferredBatch = {
+        buffer: newBuffer,
+      };
+      deferred.batches.push(batch);
+      void Promise.resolve()
+        .then(() => cfg.observer?.(newBuffer))
+        .then(
+          (distilled) => {
+            batch.result = distilled ?? [];
+          },
+          () => {
+            batch.failed = true;
+          },
+        );
+      return {
+        ...withReady,
+        buffer: [],
+        bufferTokens: 0,
+      };
+    }
     return {
-      observations: newObservations,
+      observations: [
+        ...withReady.observations,
+        `Processed ${newBuffer.length} items`,
+      ].slice(-cfg.maxObs),
       buffer: [],
       bufferTokens: 0,
-      version: s.version + 1,
+      version: withReady.version + 1,
     };
   }
   return {
-    ...s,
+    ...withReady,
     buffer: newBuffer,
     bufferTokens: totalBufferTokens,
   };
@@ -116,22 +204,33 @@ export function observations(config?: ObservationsConfig) {
   const maxObs = config?.maxObservations ?? DEFAULT_MAX_OBSERVATIONS;
   const threshold = config?.bufferThreshold ?? DEFAULT_BUFFER_THRESHOLD_TOKENS;
   const observer = config?.observer;
+  const scope = config?.scope ?? 'resource';
+  // One bucket per scope key: this layer instance is shared across every
+  // thread/resource on a harness, but its state is stored per scope.
+  const deferredByScope = new Map<string, DeferredDistill>();
+  const deferredFor = (ctx: ExecutionContext): DeferredDistill => {
+    const key = resolveScopeKey(scope, ctx);
+    let bucket = deferredByScope.get(key);
+    if (!bucket) {
+      bucket = {
+        batches: [],
+      };
+      deferredByScope.set(key, bucket);
+    }
+    return bucket;
+  };
 
   return {
     id: 'observations' as const,
     name: 'Observations',
     slot: Slot.OBSERVATIONS,
-    scope: config?.scope ?? 'resource',
+    scope,
     budget: {
       min: 500,
       max: 2_500,
     },
-    timeouts: {
-      store: 60_000,
-      // onItemAppend runs the same LLM-backed accumulate/distill path as
-      // store — it needs the same headroom, not the 5s pipeline default.
-      onItemAppend: 60_000,
-    },
+    // No LLM in the hook path any more — distillation is deferred, so no
+    // `timeouts` override: the default hook timeouts are ample.
     hooks: {
       async init({ storage }) {
         const saved = await storage.get<ObservationsState>('state');
@@ -157,34 +256,48 @@ export function observations(config?: ObservationsConfig) {
         };
       },
 
-      // Captures assistant output text.
-      async store({ newItems, state }) {
+      // Captures assistant output text. Also the drain point for background
+      // distillations: `store` runs every turn and its returned state is always
+      // persisted, so a completed batch lands without `recall` mutating state
+      // (which would force this layer out of the anchor band for that turn).
+      async store({ newItems, state, ctx }) {
         const s = state ?? emptyObservationsState();
         const texts = collectOutputText(newItems);
         return {
-          state: await accumulate(s, texts, {
+          state: accumulate(s, texts, {
             threshold,
             maxObs,
             observer,
+            deferred: deferredFor(ctx),
           }),
         };
       },
 
       // Captures user input and tool output text (pass-through; no transform).
-      async onItemAppend({ items, state }) {
+      async onItemAppend({ items, state, ctx }) {
         const s = state ?? emptyObservationsState();
         const texts = collectInputText(items);
+        const deferred = deferredFor(ctx);
         if (texts.length === 0) {
-          return {
-            items,
-          };
+          // Still fold in anything that finished, so a quiet append is not a
+          // missed drain opportunity.
+          const drained = drainDeferred(s, deferred, maxObs);
+          return drained === s
+            ? {
+                items,
+              }
+            : {
+                items,
+                state: drained,
+              };
         }
         return {
           items,
-          state: await accumulate(s, texts, {
+          state: accumulate(s, texts, {
             threshold,
             maxObs,
             observer,
+            deferred,
           }),
         };
       },

--- a/packages/core/test/context/e2e-context-layers.test.ts
+++ b/packages/core/test/context/e2e-context-layers.test.ts
@@ -376,7 +376,7 @@ describe('Observational Memory: real LLM observer', () => {
           2e3,
         ],
       ]);
-      const recallResults = await recallLayers({
+      let results = await recallLayers({
         layers: [
           layer,
         ],
@@ -387,9 +387,34 @@ describe('Observational Memory: real LLM observer', () => {
         store,
       });
 
-      // ~50 tokens in the message exceeds the bufferThreshold of 10, so observer must fire
-      expect(recallResults.length).toBe(1);
-      expect(recallResults[0].items.length).toBeGreaterThan(0);
+      // ~50 tokens exceeds the bufferThreshold of 10, so the observer fires —
+      // but distillation is DEFERRED off the turn path now. A later `store`
+      // drains the completed batch into state; poll until it lands.
+      for (let attempt = 0; attempt < 40 && results.length === 0; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        await storeLayers({
+          layers: [
+            layer,
+          ],
+          response: makeLLMResponse(''),
+          ctx,
+          log,
+          store,
+          storage: makeStorage(),
+        });
+        results = await recallLayers({
+          layers: [
+            layer,
+          ],
+          query: '',
+          ctx,
+          log,
+          budgets,
+          store,
+        });
+      }
+      expect(results.length).toBe(1);
+      expect(results[0].items.length).toBeGreaterThan(0);
     },
   );
 });

--- a/packages/core/test/context/observations.test.ts
+++ b/packages/core/test/context/observations.test.ts
@@ -144,14 +144,227 @@ describe('observations', () => {
   });
 });
 
-describe('observations timeouts (M8)', () => {
-  it('pins LLM-headroom timeouts for store AND onItemAppend', () => {
+describe('observations deferred distillation (M8, redesigned)', () => {
+  function assistantItem(text: string): MessageItem {
+    return {
+      id: 'a1',
+      type: 'message',
+      role: 'assistant',
+      status: 'completed',
+      content: [
+        {
+          type: 'output_text',
+          text,
+        },
+      ],
+    };
+  }
+
+  const emptyResponse = {
+    items: [],
+    usage: {
+      inputTokens: 0,
+      outputTokens: 0,
+    },
+  };
+
+  it('declares no LLM-headroom timeouts — distillation runs off the turn path', () => {
     const layer = observations();
-    // Both hooks run the same LLM-backed accumulate path; onItemAppend must
-    // not be limited by the 5s pipeline default.
-    expect(layer.timeouts).toEqual({
-      store: 60_000,
-      onItemAppend: 60_000,
+    // The observer is fire-and-collect now: hooks only append to the buffer,
+    // so the default hook timeouts are sufficient and the turn never blocks
+    // on an LLM distillation call.
+    expect('timeouts' in layer).toBe(false);
+  });
+
+  it('crossing the threshold with an observer clears the buffer without blocking', async () => {
+    let resolveObserver: ((v: string[]) => void) | undefined;
+    const layer = observations({
+      bufferThreshold: 1,
+      observer: () =>
+        new Promise<string[]>((resolve) => {
+          resolveObserver = resolve;
+        }),
     });
+    const ctx = makeCtx();
+    const result = await layer.hooks.store!({
+      newItems: [
+        assistantItem('a long enough assistant answer to cross the threshold'),
+      ],
+      log: makeItemLog(),
+      response: emptyResponse,
+      ctx,
+      state: {
+        observations: [],
+        buffer: [],
+        bufferTokens: 0,
+        version: 0,
+      },
+    });
+    assert(result !== undefined);
+    // Returned without awaiting the observer; the batch is in flight.
+    expect(result.state.buffer).toEqual([]);
+    expect(result.state.observations).toEqual([]);
+
+    // ...and the observation lands on a later hook once the observer resolves.
+    assert(resolveObserver);
+    resolveObserver([
+      'deferred fact',
+    ]);
+    await Bun.sleep(1);
+
+    const drained = await layer.hooks.store!({
+      newItems: [],
+      log: makeItemLog(),
+      response: emptyResponse,
+      ctx,
+      state: result.state,
+    });
+    assert(drained !== undefined);
+    expect(drained.state.observations).toEqual([
+      'deferred fact',
+    ]);
+    // The drain bumps version so downstream churn tracking sees the change.
+    expect(drained.state.version).toBe(result.state.version + 1);
+  });
+
+  it('a failed distillation retains its batch and retries on a later hook', async () => {
+    // The blocking path kept the buffer on observer failure; the deferred path
+    // must not silently drop the batch either. A rejected batch drains back
+    // into the buffer, which re-crosses the threshold and retries.
+    let calls = 0;
+    const layer = observations({
+      bufferThreshold: 1,
+      observer: () =>
+        ++calls === 1
+          ? Promise.reject(new Error('observer exploded'))
+          : Promise.resolve([
+              'recovered fact',
+            ]),
+    });
+    const ctx = makeCtx();
+    const emptyState = {
+      observations: [],
+      buffer: [],
+      bufferTokens: 0,
+      version: 0,
+    };
+    const storeOnce = (state: ObservationsState) =>
+      layer.hooks.store!({
+        newItems: [
+          assistantItem('enough text to cross the tiny threshold'),
+        ],
+        log: makeItemLog(),
+        response: emptyResponse,
+        ctx,
+        state,
+      });
+
+    const first = await storeOnce(emptyState);
+    assert(first !== undefined);
+    expect(first.state.buffer).toEqual([]);
+    await Bun.sleep(1);
+    expect(calls).toBe(1);
+
+    // The failed batch drains back into the buffer and immediately retries.
+    const second = await storeOnce(first.state);
+    assert(second !== undefined);
+    await Bun.sleep(1);
+    expect(calls).toBe(2);
+
+    const third = await storeOnce(second.state);
+    assert(third !== undefined);
+    expect(third.state.observations).toEqual([
+      'recovered fact',
+    ]);
+  });
+
+  it('keeps deferred batches keyed per scope so resources cannot cross-contaminate', async () => {
+    // One layer instance is shared across every resource on a harness, while
+    // its state is stored per scope key. A single shared bucket would drain
+    // resource A's distillation into resource B's observations.
+    let resolveA: ((v: string[]) => void) | undefined;
+    const layer = observations({
+      bufferThreshold: 1,
+      observer: () =>
+        new Promise<string[]>((resolve) => {
+          resolveA = resolve;
+        }),
+    });
+    const ctxA = makeCtx({
+      resourceId: 'user-a',
+    });
+    const ctxB = makeCtx({
+      resourceId: 'user-b',
+    });
+    const emptyState = {
+      observations: [],
+      buffer: [],
+      bufferTokens: 0,
+      version: 0,
+    };
+
+    const a1 = await layer.hooks.store!({
+      newItems: [
+        assistantItem('resource A text long enough to cross the threshold'),
+      ],
+      log: makeItemLog(),
+      response: emptyResponse,
+      ctx: ctxA,
+      state: emptyState,
+    });
+    assert(a1 !== undefined);
+    assert(resolveA);
+    resolveA([
+      'A-only fact',
+    ]);
+    await Bun.sleep(1);
+
+    // B drains its own (empty) bucket — A's batch must not appear here.
+    const b1 = await layer.hooks.store!({
+      newItems: [],
+      log: makeItemLog(),
+      response: emptyResponse,
+      ctx: ctxB,
+      state: emptyState,
+    });
+    assert(b1 !== undefined);
+    expect(b1.state.observations).toEqual([]);
+
+    // A still gets it.
+    const a2 = await layer.hooks.store!({
+      newItems: [],
+      log: makeItemLog(),
+      response: emptyResponse,
+      ctx: ctxA,
+      state: a1.state,
+    });
+    assert(a2 !== undefined);
+    expect(a2.state.observations).toEqual([
+      'A-only fact',
+    ]);
+  });
+
+  it('recall never mutates state, so a drained batch cannot demote the anchor band', async () => {
+    // Draining in store/onItemAppend keeps recall pure: `state` is absent from
+    // recall's return type, so the lifecycle can never see it as mutated here.
+    const layer = observations();
+    const state = {
+      observations: [
+        'known fact',
+      ],
+      buffer: [],
+      bufferTokens: 0,
+      version: 1,
+    };
+    const recall = await layer.hooks.recall!({
+      log: makeItemLog(),
+      query: '',
+      ctx: makeCtx(),
+      state,
+      budget: 1_000,
+    });
+    assert(recall !== null && typeof recall !== 'string');
+    expect(Object.hasOwn(recall, 'state')).toBe(false);
+    expect(recall.items.length).toBe(1);
   });
 });

--- a/packages/web/content/docs/framework/context-layers/observations.mdx
+++ b/packages/web/content/docs/framework/context-layers/observations.mdx
@@ -10,7 +10,7 @@ Observations accumulates conversation text into a buffer, and when the buffer cr
 - **Slot**: `200` (`Slot.OBSERVATIONS`)
 - **Default scope**: `resource`
 - **Default budget**: `{ min: 500, max: 2500 }`
-- **Hook timeouts**: `store` and `onItemAppend` both `60000` ms (both hooks run the LLM-backed distillation path)
+- **Hook timeouts**: none — distillation is deferred off the turn path, so the default hook timeouts apply
 
 ## Usage
 
@@ -79,9 +79,11 @@ If observations exist, formats them as a bulleted list inside an `<observations>
 
 1. Extracts text content from new `message` items in the LLM response.
 2. Appends the text to the buffer and updates the token count.
-3. When `bufferTokens` reaches `bufferThreshold`, calls the `observer` function with the full buffer.
-4. The observer returns distilled observation strings, which are appended to the observations list (capped at `maxObservations`).
-5. The buffer resets to empty.
+3. When `bufferTokens` reaches `bufferThreshold`, dispatches the `observer` with the full buffer **in the background** — the hook returns immediately without awaiting the LLM call.
+4. When the observer resolves, its distilled observations drain into state on the next `store`/`onItemAppend` (capped at `maxObservations`). If the observer rejects, the batch is retained and retried on a later hook — nothing is silently dropped.
+5. The buffer resets to empty when a batch is dispatched.
+
+Deferred batches are keyed per scope key: one layer instance serves every thread/resource on a harness, so results always drain back into the scope that produced them. Because draining only happens in `store`/`onItemAppend`, `recall` never mutates state.
 
 If no custom `observer` is provided, a simple fallback records `"Processed N items"`.
 

--- a/specs/12-builtin-context-layers.md
+++ b/specs/12-builtin-context-layers.md
@@ -95,13 +95,14 @@ function observations(config?: ObservationsConfig): ContextLayer<ObservationsSta
 | **slot** | `Slot.OBSERVATIONS` (200) |
 | **scope** | `config.scope ?? 'resource'` |
 | **budget** | `{ min: 500, max: 2500 }` |
-| **timeouts** | `{ store: 60_000, onItemAppend: 60_000 }` (both hooks run the LLM-backed distillation path) |
 | **hooks** | `init`, `recall`, `store`, `onItemAppend`, `onSpawn` |
+
+Distillation is deferred: when the buffer crosses the threshold, the observer batch is dispatched in the background (fire-and-collect) instead of being awaited in the hook. The completed batch drains into state on the next `store`/`onItemAppend`, so an LLM-backed observer never blocks the turn and the layer needs no hook-timeout override. Deferred batches are keyed per scope key — one layer instance serves every thread/resource on a harness, so a shared bucket would cross-contaminate scopes. A rejected observer batch is retained and retried on a later hook (nothing is silently dropped), and rejections are always handled so they can never surface as unhandled.
 
 **Behavior:**
 - `init`: Loads versioned state from storage.
-- `recall`: Renders observations as `<observations>` bullet list in a `MessageItem` with `role: developer`. Trims output to the allocated budget.
-- `store`: Buffers **assistant output** items. When the token threshold is reached, runs the observer LLM on the buffer. Compacts if over `maxObservations`.
+- `recall`: Renders observations as `<observations>` bullet list in a `MessageItem` with `role: developer`. Trims output to the allocated budget. Never mutates state (draining happens in `store`/`onItemAppend`, keeping `recall` pure and the layer anchorable).
+- `store`: Buffers **assistant output** items. When the token threshold is reached, dispatches the observer on the buffer in the background; completed batches drain in here. Compacts if over `maxObservations`.
 - `onItemAppend`: Buffers **user input and tool output** items the same way `store` buffers assistant output, so observations are distilled from the full conversation, not just the model's replies.
 - `onSpawn`: Clones observations to child.
 


### PR DESCRIPTION
## What

- dispatch observation distillation after threshold crossing without awaiting the observer in `store`/`onItemAppend`
- collect settled batches on later lifecycle hooks while preserving dispatch order
- retry rejected batches instead of dropping buffered conversation
- isolate deferred queues by resolved thread/resource scope
- remove the obsolete 60-second hook timeout overrides

## Why

The observations layer awaited an LLM-backed observer in the append pipeline, adding a full model round trip to user/tool item ingestion. Distillation is eventually visible context and does not need to block the turn.

This semantically ports the observations portion of `fork/port/openrouter-fixes` commit `fb22ac35` onto the current `observations()` names and scope model.

## Test plan

- [x] focused observations/e2e tests — 15 pass
- [x] context and core typechecks
- [x] root lint
- [x] `sentrux check .`
- [x] source worker full root suite — 2,050 pass, 0 fail
- [x] clean-context Pi review; fixed completion-order inversion and synchronous observer throws

## Semantics

Completed batches become visible on the next `store` or `onItemAppend`. `recall` remains pure. Observer failures re-buffer their source batch for retry.
