### PR TITLE
fix(core): reap channels and streamline control dispatch

### DIFF
--- a/packages/core/src/adapters/in-memory-subprocess-adapter.ts
+++ b/packages/core/src/adapters/in-memory-subprocess-adapter.ts
@@ -42,6 +42,11 @@ export function createInMemorySubprocessAdapter(
   options: CreateInMemorySubprocessAdapterOptions = {},
 ): SubprocessAdapter {
   const handles = new Map<string, SubprocessHandle>();
+  const inlineEligible =
+    options.storage === undefined &&
+    options.run === undefined &&
+    options.stepRunner === undefined &&
+    options.metadataInjector === undefined;
   const active = new Set<string>();
   const storage = options.storage;
 
@@ -168,7 +173,7 @@ export function createInMemorySubprocessAdapter(
     };
   }
 
-  return {
+  const adapter: SubprocessAdapter = {
     async spawn(request) {
       if (isStepRequest(request)) {
         return spawnStepHandle(request);
@@ -278,6 +283,13 @@ export function createInMemorySubprocessAdapter(
       ];
     },
   };
+  // In-process + no durable manifests ⇒ dispatch may inline (see execute.ts).
+  // Non-enumerable so it never leaks into spreads or JSON.
+  Object.defineProperty(adapter, '_inline', {
+    value: inlineEligible,
+    enumerable: false,
+  });
+  return adapter;
 }
 
 //#endregion

--- a/packages/core/src/interpreter/execute-control.ts
+++ b/packages/core/src/interpreter/execute-control.ts
@@ -700,6 +700,12 @@ export async function executeLoop<TContext, I, O>(
     if (history.length > maxHistory) {
       history.splice(0, history.length - maxHistory);
     }
+    // One frozen view per iteration, shared with the snapshot below. The old
+    // per-snapshot spread copied the whole array every verdict evaluation —
+    // O(history) per iteration for mutation protection freeze() gives for free.
+    const frozenHistory = Object.freeze([
+      ...history,
+    ]);
 
     // Extract text from output for snapshot
     if (typeof output === 'string') {
@@ -720,9 +726,7 @@ export async function executeLoop<TContext, I, O>(
       cost: ctx.cost,
       lastOutput: output,
       lastText,
-      history: [
-        ...history,
-      ],
+      history: frameworkCast<unknown[]>(frozenHistory),
       depth: ctx.depth,
       lastStepMeta: isMutableContext(baseCtx) ? baseCtx.lastStepMeta : null,
     };
@@ -775,18 +779,57 @@ export async function executeLoop<TContext, I, O>(
 interface ParkContext<TContext> {
   ms: number;
   jitter: number;
+  /** Jitter seed (the step id) — see `jitterFactor`. */
+  seed: string;
+  /** Iteration counter, so successive parks land on different phases. */
+  iteration: number;
   inbox?: Channel<unknown>;
   ctx: Context<TContext>;
   channelStore?: ChannelStore;
 }
 
-/** Returns the next park duration in ms, applying random jitter clamped to `[ms - jitter, ms + jitter]`. */
-function nextParkMs(ms: number, jitter: number): number {
+/**
+ * Deterministic jitter: FNV-1a over `(seed, iteration)` mapped to [-1, 1).
+ * `Math.random()` here would make park durations differ between a run and its
+ * durable replay — the same nondeterminism the workflow runtime bans from
+ * scripts. Hash-based jitter keeps the fleet-desynchronization property
+ * (different step ids → different phases) while staying replayable.
+ *
+ * The murmur3 finalizer is load-bearing, not decoration: bare FNV-1a over
+ * `${seed}#${iteration}` only perturbs the trailing digit, so consecutive
+ * iterations of one seed land within ~0.04 of each other and the step would
+ * park at a near-constant offset instead of jittering. The avalanche step
+ * restores per-iteration spread.
+ */
+function jitterFactor(seed: string, iteration: number): number {
+  let h = 0x811c9dc5;
+  const input = `${seed}#${iteration}`;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  h ^= h >>> 16;
+  h = Math.imul(h, 0x85ebca6b);
+  h ^= h >>> 13;
+  h = Math.imul(h, 0xc2b2ae35);
+  h ^= h >>> 16;
+  // Unsigned 32-bit → [0, 1) → [-1, 1).
+  return ((h >>> 0) / 0x100000000) * 2 - 1;
+}
+
+interface NextParkParams {
+  ms: number;
+  jitter: number;
+  seed: string;
+  iteration: number;
+}
+
+/** Returns the next park duration in ms, applying deterministic jitter clamped to `[ms - jitter, ms + jitter]`. */
+function nextParkMs({ ms, jitter, seed, iteration }: NextParkParams): number {
   if (jitter <= 0) {
     return ms;
   }
-  // Math.random() returns [0, 1); shift to [-1, 1) so jitter is symmetric.
-  const offset = (Math.random() * 2 - 1) * jitter;
+  const offset = jitterFactor(seed, iteration) * jitter;
   const value = ms + offset;
   if (value < 0) {
     return 0;
@@ -800,7 +843,12 @@ function nextParkMs(ms: number, jitter: number): number {
  * the next iteration's abort check).
  */
 function park<TContext>(parkCtx: ParkContext<TContext>): Promise<void> {
-  const duration = nextParkMs(parkCtx.ms, parkCtx.jitter);
+  const duration = nextParkMs({
+    ms: parkCtx.ms,
+    jitter: parkCtx.jitter,
+    seed: parkCtx.seed,
+    iteration: parkCtx.iteration,
+  });
 
   return new Promise<void>((resolve) => {
     let settled = false;
@@ -900,6 +948,7 @@ export async function executeSchedule<TContext, I, O>(
   // Resolve once — the channel store reference is stable for the lifetime
   // of the every loop, no need to re-derive it per park.
   const channelStore = getContextChannelStore(ctx);
+  let iteration = 0;
 
   while (true) {
     if (ctx.aborted) {
@@ -927,6 +976,8 @@ export async function executeSchedule<TContext, I, O>(
     await park({
       ms: step.interval,
       jitter,
+      seed: step.id,
+      iteration: iteration++,
       inbox: step.inbox,
       ctx,
       channelStore,

--- a/packages/core/src/interpreter/execute.ts
+++ b/packages/core/src/interpreter/execute.ts
@@ -128,6 +128,15 @@ async function dispatchViaAdapter<TContext, I, O>(
   executor: () => Promise<O>,
 ): Promise<O> {
   const adapter = resolveStepAdapter(step, ctx);
+  // Fast path: the default in-memory adapter (no durable manifests) adds a
+  // handle + promise round-trip per step purely to funnel into
+  // `_localExecutor`. runCode is the hottest structural step — skip the
+  // plumbing when nothing durable can observe it. Adapters WITH storage (or
+  // out-of-process adapters) always take the full path so reattach manifests
+  // and handle bookkeeping stay intact.
+  if (adapter._inline === true) {
+    return executor();
+  }
   const request: StepSubprocessRequest = {
     kind: 'step',
     stepId: step.id,

--- a/packages/core/src/runtime/channel-store.ts
+++ b/packages/core/src/runtime/channel-store.ts
@@ -69,6 +69,16 @@ interface ChannelState<T> {
    * through `queueWaiters` instead and never appear here.
    */
   externalSubscribers: Set<ExternalSubscriber<T>>;
+  /**
+   * Live `subscribe()` readers holding a reference to THIS state object,
+   * across all modes. Queue-mode readers compete through `queueWaiters` and
+   * never appear in `externalSubscribers`, but their `takeShared`/`parkShared`
+   * closures still capture this object — so reaping the map entry while one is
+   * alive would fork the channel: internal senders would write to a freshly
+   * minted state while the orphaned reader parks forever on this one. Reaping
+   * is therefore gated on this reaching zero.
+   */
+  liveSubscribers: number;
 }
 
 export class ChannelStore {
@@ -98,6 +108,7 @@ export class ChannelStore {
         topicSubscribers: new Set(),
         wakeSubscribers: new Set(),
         externalSubscribers: new Set(),
+        liveSubscribers: 0,
       };
       this.channels.set(channel.name, frameworkCast<ChannelState<unknown>>(state));
     }
@@ -307,6 +318,7 @@ export class ChannelStore {
       case 'queue': {
         const head = this.dequeueHead(state);
         if (head) {
+          this.maybeReap(channel.name);
           return head.value;
         }
         // capacity-0 edge: senders can be parked while the queue is empty —
@@ -314,6 +326,7 @@ export class ChannelStore {
         if (state.pendingSenders.length > 0) {
           const sender = state.pendingSenders.shift()!;
           sender.resolve();
+          this.maybeReap(channel.name);
           return sender.value;
         }
         return this.waitWithTimeout(state.queueWaiters, channel.name, timeout, signal);
@@ -372,17 +385,24 @@ export class ChannelStore {
   tryRecv<T>(channel: Channel<T>): T | null {
     const state = this.getOrCreate(channel);
 
-    switch (state.mode) {
-      case 'value':
-        return state.hasValue ? state.currentValue! : null;
-      case 'queue': {
-        // Explicit head check (not `?? null`): a stored `undefined` must come
-        // back as `undefined`, distinguishable from the empty-queue sentinel.
-        const head = this.dequeueHead(state);
-        return head ? head.value : null;
+    // `finally` so the entry `getOrCreate` just minted for a probe of a
+    // never-used channel is freed too — polling an idle channel must not grow
+    // the store.
+    try {
+      switch (state.mode) {
+        case 'value':
+          return state.hasValue ? state.currentValue! : null;
+        case 'queue': {
+          // Explicit head check (not `?? null`): a stored `undefined` must come
+          // back as `undefined`, distinguishable from the empty-queue sentinel.
+          const head = this.dequeueHead(state);
+          return head ? head.value : null;
+        }
+        case 'topic':
+          return null;
       }
-      case 'topic':
-        return null;
+    } finally {
+      this.maybeReap(channel.name);
     }
   }
 
@@ -406,6 +426,11 @@ export class ChannelStore {
           clearTimeout(timer);
         }
         removeAbortListener?.();
+        // Deferred: a delivering path settles this waiter before splicing it
+        // out of `waiters`, so an immediate reap would still see it parked.
+        queueMicrotask(() => {
+          this.maybeReap(channelName);
+        });
       };
       const wrappedResolve = (v: T) => {
         cleanup();
@@ -540,6 +565,10 @@ export class ChannelStore {
           : undefined,
       onFinish: () => {
         state.externalSubscribers.delete(subscriber);
+        if (state.liveSubscribers > 0) {
+          state.liveSubscribers -= 1;
+        }
+        this.maybeReap(channel.name);
         const byExecution = this.subscribersByExecution.get(executionId);
         if (byExecution) {
           byExecution.delete(erased);
@@ -550,6 +579,9 @@ export class ChannelStore {
       },
     });
     const erased = frameworkCast<ExternalSubscriber<unknown>>(subscriber);
+    // Counted for every mode: queue readers are absent from
+    // `externalSubscribers` but still capture `state` in their closures.
+    state.liveSubscribers += 1;
     if (state.mode !== 'queue') {
       state.externalSubscribers.add(subscriber);
     }
@@ -563,6 +595,46 @@ export class ChannelStore {
     }
     byExecution.add(erased);
     return subscriber;
+  }
+
+  /**
+   * Free a channel entry that holds nothing and nobody is waiting on. Without
+   * this the map grows one entry per channel NAME for the store's lifetime,
+   * and callers that mint per-delegation channel names (uuid-suffixed inbox /
+   * outbox / result channels) leak unboundedly.
+   *
+   * Reuse after reaping is transparent: `getOrCreate` recreates the state with
+   * identical semantics, because everything that carried meaning is gone by
+   * definition. The predicate must stay exhaustive over every field that holds
+   * a value or a reference — see `liveSubscribers` for the subtle one.
+   */
+  private reapIfIdle<T>(name: string, state: ChannelState<T>): void {
+    if (
+      state.queue.length === 0 &&
+      !state.hasValue &&
+      state.valueWaiters.length === 0 &&
+      state.queueWaiters.length === 0 &&
+      state.pendingSenders.length === 0 &&
+      state.topicSubscribers.size === 0 &&
+      state.wakeSubscribers.size === 0 &&
+      state.externalSubscribers.size === 0 &&
+      state.liveSubscribers === 0
+    ) {
+      this.channels.delete(name);
+    }
+  }
+
+  /** Look up `name` and reap it if fully drained. */
+  private maybeReap(name: string): void {
+    const state = this.channels.get(name);
+    if (state) {
+      this.reapIfIdle(name, state);
+    }
+  }
+
+  /** @internal Live channel-state entries — the observable surface for reaping. */
+  get channelCount(): number {
+    return this.channels.size;
   }
 
   /** Shift the queue head and promote the oldest parked sender into the freed slot. */
@@ -764,11 +836,11 @@ class ExternalSubscriber<T> implements AsyncIterableIterator<T> {
       }
     }
     this.done = true;
-    this.opts.onFinish();
     for (const entry of this.parked.splice(0)) {
       entry.unpark();
       entry.settleDone();
     }
+    this.opts.onFinish();
     for (const waiter of this.waiters.splice(0)) {
       waiter({
         value: undefined,

--- a/packages/core/test/interpreter/execute-every.test.ts
+++ b/packages/core/test/interpreter/execute-every.test.ts
@@ -494,3 +494,90 @@ describe('executeSchedule', () => {
     ]);
   });
 });
+
+describe('deterministic park jitter', () => {
+  const originalSetTimeout = globalThis.setTimeout;
+
+  /** Capture the requested delay of every setTimeout while making each fire in 1ms. */
+  function interceptDelays(): {
+    delays: number[];
+    restore: () => void;
+  } {
+    const delays: number[] = [];
+    const handler: ProxyHandler<typeof setTimeout> = {
+      apply(target, thisArg, argsList: unknown[]) {
+        const delay = argsList[1];
+        if (typeof delay === 'number' && delay > 0) {
+          delays.push(delay);
+        }
+        argsList[1] = 1;
+        return Reflect.apply(target, thisArg, argsList);
+      },
+    };
+    globalThis.setTimeout = new Proxy(originalSetTimeout, handler);
+    return {
+      delays,
+      restore: () => {
+        globalThis.setTimeout = originalSetTimeout;
+      },
+    };
+  }
+
+  async function runParkedSchedule(stepId: string): Promise<number[]> {
+    const { delays, restore } = interceptDelays();
+    try {
+      const ctx = new ContextImpl({
+        harness: makeMockHarness(),
+      });
+      let count = 0;
+      const s = schedule<ContextData, void, void>({
+        id: stepId,
+        step: {
+          kind: 'runCode',
+          id: 'tick',
+          execute: async () => {
+            count++;
+            if (count >= 5) {
+              ctx.abort('done');
+            }
+          },
+        },
+        interval: 200,
+        jitter: 100,
+      });
+      await executeSchedule(s, undefined, ctx, simpleExecute).catch(() => {});
+      // The abort poll uses setInterval, so the only setTimeout delays inside
+      // the park window are the park durations themselves.
+      return delays.filter((d) => d >= 100 && d <= 300);
+    } finally {
+      restore();
+    }
+  }
+
+  it('same step id replays an identical park-duration sequence', async () => {
+    const a = await runParkedSchedule('det-jitter');
+    const b = await runParkedSchedule('det-jitter');
+    // 5 iterations, abort during the 5th body → 4 parks.
+    expect(a.length).toBe(4);
+    expect(a).toEqual(b);
+    // The avalanche pass keeps successive iterations decorrelated — without
+    // it bare FNV-1a would park every iteration at a near-constant offset.
+    expect(new Set(a).size).toBe(a.length);
+  });
+
+  it('different step ids land on different jitter phases', async () => {
+    const a = await runParkedSchedule('det-jitter-a');
+    const b = await runParkedSchedule('det-jitter-b');
+    expect(a.length).toBe(4);
+    expect(b.length).toBe(4);
+    expect(a).not.toEqual(b);
+  });
+
+  it('every park duration stays within [interval - jitter, interval + jitter]', async () => {
+    const delays = await runParkedSchedule('det-jitter-clamp');
+    for (const d of delays) {
+      expect(d).toBeGreaterThanOrEqual(100);
+      expect(d).toBeLessThanOrEqual(300);
+    }
+  });
+});

--- a/packages/core/test/interpreter/execute-loop.test.ts
+++ b/packages/core/test/interpreter/execute-loop.test.ts
@@ -874,3 +874,46 @@ describe('executeLoop inbox channel', () => {
     });
   });
 });
+
+describe('loop snapshot history', () => {
+  it('each iteration sees a frozen history view; later iterations cannot mutate earlier snapshots', async () => {
+    const snapshots: Snapshot[] = [];
+    const loopStep = loop<ContextData, number, number>({
+      id: 'frozen-history-loop',
+      steps: [
+        {
+          kind: 'runCode',
+          id: 'inc',
+          execute: async (input: number) => input + 1,
+        },
+      ],
+      until: (snapshot) => {
+        snapshots.push(snapshot);
+        return {
+          stop: snapshot.stepCount >= 3,
+        };
+      },
+    });
+
+    const ctx = new ContextImpl({
+      harness: makeMockHarness(),
+    });
+    await executeLoop(loopStep, 0, ctx, simpleExecute);
+
+    expect(snapshots.length).toBe(3);
+    for (const [i, snapshot] of snapshots.entries()) {
+      expect(Object.isFrozen(snapshot.history)).toBe(true);
+      expect(snapshot.history.length).toBe(i + 1);
+    }
+    // Snapshot 1's history must still read [1] after iterations 2 and 3 ran —
+    // the loop trims/pushes its live array, never a shared snapshot view.
+    expect(snapshots[0]?.history).toEqual([
+      1,
+    ]);
+    expect(snapshots[2]?.history).toEqual([
+      1,
+      2,
+      3,
+    ]);
+  });
+});

--- a/packages/core/test/runtime/channel-store.test.ts
+++ b/packages/core/test/runtime/channel-store.test.ts
@@ -675,3 +675,131 @@ describe('ChannelStore', () => {
     });
   });
 });
+
+describe('channel state reaping', () => {
+  it('frees a queue channel once fully drained, and recreates it transparently', async () => {
+    const store = new ChannelStore();
+    const ch = channel<string>('one-shot', {
+      schema: z.string(),
+      mode: 'queue',
+    });
+    await store.send(ch, 'a');
+    expect(store.channelCount).toBe(1);
+    expect(store.tryRecv(ch)).toBe('a');
+    // Drained → reaped.
+    expect(store.channelCount).toBe(0);
+    // Reuse after reap behaves like a fresh channel.
+    await store.send(ch, 'b');
+    expect(store.tryRecv(ch)).toBe('b');
+    expect(store.channelCount).toBe(0);
+  });
+
+  it('probing an idle channel with tryRecv does not grow the store', () => {
+    const store = new ChannelStore();
+    for (let i = 0; i < 100; i++) {
+      const ch = channel<string>(`probe-${i}`, {
+        schema: z.string(),
+        mode: 'queue',
+      });
+      expect(store.tryRecv(ch)).toBeNull();
+    }
+    expect(store.channelCount).toBe(0);
+  });
+
+  it('does NOT reap a channel holding buffered items, waiters, or a value', async () => {
+    const store = new ChannelStore();
+    const buffered = channel<string>('buffered', {
+      schema: z.string(),
+      mode: 'queue',
+    });
+    await store.send(buffered, 'kept');
+    const valueCh = channel<string>('val', {
+      schema: z.string(),
+      mode: 'value',
+    });
+    await store.send(valueCh, 'latest');
+    expect(store.channelCount).toBe(2);
+  });
+
+  it('a timed-out waiter leaves the channel reaped, not leaked', async () => {
+    const store = new ChannelStore();
+    const ch = channel<string>('waiter-timeout', {
+      schema: z.string(),
+      mode: 'queue',
+    });
+    await expect(store.recv(ch, 10)).rejects.toThrow();
+    // Reap is deferred a microtask after settle.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(store.channelCount).toBe(0);
+  });
+
+  it('never reaps under a live queue-mode stream, even after an internal recv times out', async () => {
+    // The hazard the naive predicate misses. A queue-mode subscriber is NOT in
+    // `externalSubscribers` (it competes through `queueWaiters`), but its
+    // takeShared/parkShared closures capture the state OBJECT. Reaping here
+    // would fork the channel: the later send lands on a freshly minted state
+    // and the subscriber's next() hangs forever.
+    const store = new ChannelStore();
+    const ch = channel<number>('live-stream-q', {
+      schema: z.number(),
+      mode: 'queue',
+      external: true,
+    });
+    const stream = store.subscribe(ch, 'exec-reap');
+    const iterator = stream[Symbol.asyncIterator]();
+
+    await expect(store.recv(ch, 10)).rejects.toThrow();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(store.channelCount).toBe(1);
+
+    const next = iterator.next();
+    await store.send(ch, 7);
+    expect((await next).value).toBe(7);
+
+    // Ending the stream releases the last reference, so the entry is freed.
+    await iterator.return?.();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(store.channelCount).toBe(0);
+  });
+
+  it('never reaps under a live topic-mode stream between sends', async () => {
+    const store = new ChannelStore();
+    const ch = channel<number>('live-stream-t', {
+      schema: z.number(),
+      mode: 'topic',
+      external: true,
+    });
+    const stream = store.subscribe(ch, 'exec-reap-topic');
+    const iterator = stream[Symbol.asyncIterator]();
+
+    store.send(ch, 1);
+    expect((await iterator.next()).value).toBe(1);
+    // Buffer drained, no waiters — but the subscriber is still live.
+    expect(store.channelCount).toBe(1);
+
+    store.send(ch, 2);
+    expect((await iterator.next()).value).toBe(2);
+
+    await iterator.return?.();
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(store.channelCount).toBe(0);
+  });
+
+  it('closeExecution releases the channel entry once buffered values drain', async () => {
+    const store = new ChannelStore();
+    const ch = channel<number>('close-reap', {
+      schema: z.number(),
+      mode: 'topic',
+      external: true,
+    });
+    const stream = store.subscribe(ch, 'exec-close-reap');
+    const iterator = stream[Symbol.asyncIterator]();
+    store.send(ch, 1);
+    expect((await iterator.next()).value).toBe(1);
+    expect(store.channelCount).toBe(1);
+
+    store.closeExecution('exec-close-reap');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    expect(store.channelCount).toBe(0);
+  });
+});

--- a/packages/core/test/runtime/subprocess-routing.test.ts
+++ b/packages/core/test/runtime/subprocess-routing.test.ts
@@ -15,7 +15,7 @@
  * tests; this file focuses on adapter routing end-to-end from `detachedSpawn`.
  */
 
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, spyOn } from 'bun:test';
 import assert from 'node:assert';
 import type { ContextData } from '@noetic-tools/context';
 import type {
@@ -28,6 +28,8 @@ import type {
 import { isNoeticError } from '@noetic-tools/types';
 import { createInMemorySubprocessAdapter } from '../../src/adapters/in-memory-subprocess-adapter';
 import { AgentHarness } from '../../src/harness/agent-harness';
+import { execute } from '../../src/interpreter/execute';
+import { createInMemoryStorage } from '../../src/runtime/in-memory-storage';
 
 //#region Recording adapter
 
@@ -270,3 +272,93 @@ describe('Phase A adapter routing', () => {
 });
 
 //#endregion
+
+describe('inline dispatch (_inline fast path)', () => {
+  it('storage-less in-memory adapter is marked _inline, non-enumerably', () => {
+    const adapter = createInMemorySubprocessAdapter();
+    expect(adapter._inline).toBe(true);
+    expect(Object.keys(adapter)).not.toContain('_inline');
+    expect(JSON.stringify(adapter)).not.toContain('_inline');
+  });
+
+  it('storage-backed in-memory adapter is NOT inline-eligible', () => {
+    const adapter = createInMemorySubprocessAdapter({
+      storage: createInMemoryStorage(),
+    });
+    expect(adapter._inline).toBe(false);
+  });
+
+  it('nested runCode dispatch skips adapter.spawn when nothing durable can observe it', async () => {
+    const adapter = createInMemorySubprocessAdapter();
+    const spawnSpy = spyOn(adapter, 'spawn');
+    const harness = new AgentHarness({
+      name: 'inline-dispatch',
+      params: {},
+      environment: {
+        subprocess: adapter,
+      },
+    });
+    const ctx = harness.createContext();
+    const step: Step<ContextData, string, string> = {
+      kind: 'runCode',
+      id: 'inline-step',
+      execute: async (input) => `echo:${input}`,
+    };
+
+    const result = await execute(step, 'hi', ctx);
+    expect(result).toBe('echo:hi');
+    expect(spawnSpy).not.toHaveBeenCalled();
+    spawnSpy.mockRestore();
+  });
+
+  it('nested runCode dispatch still routes through a storage-backed adapter', async () => {
+    const adapter = createInMemorySubprocessAdapter({
+      storage: createInMemoryStorage(),
+    });
+    const spawnSpy = spyOn(adapter, 'spawn');
+    const harness = new AgentHarness({
+      name: 'durable-dispatch',
+      params: {},
+      environment: {
+        subprocess: adapter,
+      },
+    });
+    const ctx = harness.createContext();
+    const step: Step<ContextData, string, string> = {
+      kind: 'runCode',
+      id: 'durable-step',
+      execute: async (input) => `echo:${input}`,
+    };
+
+    const result = await execute(step, 'hi', ctx);
+    expect(result).toBe('echo:hi');
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+    spawnSpy.mockRestore();
+  });
+
+  it('inline dispatch propagates the typed step_failed error directly', async () => {
+    const harness = new AgentHarness({
+      name: 'inline-throws',
+      params: {},
+    });
+    const ctx = harness.createContext();
+    const step: Step<ContextData, string, string> = {
+      kind: 'runCode',
+      id: 'inline-sync-throw',
+      execute: () => {
+        throw new Error('sync boom');
+      },
+    };
+
+    try {
+      await execute(step, 'irrelevant', ctx);
+      expect.unreachable('execute() should have rejected');
+    } catch (err) {
+      assert(isNoeticError(err));
+      const ne = err.noeticError;
+      assert(ne.kind === 'step_failed');
+      expect(ne.stepId).toBe('inline-sync-throw');
+      expect(ne.cause.message).toBe('sync boom');
+    }
+  });
+});

--- a/packages/types/src/types/subprocess-adapter.ts
+++ b/packages/types/src/types/subprocess-adapter.ts
@@ -196,6 +196,13 @@ export interface SubprocessAdapter {
    * persisted manifest.
    */
   listLive(): Promise<ReadonlyArray<SubprocessHandle>>;
+  /**
+   * @internal Set by an adapter that runs in-process and persists no durable
+   * manifests, so step dispatch may call the local executor directly instead
+   * of spawning a handle nothing can observe. Never set by out-of-process
+   * adapters or by any adapter given a `StorageAdapter`.
+   */
+  _inline?: boolean;
 }
 
 //#endregion

--- a/specs/05-loop-and-until.md
+++ b/specs/05-loop-and-until.md
@@ -204,7 +204,7 @@ interface ScheduleOptions<I, O> {
   interval: number;           // park duration between iterations (>= 0)
   inbox?: Channel<unknown>;   // any value on this channel wakes the park
   onError?: 'continue' | 'fail';   // default 'continue'
-  jitter?: number;            // ms of symmetric random jitter (>= 0, default 0)
+  jitter?: number;            // ms of symmetric deterministic jitter (>= 0, default 0)
 }
 
 schedule<I, O>(opts: ScheduleOptions<I, O>): StepSchedule<I, O>;
@@ -213,7 +213,7 @@ schedule<I, O>(opts: ScheduleOptions<I, O>): StepSchedule<I, O>;
 ### Semantics
 
 1. The first iteration starts immediately; the body step is invoked with `input`.
-2. After the body returns, `schedule` parks for `interval ± jitter` ms or until any value is sent on `inbox` — whichever happens first. The park observes the wake non-consumingly: a queue-mode wake message stays on the queue so the next iteration's body can drain it via `tryRecv`.
+2. After the body returns, `schedule` parks for `interval ± jitter` ms or until any value is sent on `inbox` — whichever happens first. The park observes the wake non-consumingly: a queue-mode wake message stays on the queue so the next iteration's body can drain it via `tryRecv`. Jitter is deterministic: the offset derives from a hash of `(step id, iteration)` (FNV-1a with a murmur3 finalizer for per-iteration avalanche), so a replayed run reproduces the same park-duration sequence while distinct step ids still desynchronize across a fleet.
 3. The park resolves immediately when the executing context is aborted; the next iteration's abort check then surfaces a `cancelled` `NoeticError`.
 4. The operator output is `void`. `schedule` does not accumulate iteration outputs.
 5. `schedule` only terminates by throw — either `cancelled` from abort, or the body's error under `onError: 'fail'`.

--- a/specs/06-channels.md
+++ b/specs/06-channels.md
@@ -218,7 +218,7 @@ Channels are scoped to the harness, not to a boundary within it. Channel state l
 
 ### Lifecycle
 
-Channels are created on first reference and garbage-collected when the execution tree completes. Queue channels buffer indefinitely within an execution (bounded by `capacity`, default 1000 items). When the buffer is full, internal senders block (back-pressure); external senders drop oldest (see above). Topic channels are ephemeral — items are delivered to currently-waiting receivers and dropped if no one is listening.
+Channels are created on first reference and garbage-collected when the execution tree completes. Additionally, a channel entry whose state is fully drained — empty queue, no held value, no parked waiters or senders, no topic/wake subscribers, no external registration, and no live stream readers — is reaped immediately rather than retained for the store's lifetime, so per-delegation channel names (e.g. uuid-suffixed one-shot channels) do not leak. Reuse after reaping is transparent: the next reference recreates an identical fresh state. Queue channels buffer indefinitely within an execution (bounded by `capacity`, default 1000 items). When the buffer is full, internal senders block (back-pressure); external senders drop oldest (see above). Topic channels are ephemeral — items are delivered to currently-waiting receivers and dropped if no one is listening.
 
 ### Default Timeout and Deadlock Prevention
 

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -199,6 +199,8 @@ interface SubprocessAdapter {
 }
 ```
 
+An adapter that runs step requests in-process and persists no durable manifests (the storage-less in-memory adapter) may additionally mark itself `@internal _inline`, in which case the interpreter's nested `runCode`/`spawn` dispatch calls the local executor directly instead of round-tripping a handle nothing durable could observe. Adapters with storage, and all out-of-process adapters, always take the full spawn path.
+
 `createInMemorySubprocessAdapter(opts?)` is the default test double. It dispatches step requests through the in-process execute pipeline via a closure the interpreter attaches to the request, records the handle in memory, and settles synchronously on the microtask queue. Options:
 
 - `storage?: StorageAdapter` — when supplied, the adapter persists handle manifests through the store so `listLive()` survives adapter re-creation within the process lifetime. `reattach()` is implemented as an idempotent replay of the persisted step request; "reattach" here is honestly a test-double semantic rather than a process resume, consistent with the adapter's role as the default in-process backend.


### PR DESCRIPTION
## What

- reap idle channel state without dropping buffered values, waiters, senders, or live subscribers
- build one frozen loop-history snapshot per iteration
- replace random park jitter with deterministic step-id/iteration jitter
- inline dispatch only for the bare ephemeral in-memory subprocess adapter

## Why

Per-delegation channels accumulated for the harness lifetime, loop snapshots recopied history for each predicate, random jitter made replay nondeterministic, and ephemeral in-memory dispatch paid a handle round trip with nothing durable observing it.

This semantically ports the item-11 portion of `fork/port/openrouter-fixes` commit `27ddda8e` onto current names. It deliberately excludes [#69](https://github.com/mattapperson/noetic/pull/69) EventBroadcaster and generator-yield behavior.

## Test plan

- [x] 98 focused channel/control/subprocess tests pass
- [x] core/types typechecks
- [x] root lint
- [x] `sentrux check .`
- [x] `sentrux gate .`
- [x] source worker full core suite — 1,462 pass
- [x] clean-context Pi review; fixed parked-stream reap order and narrowed inline eligibility

## Compatibility

The default ephemeral in-memory adapter may dispatch nested steps inline. Adapters with storage or custom hooks continue through `spawn()`.
