### PR TITLE
fix(types): make context builder output attachable

### DIFF
--- a/.claude/skills/noetic-agent-builder/references/api-reference.md
+++ b/.claude/skills/noetic-agent-builder/references/api-reference.md
@@ -113,7 +113,7 @@ Child execution with context boundary. Context layers control what state crosses
 spawn<TContext = ContextData, I = unknown, O = unknown>({
   id: string;
   child: Step<TContext, I, O>;
-  context?: ContextConfig | ContextLayer[];
+  context?: ContextInput;
   timeout?: number;
   subprocess?: SubprocessAdapter; // per-step adapter override
 }): StepSpawn<TContext, I, O>
@@ -971,6 +971,18 @@ interface ContextConfig<TLayers extends readonly ContextLayer[] = readonly Conte
   readonly _shape: InferContextShape<TLayers>;  // phantom — never accessed at runtime
 }
 ```
+
+### ContextInput
+
+What every context-accepting entry point takes: a bare layer list, or anything carrying one — notably the `ContextConfig` from `context()`.
+
+```typescript
+type ContextInput =
+  | ReadonlyArray<ContextLayer>
+  | { readonly layers: ReadonlyArray<ContextLayer> };
+```
+
+Spelled structurally (not `ContextConfig | ContextLayer[]`) because `ContextConfig` is invariant in `TLayers` via `_shape`, so a concrete `ContextConfig<readonly [SomeLayer]>` is not assignable to the defaulted `ContextConfig`.
 
 ### layerData
 

--- a/packages/core/examples/delegate-tools.ts
+++ b/packages/core/examples/delegate-tools.ts
@@ -4,10 +4,11 @@
  * Used by the sync-delegate, async-delegate, and dynamic-delegate examples.
  */
 
-import type { ContextData, ContextLayer } from '@noetic-tools/context';
+import type { ContextData } from '@noetic-tools/context';
 import type {
   AgentHarnessContract,
   Channel,
+  ContextInput,
   DetachedHandle,
   DetachedStatus,
   Tool,
@@ -26,7 +27,7 @@ export interface SubAgentConfig {
   model: string;
   instructions: string;
   tools?: Tool[];
-  context?: ContextLayer[];
+  context?: ContextInput;
 }
 
 export type SubAgentResolver = (task: string) => SubAgentConfig;

--- a/packages/core/examples/react-agent.ts
+++ b/packages/core/examples/react-agent.ts
@@ -1,4 +1,4 @@
-import type { ContextConfig, ContextData, ContextLayer } from '@noetic-tools/context';
+import type { ContextData, ContextInput } from '@noetic-tools/context';
 import type { StepLoop, StepSpawn, Tool } from '@noetic-tools/types';
 import { loop } from '../src/builders/loop-builder';
 import { spawn } from '../src/builders/spawn-builder';
@@ -19,7 +19,7 @@ export function react(opts: {
   tools: Tool[];
   maxSteps?: number;
   maxCost?: number;
-  context?: ContextConfig | ContextLayer[];
+  context?: ContextInput;
 }): StepLoop<ContextData, string, string> | StepSpawn<ContextData, string, string> {
   const llmStep = callModel<ContextData, string, string>({
     id: 'react-step',

--- a/packages/core/src/builders/provide-builder.ts
+++ b/packages/core/src/builders/provide-builder.ts
@@ -1,4 +1,4 @@
-import type { ContextConfig, ContextData, ContextLayer } from '@noetic-tools/context';
+import type { ContextData, ContextInput } from '@noetic-tools/context';
 import type { Step, StepWithContext } from '@noetic-tools/types';
 import { NoeticConfigError } from '@noetic-tools/types';
 import { getDefaultRegistrar } from '../types/step-registrar';
@@ -19,7 +19,7 @@ import { getDefaultRegistrar } from '../types/step-registrar';
 export function withContext<TContext = ContextData, I = unknown, O = unknown>(opts: {
   id: string;
   child: Step<TContext, I, O>;
-  context: ContextConfig | ContextLayer[];
+  context: ContextInput;
 }): StepWithContext<TContext, I, O> {
   if (!opts.id?.trim()) {
     throw new NoeticConfigError({

--- a/packages/core/src/builders/spawn-builder.ts
+++ b/packages/core/src/builders/spawn-builder.ts
@@ -1,4 +1,4 @@
-import type { ContextConfig, ContextData, ContextLayer } from '@noetic-tools/context';
+import type { ContextData, ContextInput } from '@noetic-tools/context';
 import type { Step, StepSpawn, SubprocessAdapter } from '@noetic-tools/types';
 import { NoeticConfigError } from '@noetic-tools/types';
 import { getDefaultRegistrar } from '../types/step-registrar';
@@ -8,7 +8,7 @@ import { getDefaultRegistrar } from '../types/step-registrar';
 interface SpawnOpts<TContext, I, O> {
   id: string;
   child: Step<TContext, I, O>;
-  context?: ContextConfig | ContextLayer[];
+  context?: ContextInput;
   timeout?: number;
   /**
    * Optional per-step subprocess adapter override. The interpreter routes

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -423,6 +423,7 @@ export type {
   CompleteParams,
   ContextConfig,
   ContextData,
+  ContextInput,
   ContextLayer,
   ContextLayerHooks,
   DisposeParams,
@@ -527,6 +528,7 @@ export { LedgerEntryKind, SteeringAction } from '@noetic-tools/types';
 /** @public */
 export type {
   ExecuteStepFn,
+  Lazy,
   SettleResult,
   Snapshot,
   Step,
@@ -539,6 +541,7 @@ export type {
   StepInvokeTool,
   StepLoop,
   StepRunCode,
+  StepSchedule,
   StepSpawn,
   StepSubHarness,
   StepWithContext,

--- a/packages/core/src/interpreter/action-types.ts
+++ b/packages/core/src/interpreter/action-types.ts
@@ -1,6 +1,6 @@
 export type {
-  ContextConfig,
   ContextData,
+  ContextInput,
   ContextLayer,
   ExecutionContext,
 } from '@noetic-tools/context';

--- a/packages/core/src/interpreter/execute-action.ts
+++ b/packages/core/src/interpreter/execute-action.ts
@@ -111,7 +111,7 @@ export async function executeRunCode<TContext, I, O>(
       lastError = e instanceof Error ? e : new Error(String(e));
 
       if (attempt < maxAttempts - 1 && retry) {
-        const delay = computeDelay(retry, attempt);
+        const delay = computeRetryDelay(retry, attempt);
         await new Promise((r) => setTimeout(r, delay));
       }
     }
@@ -125,7 +125,8 @@ export async function executeRunCode<TContext, I, O>(
   });
 }
 
-function computeDelay(retry: RetryPolicy, attempt: number): number {
+/** @internal Pure retry delay calculation for deterministic tests. */
+export function computeRetryDelay(retry: RetryPolicy, attempt: number): number {
   let delay: number;
   switch (retry.backoff) {
     case 'fixed':

--- a/packages/core/src/interpreter/execute-action.ts
+++ b/packages/core/src/interpreter/execute-action.ts
@@ -43,8 +43,8 @@ import type {
   AgentHarnessContract,
   CallModelRequest,
   Context,
-  ContextConfig,
   ContextData,
+  ContextInput,
   ContextLayer,
   ContextRerenderRequest,
   ExecuteStepFn,
@@ -912,8 +912,15 @@ interface CollectSpawnItemsParams {
   itemSchemas?: ItemSchemaRegistry;
 }
 
-function isContextConfig(value: unknown): value is ContextConfig {
-  return typeof value === 'object' && value !== null && 'layers' in value;
+/**
+ * Discriminates the two members of `ContextInput`. Checks `!Array.isArray`
+ * first: the array member is a `ReadonlyArray`, which a `'layers' in value`
+ * test alone does not narrow away.
+ */
+function hasLayersField(value: ContextInput): value is {
+  readonly layers: ReadonlyArray<ContextLayer>;
+} {
+  return !Array.isArray(value) && 'layers' in value && Array.isArray(value.layers);
 }
 
 function resolveLayersForSpawn<TContext, I, O>(
@@ -923,12 +930,14 @@ function resolveLayersForSpawn<TContext, I, O>(
   if (!step.context) {
     return parentLayers ?? [];
   }
-  if (isContextConfig(step.context)) {
+  if (hasLayersField(step.context)) {
     return [
       ...step.context.layers,
     ];
   }
-  return step.context;
+  return [
+    ...step.context,
+  ];
 }
 
 async function collectSpawnItems({
@@ -1085,12 +1094,14 @@ export async function executeSpawn<TContext, I, O>(
 //#region provide
 
 function resolveLayers<TContext, I, O>(step: StepWithContext<TContext, I, O>): ContextLayer[] {
-  if (isContextConfig(step.context)) {
+  if (hasLayersField(step.context)) {
     return [
       ...step.context.layers,
     ];
   }
-  return step.context;
+  return [
+    ...step.context,
+  ];
 }
 
 function mergeLayers(

--- a/packages/core/test/context/context-input.test.ts
+++ b/packages/core/test/context/context-input.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Regression pin for `ContextInput`.
+ *
+ * `ContextConfig<TLayers>` is invariant in `TLayers` — its phantom `_shape`
+ * field carries the type parameter in an invariant position — so the concrete
+ * `ContextConfig<readonly [ScratchpadLayer]>` that `context()` infers is NOT
+ * assignable to the defaulted `ContextConfig<readonly ContextLayer[]>`. Any
+ * entry point that spells its parameter `ContextConfig | ContextLayer[]`
+ * therefore rejects the `context()` builder's own output.
+ *
+ * Every case below passes a `context([...])` result — with a real layer, so the
+ * inferred tuple is non-trivial and `_shape` is not `Record<string, never>` —
+ * straight into `spawn`, `withContext`, and the `StepSpawn`/`StepWithContext`
+ * literals. If any of those sites reverts to the `ContextConfig`-based union
+ * these calls stop compiling, failing `bun run typecheck` (this directory is
+ * inside the package tsconfig's `test/**\/*.ts` include).
+ *
+ * The bodies also assert at runtime that the config's layers reach the built
+ * step, so the pin fails loudly if the interpreter's `hasLayersField`
+ * discrimination stops unwrapping `{ layers }`.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import assert from 'node:assert';
+import type { ContextInput, ContextLayer } from '@noetic-tools/context';
+import { scratchpad } from '@noetic-tools/context';
+import type { Step, StepSpawn, StepWithContext } from '@noetic-tools/types';
+import { context } from '../../src/builders/context-builder';
+import { withContext } from '../../src/builders/provide-builder';
+import { spawn } from '../../src/builders/spawn-builder';
+import { runCode } from '../../src/builders/step-builders';
+
+function makeChild(id: string): Step<unknown, string, string> {
+  return runCode<unknown, string, string>({
+    id,
+    execute: async (input: string) => input,
+  });
+}
+
+/**
+ * Reads whichever `ContextInput` member was supplied back into a flat list.
+ * Discriminates with the same `!Array.isArray` shape the interpreter uses:
+ * `'layers' in value` alone does not narrow away the `ReadonlyArray` member.
+ */
+function hasLayersField(input: ContextInput): input is {
+  readonly layers: readonly ContextLayer[];
+} {
+  return !Array.isArray(input) && 'layers' in input;
+}
+
+function layersOf(input: ContextInput): readonly ContextLayer[] {
+  if (hasLayersField(input)) {
+    return input.layers;
+  }
+  return input;
+}
+
+describe('ContextInput accepts the context() builder output', () => {
+  it('spawn({ context: context([...]) }) compiles and carries the layers', () => {
+    const config = context([
+      scratchpad(),
+    ]);
+
+    const spawned = spawn({
+      id: 'spawn-with-config',
+      child: makeChild('spawn-with-config-child'),
+      context: config,
+    });
+
+    assert(spawned.context);
+    expect(layersOf(spawned.context).map((layer) => layer.id)).toEqual([
+      'scratchpad',
+    ]);
+  });
+
+  it('withContext({ context: context([...]) }) compiles and carries the layers', () => {
+    const config = context([
+      scratchpad(),
+    ]);
+
+    const provided = withContext({
+      id: 'with-context-config',
+      child: makeChild('with-context-config-child'),
+      context: config,
+    });
+
+    expect(layersOf(provided.context).map((layer) => layer.id)).toEqual([
+      'scratchpad',
+    ]);
+  });
+
+  it('StepSpawn and StepWithContext literals accept a config directly', () => {
+    const config = context([
+      scratchpad(),
+    ]);
+
+    const spawnStep: StepSpawn<unknown, string, string> = {
+      kind: 'spawn',
+      id: 'literal-spawn',
+      child: makeChild('literal-spawn-child'),
+      context: config,
+    };
+    const withContextStep: StepWithContext<unknown, string, string> = {
+      kind: 'withContext',
+      id: 'literal-with-context',
+      child: makeChild('literal-with-context-child'),
+      context: config,
+    };
+
+    assert(spawnStep.context);
+    expect(layersOf(spawnStep.context)).toHaveLength(1);
+    expect(layersOf(withContextStep.context)).toHaveLength(1);
+  });
+
+  it('a bare readonly layer array is still accepted', () => {
+    const layers: readonly ContextLayer[] = [
+      scratchpad(),
+    ];
+
+    const spawned = spawn({
+      id: 'spawn-with-readonly-array',
+      child: makeChild('spawn-with-readonly-array-child'),
+      context: layers,
+    });
+
+    assert(spawned.context);
+    expect(layersOf(spawned.context).map((layer) => layer.id)).toEqual([
+      'scratchpad',
+    ]);
+  });
+});

--- a/packages/core/test/interpreter/execute-provide.test.ts
+++ b/packages/core/test/interpreter/execute-provide.test.ts
@@ -295,9 +295,11 @@ describe('executeWithContext', () => {
             return 'done';
           },
         },
-        context: [
-          layer,
-        ],
+        context: {
+          layers: [
+            layer,
+          ],
+        },
       };
 
       await executeWithContext(step, 'input', ctx, simpleExecute);

--- a/packages/core/test/interpreter/execute-run.test.ts
+++ b/packages/core/test/interpreter/execute-run.test.ts
@@ -1,47 +1,15 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import assert from 'node:assert';
 import type { ContextData } from '@noetic-tools/context';
-import type { Context, StepRunCode } from '@noetic-tools/types';
+import type { Context, RetryPolicy, StepRunCode } from '@noetic-tools/types';
 import { isNoeticError, NoeticErrorImpl } from '@noetic-tools/types';
-import { executeRunCode } from '../../src/interpreter/execute-action';
+import { computeRetryDelay, executeRunCode } from '../../src/interpreter/execute-action';
 import { ContextImpl } from '../../src/runtime/context-impl';
 import { makeMockContext, makeMockHarness } from '../_helpers';
 
 const mockCtx: Context = makeMockContext();
 
-// Safety net: ensure setTimeout is always restored
-const _originalSetTimeout = globalThis.setTimeout;
-afterEach(() => {
-  globalThis.setTimeout = _originalSetTimeout;
-});
-
-/** Patch setTimeout to capture delay values and execute callbacks instantly. */
-function interceptDelays(): {
-  delays: number[];
-  restore: () => void;
-} {
-  const delays: number[] = [];
-  // Wrap the original to intercept delay values while preserving the full overloaded signature
-  const handler: ProxyHandler<typeof setTimeout> = {
-    apply(_target, thisArg, argsList: unknown[]) {
-      const delay = argsList[1];
-      if (typeof delay === 'number' && delay > 0) {
-        delays.push(delay);
-      }
-      argsList[1] = 1;
-      return Reflect.apply(_originalSetTimeout, thisArg, argsList);
-    },
-  };
-  globalThis.setTimeout = new Proxy(_originalSetTimeout, handler);
-  return {
-    delays,
-    restore: () => {
-      globalThis.setTimeout = _originalSetTimeout;
-    },
-  };
-}
-
-describe.serial('executeRunCode', () => {
+describe('executeRunCode', () => {
   it('calls execute function and returns output', async () => {
     const s: StepRunCode<ContextData, string, number> = {
       kind: 'runCode',
@@ -88,105 +56,81 @@ describe.serial('executeRunCode', () => {
   });
 
   it('retries with fixed backoff', async () => {
-    const { delays, restore } = interceptDelays();
-
     let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
+    const retry: RetryPolicy = {
+      maxAttempts: 3,
+      backoff: 'fixed',
+      initialDelay: 1,
+    };
+    const step: StepRunCode<ContextData, string, string> = {
       kind: 'runCode',
       id: 'retry-test',
-      execute: async (_input) => {
+      retry,
+      execute: async () => {
         attempts++;
         if (attempts < 3) {
           throw new Error('not yet');
         }
         return 'success';
       },
-      retry: {
-        maxAttempts: 3,
-        backoff: 'fixed',
-        initialDelay: 10,
-      },
     };
-    try {
-      const result = await executeRunCode(s, 'test', mockCtx);
-      expect(result).toBe('success');
-      expect(attempts).toBe(3);
-      // Fixed backoff: all delays should be 10
-      expect(delays).toEqual([
-        10,
-        10,
-      ]);
-    } finally {
-      restore();
-    }
+    expect(await executeRunCode(step, 'test', mockCtx)).toBe('success');
+    expect(attempts).toBe(3);
+    expect(
+      [
+        0,
+        1,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
+      1,
+      1,
+    ]);
   });
 
   it('retries with exponential backoff and exhausts', async () => {
-    const { delays, restore } = interceptDelays();
     let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
+    const retry: RetryPolicy = {
+      maxAttempts: 3,
+      backoff: 'exponential',
+      initialDelay: 1,
+    };
+    const step: StepRunCode<ContextData, string, string> = {
       kind: 'runCode',
       id: 'exhaust-test',
+      retry,
       execute: async () => {
         attempts++;
         throw new Error('always fails');
       },
-      retry: {
-        maxAttempts: 3,
-        backoff: 'exponential',
-        initialDelay: 10,
-      },
     };
-    try {
-      await executeRunCode(s, 'test', mockCtx);
-      expect.unreachable('should have thrown');
-    } catch (e) {
-      assert(isNoeticError(e));
-      const oe = e.noeticError;
-      assert(oe.kind === 'step_failed');
-      expect(oe.retriesExhausted).toBe(true);
-      expect(attempts).toBe(3);
-      expect(delays).toEqual([
-        10,
-        20,
-      ]);
-    } finally {
-      restore();
-    }
+    await expect(executeRunCode(step, 'test', mockCtx)).rejects.toThrow('always fails');
+    expect(attempts).toBe(3);
+    expect(
+      [
+        0,
+        1,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
+      1,
+      2,
+    ]);
   });
 
-  it('caps exponential backoff delay at maxDelay', async () => {
-    const { delays, restore } = interceptDelays();
-
-    let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
-      kind: 'runCode',
-      id: 'cap-test',
-      execute: async () => {
-        attempts++;
-        if (attempts < 5) {
-          throw new Error('fail');
-        }
-        return 'ok';
-      },
-      retry: {
-        maxAttempts: 5,
-        backoff: 'exponential',
-        initialDelay: 100,
-        maxDelay: 500,
-      },
+  it('caps exponential backoff delay at maxDelay', () => {
+    const retry: RetryPolicy = {
+      maxAttempts: 5,
+      backoff: 'exponential',
+      initialDelay: 100,
+      maxDelay: 500,
     };
-    try {
-      await executeRunCode(s, 'test', mockCtx);
-    } finally {
-      restore();
-    }
-    // Delays: 100, 200, 400, 500 (capped from 800)
-    for (const d of delays) {
-      expect(d).toBeLessThanOrEqual(500);
-    }
-    expect(delays.length).toBeGreaterThan(0);
-    expect(delays).toEqual([
+    expect(
+      [
+        0,
+        1,
+        2,
+        3,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
       100,
       200,
       400,
@@ -194,46 +138,26 @@ describe.serial('executeRunCode', () => {
     ]);
   });
 
-  it('defaults maxDelay to 30000', async () => {
-    // With exponential backoff, delay = 100 * 2^attempt
-    // For attempt 9: 100 * 512 = 51200, should be capped at 30000
-    const { delays, restore } = interceptDelays();
-
-    let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
-      kind: 'runCode',
-      id: 'default-cap-test',
-      execute: async () => {
-        attempts++;
-        if (attempts < 11) {
-          throw new Error('fail');
-        }
-        return 'ok';
-      },
-      retry: {
-        maxAttempts: 11,
-        backoff: 'exponential',
-        initialDelay: 100,
-      },
+  it('defaults maxDelay to 30000', () => {
+    const retry: RetryPolicy = {
+      maxAttempts: 11,
+      backoff: 'exponential',
+      initialDelay: 100,
     };
-    try {
-      await executeRunCode(s, 'test', mockCtx);
-    } finally {
-      restore();
-    }
-    for (const d of delays) {
-      expect(d).toBeLessThanOrEqual(30_000);
-    }
-    expect(delays.length).toBeGreaterThan(0);
+    expect(computeRetryDelay(retry, 9)).toBe(30_000);
   });
 
   it('retries with linear backoff', async () => {
-    const { delays, restore } = interceptDelays();
-
     let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
+    const retry: RetryPolicy = {
+      maxAttempts: 3,
+      backoff: 'linear',
+      initialDelay: 1,
+    };
+    const step: StepRunCode<ContextData, string, string> = {
       kind: 'runCode',
       id: 'linear-test',
+      retry,
       execute: async () => {
         attempts++;
         if (attempts < 3) {
@@ -241,24 +165,18 @@ describe.serial('executeRunCode', () => {
         }
         return 'ok';
       },
-      retry: {
-        maxAttempts: 3,
-        backoff: 'linear',
-        initialDelay: 10,
-      },
     };
-    try {
-      const result = await executeRunCode(s, 'test', mockCtx);
-      expect(result).toBe('ok');
-      expect(attempts).toBe(3);
-      // Linear backoff: delay = initialDelay * attempt
-      expect(delays).toEqual([
-        10,
-        20,
-      ]);
-    } finally {
-      restore();
-    }
+    expect(await executeRunCode(step, 'test', mockCtx)).toBe('ok');
+    expect(attempts).toBe(3);
+    expect(
+      [
+        0,
+        1,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
+      1,
+      2,
+    ]);
   });
 
   describe('cancellation (not retriable)', () => {

--- a/packages/core/test/interpreter/execute-run.test.ts
+++ b/packages/core/test/interpreter/execute-run.test.ts
@@ -41,7 +41,7 @@ function interceptDelays(): {
   };
 }
 
-describe('executeRunCode', () => {
+describe.serial('executeRunCode', () => {
   it('calls execute function and returns output', async () => {
     const s: StepRunCode<ContextData, string, number> = {
       kind: 'runCode',

--- a/packages/types/src/types/context-layer.ts
+++ b/packages/types/src/types/context-layer.ts
@@ -119,6 +119,29 @@ export interface ContextConfig<TLayers extends readonly ContextLayer[] = readonl
 }
 
 /**
+ * What every context-accepting entry point takes: either a bare list of layers
+ * or anything carrying a `layers` list — notably the `ContextConfig` the
+ * `context()` builder returns.
+ *
+ * Declared structurally rather than as `ContextConfig | ContextLayer[]` because
+ * `ContextConfig` is **invariant** in `TLayers`: the phantom `_shape` field puts
+ * `TLayers` in an invariant position, so the concrete
+ * `ContextConfig<readonly [SomeLayer]>` that `context()` infers is not
+ * assignable to the defaulted `ContextConfig<readonly ContextLayer[]>`.
+ * Spelling the union as `ContextConfig | ContextLayer[]` therefore rejects the
+ * builder's own output at its primary destination. Matching on the `layers`
+ * field instead accepts every config the builder produces while still refusing
+ * unrelated objects.
+ *
+ * @public
+ */
+export type ContextInput =
+  | ReadonlyArray<ContextLayer>
+  | {
+      readonly layers: ReadonlyArray<ContextLayer>;
+    };
+
+/**
  * Extract the typed context shape from a ContextConfig.
  * Constrains structurally on the phantom `_shape` field rather than on
  * `ContextConfig` itself: `ContextConfig` is invariant in `TLayers` (the `_shape`

--- a/packages/types/src/types/step.ts
+++ b/packages/types/src/types/step.ts
@@ -2,7 +2,7 @@ import type { StandardSchemaV1 } from '@standard-schema/spec';
 import type { Channel } from './channel';
 import type { ModelParams, RetryPolicy, ServerToolSpec, StepMeta } from './common';
 import type { Context } from './context';
-import type { ContextConfig, ContextData, ContextLayer, ProjectionPolicy } from './context-layer';
+import type { ContextData, ContextInput, ProjectionPolicy } from './context-layer';
 import type { NoeticError } from './error';
 import type { OutputCodec } from './output-codec';
 import type {
@@ -244,7 +244,7 @@ export interface StepWithContext<TContext = ContextData, I = unknown, O = unknow
   kind: 'withContext';
   id: string;
   child: Step<TContext, I, O>;
-  context: ContextConfig | ContextLayer[];
+  context: ContextInput;
 }
 
 /** @public A step that launches a child execution with its own context scope. */
@@ -252,7 +252,7 @@ export interface StepSpawn<TContext = ContextData, I = unknown, O = unknown> {
   kind: 'spawn';
   id: string;
   child: Step<TContext, I, O>;
-  context?: ContextConfig | ContextLayer[];
+  context?: ContextInput;
   timeout?: number;
   /**
    * Per-step subprocess adapter override applied when the interpreter

--- a/packages/web/content/docs/framework/api/context-layer-types.mdx
+++ b/packages/web/content/docs/framework/api/context-layer-types.mdx
@@ -431,10 +431,16 @@ type ContextData = Readonly<Record<string, Record<string, unknown>>>;
 A typed context configuration that carries a phantom `_shape` for compile-time context access. Created via the `context()` builder.
 
 ```ts validate=none
-interface ContextConfig<TLayers extends ContextLayer[] = ContextLayer[]> {
-  layers: TLayers;
-  _shape: InferContextShape<TLayers>;
+interface ContextConfig<
+  TLayers extends readonly ContextLayer[] = readonly ContextLayer[],
+> {
+  readonly layers: TLayers;
+  readonly _shape: InferContextShape<TLayers>;
 }
+
+type ContextInput =
+  | ReadonlyArray<ContextLayer>
+  | { readonly layers: ReadonlyArray<ContextLayer> };
 ```
 
 | Field | Type | Description |

--- a/packages/web/content/docs/framework/api/step-types.mdx
+++ b/packages/web/content/docs/framework/api/step-types.mdx
@@ -136,7 +136,7 @@ inParallel has three mode variants, each a separate interface.
 | `kind` | `'withContext'` | yes | Discriminant |
 | `id` | `string` | yes | Step identifier |
 | `child` | `Step<TContext, I, O>` | yes | Child step to execute with the provided layers |
-| `context` | `ContextConfig \| ContextLayer[]` | yes | Context layers available to all descendant steps |
+| `context` | `ContextInput` | yes | Context layers available to all descendant steps. Accepts a layer array or a `context()` config. |
 
 ## StepSpawn
 
@@ -147,7 +147,7 @@ inParallel has three mode variants, each a separate interface.
 | `kind` | `'spawn'` | yes | Discriminant |
 | `id` | `string` | yes | Step identifier |
 | `child` | `Step<TContext, I, O>` | yes | Child step to execute |
-| `context` | `ContextConfig \| ContextLayer[]` | no | Spawn-local context layers |
+| `context` | `ContextInput` | no | Spawn-local context layers. Accepts a layer array or a `context()` config. |
 | `timeout` | `number` | no | Timeout in milliseconds |
 
 ## StepLoop

--- a/packages/web/content/docs/framework/operators/spawn.mdx
+++ b/packages/web/content/docs/framework/operators/spawn.mdx
@@ -32,13 +32,13 @@ This is the primitive for sub-agents, delegation, and sandboxed execution.
 | --- | --- | --- | --- |
 | `id` | `string` | Yes | Unique step identifier |
 | `child` | `Step<TContext, I, O>` | Yes | The step to execute in isolation |
-| `context` | `ContextConfig \| ContextLayer[]` | No | Spawn-local context layers (use the `context()` builder for typed access) |
+| `context` | `ContextInput` | No | Spawn-local context layers (use the `context()` builder for typed access) |
 | `timeout` | `number` | No | Timeout in milliseconds |
 | `subprocess` | `SubprocessAdapter` | No | Per-step adapter override; see [SubprocessAdapter Routing](#subprocessadapter-routing) below. |
 
 ## Context Layers
 
-The `context` field accepts either a raw `ContextLayer[]` array or a `ContextConfig` object produced by the `context()` builder. The builder provides typed access to layer state and is the recommended approach.
+The `context` field accepts a `ContextInput`: either a raw `ContextLayer[]` array or a `ContextConfig` object produced by the `context()` builder. The builder provides typed access to layer state and is the recommended approach.
 
 Spawn-local context layers control what the child sees and how results are transformed when the child completes.
 

--- a/packages/web/content/docs/framework/operators/with-context.mdx
+++ b/packages/web/content/docs/framework/operators/with-context.mdx
@@ -33,7 +33,7 @@ This is the primitive for scoping context layers to a section of your execution 
 | --- | --- | --- | --- |
 | `id` | `string` | Yes | Unique step identifier |
 | `child` | `Step<TContext, I, O>` | Yes | The step to execute with the provided layers |
-| `context` | `ContextConfig \| ContextLayer[]` | Yes | Context layers available to all descendant steps |
+| `context` | `ContextInput` | Yes | Context layers available to all descendant steps. Accepts a layer array or a `context()` config. |
 
 ## Example: Scoped Knowledge Layer
 

--- a/specs/01-step-type.md
+++ b/specs/01-step-type.md
@@ -16,8 +16,8 @@ type Step<I, O> =
   | { kind: 'invokeTool';    id: string; tool: Tool; args?: unknown }
   | { kind: 'conditional';  id: string; route: (input: I, ctx: Context) => Step<I, O> | null }
   | { kind: 'inParallel';    id: string; mode: 'all' | 'race' | 'settle'; paths: (input: I, ctx: Context) => Step<I, O>[]; merge?: MergeFn<O>; concurrency?: number }
-  | { kind: 'spawn';   id: string; child: Step<I, O>; context?: ContextLayer[]; timeout?: number; subprocess?: SubprocessAdapter }
-  | { kind: 'withContext'; id: string; child: Step<I, O>; context: ContextConfig | ContextLayer[] }
+  | { kind: 'spawn';   id: string; child: Step<I, O>; context?: ContextInput; timeout?: number; subprocess?: SubprocessAdapter }
+  | { kind: 'withContext'; id: string; child: Step<I, O>; context: ContextInput }
   | { kind: 'loop';    id: string; steps: ReadonlyArray<Step<I, O>>; until: Until; maxIterations?: number; maxHistorySize?: number; prepareNext?: (output: O, verdict: Verdict, ctx: Context) => I; onError?: (error: NoeticError, ctx: Context) => 'retry' | 'skip' | 'abort' }
 ```
 

--- a/specs/02-step-variants.md
+++ b/specs/02-step-variants.md
@@ -256,9 +256,11 @@ Attaches context layers to a descendant step subtree without creating an isolate
 interface StepWithContextOpts<TContext, I, O> {
   id: string;
   child: Step<TContext, I, O>;
-  context: ContextConfig | ContextLayer[];
+  context: ContextInput;
 }
 ```
+
+`ContextInput` is `ReadonlyArray<ContextLayer> | { readonly layers: ReadonlyArray<ContextLayer> }` — a bare layer list or anything carrying one, notably the `ContextConfig` that `context()` returns. It is spelled structurally rather than as `ContextConfig | ContextLayer[]` because `ContextConfig` is invariant in its `TLayers` parameter (the phantom `_shape` field), so the concrete config `context()` infers is not assignable to the defaulted `ContextConfig<readonly ContextLayer[]>`.
 
 ```typescript
 const withContextLayers = withContext({

--- a/specs/04-spawn.md
+++ b/specs/04-spawn.md
@@ -13,7 +13,7 @@
 interface SpawnOpts<I, O> {
   id: string;
   child: Step<I, O>;
-  context?: ContextLayer[];
+  context?: ContextInput;
   timeout?: number;
   /**
    * Per-step subprocess adapter override. Takes precedence over the harness

--- a/specs/11-context-layer-system.md
+++ b/specs/11-context-layer-system.md
@@ -2,7 +2,7 @@
 
 > **Module:** `@noetic-tools/context` (source at `packages/context/src/**`); the `ContextLayer` contract is owned by `@noetic-tools/types` (`packages/types/src/types/context-layer.ts`, also at the `@noetic-tools/types/contract` subpath). Both are re-exported by `@noetic-tools/core`.
 > **Depends On:** `07-context-and-event-log` (ItemLog, Item — type import only), `10-observability` (LayerTraceSpan, trace conventions), `04-spawn` (SpawnOpts — referenced in SpawnParams)
-> **Exports:** `ContextLayer`, `ContextLayerHooks`, `ContextScope`, `BudgetConfig`, `Slot`, `InitParams`, `InitResult`, `RecallParams`, `RecallResult`, `StoreParams`, `StoreResult`, `SpawnParams`, `SpawnResult`, `ReturnParams`, `ReturnResult`, `CompleteParams`, `DisposeParams`, `BeforeToolCallParams`, `BeforeToolCallResult`, `AfterModelCallParams`, `AfterModelCallResult`, `OnItemAppendParams`, `OnItemAppendResult`, `RerenderScope`, `ParentUpdateParams`, `ParentUpdateResult`, `ExecutionOutcome`, `ExecutionContext`, `ScopedStorage`, `StorageAdapter`, `ProjectionPolicy`, `LayerTimeouts`, `LayerProvides`, `LayerDataDecl`, `LayerFunctionDecl`, `ContextConfig`, `InferContext`, `InferContextShape`, `layerData`, `layerFunction`, `context`, `storageGetMany`, `LayerPlacement`, `RenderDeltaParams`, `ContextCacheConfig`, `ContextCacheStore`, `ContextEpoch`, `AnchorPin`, `LayerChurn`, `ReanchorReason`
+> **Exports:** `ContextLayer`, `ContextLayerHooks`, `ContextScope`, `BudgetConfig`, `Slot`, `InitParams`, `InitResult`, `RecallParams`, `RecallResult`, `StoreParams`, `StoreResult`, `SpawnParams`, `SpawnResult`, `ReturnParams`, `ReturnResult`, `CompleteParams`, `DisposeParams`, `BeforeToolCallParams`, `BeforeToolCallResult`, `AfterModelCallParams`, `AfterModelCallResult`, `OnItemAppendParams`, `OnItemAppendResult`, `RerenderScope`, `ParentUpdateParams`, `ParentUpdateResult`, `ExecutionOutcome`, `ExecutionContext`, `ScopedStorage`, `StorageAdapter`, `ProjectionPolicy`, `LayerTimeouts`, `LayerProvides`, `LayerDataDecl`, `LayerFunctionDecl`, `ContextConfig`, `ContextInput`, `InferContext`, `InferContextShape`, `layerData`, `layerFunction`, `context`, `storageGetMany`, `LayerPlacement`, `RenderDeltaParams`, `ContextCacheConfig`, `ContextCacheStore`, `ContextEpoch`, `AnchorPin`, `LayerChurn`, `ReanchorReason`
 
 ## Module Boundary
 
@@ -633,6 +633,16 @@ interface ContextConfig<TLayers extends readonly ContextLayer[] = readonly Conte
 ```typescript
 type InferContext<T extends ContextConfig> = T['_shape'];
 ```
+
+Every context-accepting entry point (`spawn`, `withContext`, and their step interfaces) spells its parameter `ContextInput` rather than `ContextConfig | ContextLayer[]`:
+
+```typescript
+type ContextInput =
+  | ReadonlyArray<ContextLayer>
+  | { readonly layers: ReadonlyArray<ContextLayer> };
+```
+
+`ContextConfig` is invariant in `TLayers` (the phantom `_shape` field carries it in an invariant position), so the concrete `ContextConfig<readonly [SomeLayer]>` that `context()` infers is not assignable to the defaulted `ContextConfig<readonly ContextLayer[]>`. Matching structurally on the `layers` field accepts every config the builder produces while still refusing unrelated objects.
 
 `TContext` is the first generic parameter on `Step` and `Context`, enabling end-to-end type safety:
 

--- a/specs/13-patterns.md
+++ b/specs/13-patterns.md
@@ -62,7 +62,7 @@ function react(opts: {
   tools: Tool[];
   maxSteps?: number;
   maxCost?: number;
-  context?: ContextConfig | ContextLayer[];
+  context?: ContextInput;
 }) {
   const llmStep = callModel({
     id: 'react-step',

--- a/specs/15-build-sequence.md
+++ b/specs/15-build-sequence.md
@@ -23,7 +23,7 @@ The discriminated union `Step` type and the `execute` interpreter. Get the core 
 
 **Specs:** `04-spawn`
 
-`spawn`, where the child starts with an empty `ItemLog` and the optional `context` (a `ContextConfig` or `ContextLayer[]`) replaces the parent's layers for the child. Write a **verify-and-retry** loop: a spawned attempt, a verdict on its output, and a retry that feeds the failure back in. This forces context isolation and the `prepareNext` feedback loop. State persistence across spawn boundaries is deferred to Stage 7 (context layers).
+`spawn`, where the child starts with an empty `ItemLog` and the optional `context` (`ContextInput`) replaces the parent's layers for the child. Write a **verify-and-retry** loop: a spawned attempt, a verdict on its output, and a retry that feeds the failure back in. This forces context isolation and the `prepareNext` feedback loop. State persistence across spawn boundaries is deferred to Stage 7 (context layers).
 
 ## Stage 4: Channels and External Channels
 


### PR DESCRIPTION
## What

- add structural `ContextInput` (`readonly ContextLayer[]` or any object with readonly `layers`)
- accept it at `spawn` and `withContext` type/runtime seams
- make `context([...])` output directly assignable without losing its inferred shape
- update example helper seams, specs, docs, and agent-builder references

## Why

`ContextConfig` preserves exact layer types and is therefore invariant. The output of the public `context()` builder was not assignable to the `context` option on the builders it is meant to feed. A shallow structural input type preserves inference while giving attachment seams the minimum shape they need.

This semantically ports `fork/port/openrouter-fixes` commit `efc2b689` onto post-#68 `withContext`/current names without restoring deleted bundled patterns.

## Test plan

- [x] compile/runtime ContextInput tests — 13 pass
- [x] types/context/core typechecks
- [x] examples typecheck
- [x] root lint
- [x] export-tag check
- [x] `sentrux check .`
- [x] clean-context Pi review; fixed docs, delegate helper seam, and object-branch runtime coverage

## Compatibility

Additive type widening only. Existing arrays and `ContextConfig` values remain valid.
