### PR TITLE
feat(context): add explicit history compaction primitives

### DIFF
--- a/.claude/skills/noetic-agent-builder/references/api-reference.md
+++ b/.claude/skills/noetic-agent-builder/references/api-reference.md
@@ -439,6 +439,7 @@ interface ProjectionPolicy {
   overflow: 'truncate' | 'summarize' | 'sliding_window';
   overflowModel?: string;
   windowSize?: number;
+  compactAt?: number;  // folded-history threshold that arms compaction (default 80% of budget − reserve)
 }
 
 // Fallback when neither step nor harness configures one:
@@ -468,6 +469,8 @@ interface StepCallModel {
 
   Both layer bands arrive slot-ascending. The budget is claimed in this order: system items (never dropped), anchor output, live output, the tail, then the supersedes — with history taking whatever is left and keeping the most recent turns. Within a layer band each non-fitting item is dropped **individually** (later-slot items that still fit are kept); history is trimmed as a contiguous recent window and orphan tool calls are stripped at the boundary. Supersedes are never dropped — each corrects a pinned block already in the view, so dropping one would leave the model reading content known to be stale. History absorbs the cost instead.
 - `forceAtomicRecall: true` makes every layer atomic regardless of `recallMode`.
+
+**Compaction** is the explicit alternative to the assembler's silent front-drop: append a `CompactionItem` (`'noetic:compaction'`) to the log and the folded view collapses the replaced prefix to a `<compacted_history>` developer message while the raw log (checkpoints, forks) keeps everything. Helpers: `historyPressure(items, policy)` (measures the folded view against `compactAt`), `compactHistory({ log, keepRecent, summarize })` / `createCompaction(...)` (build the record — the caller supplies the summary and appends it via `compactionAsItem`), `foldCompactions(items)` (project the model view; run before `assembleView`), `hasCompaction(items)`.
 
 ### Prompt-cache anchoring (`placement`)
 

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -10,7 +10,9 @@ provides:
 - The **`ContextLayer` contract** — the interface every layer implements.
 - The **lifecycle, budget, and projection machinery** that converges layer
   outputs into the assembled LLM context (`assembleView`, `allocateBudgets`,
-  layer state stores, scoping).
+  layer state stores, scoping), plus the **compaction helpers**
+  (`foldCompactions`, `historyPressure`, `createCompaction`, `compactHistory`)
+  for replacing an old history prefix with a logged summary.
 - The **built-in layers**: instructions, history, scratchpad, observations,
   temporal, filesystem, plan, task state, tool calls, and steering.
 

--- a/packages/context/src/context/projector.ts
+++ b/packages/context/src/context/projector.ts
@@ -1,5 +1,10 @@
-import type { Item, ProjectionPolicy } from '@noetic-tools/types';
-import { estimateTokens } from '@noetic-tools/types';
+import type { CompactionItem, Item, ProjectionPolicy } from '@noetic-tools/types';
+import {
+  COMPACTION_ITEM_TYPE,
+  createMessage,
+  estimateTokens,
+  frameworkCast,
+} from '@noetic-tools/types';
 import { stripUnresolvedToolCalls } from './strip-unresolved';
 
 //#region Types
@@ -18,6 +23,36 @@ interface AssembleViewParams {
   policy?: ProjectionPolicy;
 }
 
+/** @public Result of measuring folded history against a compaction threshold. */
+export interface HistoryPressure {
+  /** Estimated tokens of the folded history. */
+  historyTokens: number;
+  /** The `compactAt` threshold in effect. */
+  compactAt: number;
+  /** True when historyTokens > compactAt — compaction should run. */
+  overThreshold: boolean;
+}
+
+/** @public Parameters for `createCompaction`. */
+export interface CreateCompactionParams {
+  /** The RAW item log the compaction indexes into. */
+  items: ReadonlyArray<Item>;
+  /** How many leading raw-log items the summary replaces. */
+  replacesUntil: number;
+  /** The summary that stands in for the replaced prefix. */
+  summary: string;
+}
+
+/** @public Parameters for `compactHistory`. */
+export interface CompactHistoryParams {
+  /** The RAW item log to compact. */
+  log: ReadonlyArray<Item>;
+  /** How many trailing raw-log items to leave uncompacted. */
+  keepRecent: number;
+  /** Produces the summary for the covered prefix. */
+  summarize: (replaced: ReadonlyArray<Item>) => string | Promise<string>;
+}
+
 //#endregion
 
 //#region Helpers
@@ -25,6 +60,18 @@ interface AssembleViewParams {
 /** Conservative per-item token estimate (serialized form ⇒ never under-counts). */
 function itemTokens(item: Item): number {
   return estimateTokens(JSON.stringify(item));
+}
+
+function isCompactionItem(item: Item): item is Item & CompactionItem {
+  return item.type === COMPACTION_ITEM_TYPE;
+}
+
+/** Render a compaction summary as a developer message the model can read. */
+function renderCompaction(compaction: CompactionItem): Item {
+  return createMessage(
+    `<compacted_history items="${compaction.replacedCount}">\n${compaction.summary}\n</compacted_history>`,
+    'developer',
+  );
 }
 
 function totalTokens(items: ReadonlyArray<Item>): number {
@@ -159,6 +206,141 @@ export function assembleView({
     ...deltaItems,
     ...tailItems,
   ];
+}
+
+/**
+ * @public Fold recorded compactions into a history view.
+ *
+ * The item log is append-only; a compaction is an ordinary logged item that
+ * declares "the first `replacesUntil` items are summarized by `summary`".
+ * Folding keeps the log immutable (checkpoints, forks, and audits see the full
+ * record) while the model sees `[summary, ...items after replacesUntil]`.
+ *
+ * When multiple compactions exist, the one with the highest `replacesUntil`
+ * wins (later compactions subsume earlier ones — their summaries were produced
+ * with the earlier summary already in view). Compaction items themselves never
+ * appear in the folded view; the winning one renders as a developer message.
+ *
+ * Runs BEFORE the band assembler, so a compaction genuinely reduces what
+ * `assembleView` has to fit — and therefore how much history it has to trim.
+ */
+export function foldCompactions(items: ReadonlyArray<Item>): Item[] {
+  let winner: CompactionItem | null = null;
+  for (const item of items) {
+    if (isCompactionItem(item) && (!winner || item.replacesUntil > winner.replacesUntil)) {
+      winner = item;
+    }
+  }
+  if (!winner) {
+    return items.filter((i) => !isCompactionItem(i));
+  }
+  const kept: Item[] = [
+    renderCompaction(winner),
+  ];
+  for (let i = winner.replacesUntil; i < items.length; i++) {
+    const item = items[i];
+    if (isCompactionItem(item)) {
+      continue;
+    }
+    kept.push(item);
+  }
+  // A fold boundary can strand a tool call whose output was compacted away
+  // (or vice versa); repair the seam the same way the trimmer does.
+  return stripUnresolvedToolCalls(kept);
+}
+
+/**
+ * @public Whether a log carries any compaction record.
+ *
+ * Lets a caller skip `foldCompactions` (and its copy) on the overwhelmingly
+ * common no-compaction path while still guaranteeing that a compaction item
+ * never reaches a provider un-folded.
+ */
+export function hasCompaction(items: ReadonlyArray<Item>): boolean {
+  return items.some(isCompactionItem);
+}
+
+/**
+ * @public Measure history pressure against the policy's compaction threshold.
+ *
+ * The caller surfaces `overThreshold` to whatever drives compaction. That is
+ * the complementary half of the band assembler's budget enforcement:
+ * `assembleView` still trims the oldest history when the view will not fit, but
+ * it does so silently. This says when the trim is coming, so the caller can
+ * compact — replacing the prefix with a summary — instead of losing it.
+ */
+export function historyPressure(
+  historyItems: ReadonlyArray<Item>,
+  policy: ProjectionPolicy,
+): HistoryPressure {
+  const historyTokens = totalTokens(foldCompactions(historyItems));
+  const compactAt =
+    policy.compactAt ??
+    Math.max(0, Math.floor((policy.tokenBudget - policy.responseReserve) * 0.8));
+  return {
+    historyTokens,
+    compactAt,
+    overThreshold: historyTokens > compactAt,
+  };
+}
+
+/**
+ * @public Build the compaction record for a history prefix.
+ *
+ * The caller supplies the summary (an LLM call, a heuristic, or a verbatim
+ * digest — compaction is a composition point, not engine policy) and appends
+ * the returned item to the log. Idempotent with respect to prior compactions:
+ * `replacesUntil` indexes the RAW log, including any earlier compaction items
+ * in the prefix, so stacking compactions is well-defined.
+ */
+export function createCompaction(params: CreateCompactionParams): CompactionItem {
+  const replaced = params.items.slice(0, params.replacesUntil);
+  const summaryTokens = estimateTokens(params.summary);
+  return {
+    id: crypto.randomUUID(),
+    type: COMPACTION_ITEM_TYPE,
+    status: 'completed',
+    replacesUntil: params.replacesUntil,
+    summary: params.summary,
+    replacedCount: replaced.length,
+    tokensSaved: Math.max(0, totalTokens(replaced) - summaryTokens),
+  };
+}
+
+/**
+ * @public Compact a log down to its most recent `keepRecent` items.
+ *
+ * A thin convenience over `createCompaction`: it works out `replacesUntil` from
+ * `keepRecent`, calls `summarize` with exactly the items being replaced, and
+ * returns the record for the CALLER to append (`ctx.itemLog.append(...)`).
+ * Appending is left to the caller because compaction is an explicit, logged
+ * decision — the projector never mutates a log behind the runtime's back.
+ *
+ * Returns `null` when there is nothing to compact.
+ */
+export async function compactHistory(params: CompactHistoryParams): Promise<CompactionItem | null> {
+  const replacesUntil = params.log.length - Math.max(0, params.keepRecent);
+  if (replacesUntil <= 0) {
+    return null;
+  }
+  const summary = await params.summarize(params.log.slice(0, replacesUntil));
+  return createCompaction({
+    items: params.log,
+    replacesUntil,
+    summary,
+  });
+}
+
+/**
+ * @public Append-safe view of a compaction record.
+ *
+ * `CompactionItem` is deliberately outside the `Item` union — nothing renders
+ * it directly, the projector folds it — but it must reach `ItemLog.append`,
+ * which takes an `Item`. This is the one sanctioned bridge; the item type is
+ * registered with the schema registry so the append validates.
+ */
+export function compactionAsItem(compaction: CompactionItem): Item {
+  return frameworkCast<Item>(compaction);
 }
 
 //#endregion

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,9 +121,12 @@ export { execute } from './interpreter/execute';
 /** @public */
 /** @public */
 export type {
+  CompactHistoryParams,
+  CreateCompactionParams,
   FactExtractor,
   FactSearcher,
   HistoryConfig,
+  HistoryPressure,
   ObservationsConfig,
   ObservationsState,
   PlanConfig,
@@ -151,9 +154,15 @@ export type {
 /** @public */
 /** @public */
 export {
+  compactHistory,
+  compactionAsItem,
+  createCompaction,
   filesystem,
   findFunctionCall,
+  foldCompactions,
+  hasCompaction,
   history,
+  historyPressure,
   instructions,
   observations,
   PlanPhase,

--- a/packages/core/test/context/_audit/lifecycle.test.ts
+++ b/packages/core/test/context/_audit/lifecycle.test.ts
@@ -13,9 +13,13 @@ import { readFileSync } from 'node:fs';
 import {
   allocateBudgets,
   assembleView,
+  compactionAsItem,
   completeLayers,
+  createCompaction,
   createLayerStateStore,
   disposeLayers,
+  foldCompactions,
+  historyPressure,
   initLayers,
   recallLayers,
   returnLayers,
@@ -23,7 +27,7 @@ import {
   spawnLayers,
   storeLayers,
 } from '@noetic-tools/context';
-import type { ContextLayer, Item } from '@noetic-tools/types';
+import type { ContextLayer, Item, ProjectionPolicy } from '@noetic-tools/types';
 import {
   makeCtx,
   makeItemLog,
@@ -225,6 +229,37 @@ describe('AUDIT-3 assembleView token cap', () => {
     // CORRECT: 'truncate' with a 100-token budget must drop items. Current code
     // only branches on 'sliding_window' → 'truncate' is a silent no-op.
     expect(view.length).toBeLessThan(500);
+  });
+
+  it('3c: the trim that AUDIT-3 relies on is observable, and compaction relieves it', () => {
+    // The complement of 3a: assembleView is allowed to drop history, but the
+    // caller must be able to see it coming and do something cheaper about it.
+    const history: Item[] = Array.from(
+      {
+        length: 500,
+      },
+      (_, i) => makeMessage('user', `msg-${i}`),
+    );
+    const policy: ProjectionPolicy = {
+      tokenBudget: 1_000,
+      responseReserve: 0,
+      overflow: 'sliding_window',
+    };
+    // 1. The pressure is visible BEFORE the assembler silently drops anything.
+    expect(historyPressure(history, policy).overThreshold).toBe(true);
+    // 2. A logged compaction relieves it...
+    const compaction = createCompaction({
+      items: history,
+      replacesUntil: 495,
+      summary: 'first 495 messages: greetings',
+    });
+    const withCompaction = [
+      ...history,
+      compactionAsItem(compaction),
+    ];
+    expect(historyPressure(withCompaction, policy).overThreshold).toBe(false);
+    // 3. ...by replacing the covered prefix with the summary, not discarding it.
+    expect(foldCompactions(withCompaction)).toHaveLength(1 + 5);
   });
 });
 

--- a/packages/core/test/context/compaction.test.ts
+++ b/packages/core/test/context/compaction.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, it } from 'bun:test';
+import assert from 'node:assert';
+import {
+  compactHistory,
+  compactionAsItem,
+  createCompaction,
+  foldCompactions,
+  hasCompaction,
+  historyPressure,
+} from '@noetic-tools/context';
+import type { Item, ProjectionPolicy } from '@noetic-tools/types';
+import {
+  COMPACTION_ITEM_TYPE,
+  estimateTokens,
+  frameworkCast,
+  isNoeticError,
+} from '@noetic-tools/types';
+import { ItemLogImpl } from '../../src/runtime/item-log-impl';
+import { makeFunctionCall, makeFunctionCallOutput, makeMessage } from '../_helpers';
+
+/** Extract the text of every message item in the view (for order assertions). */
+function viewTexts(view: Item[]): string[] {
+  const texts: string[] = [];
+  for (const item of view) {
+    assert(item.type === 'message');
+    const part = item.content[0];
+    assert('text' in part && typeof part.text === 'string');
+    texts.push(part.text.slice(0, 12));
+  }
+  return texts;
+}
+
+/** Read the rendered summary text out of a folded view's leading item. */
+function summaryTextOf(view: Item[]): string {
+  const head = view[0];
+  assert(head.type === 'message');
+  const part = head.content[0];
+  assert('text' in part && typeof part.text === 'string');
+  return part.text;
+}
+
+describe('foldCompactions', () => {
+  const history = [
+    makeMessage('user', 'old-1'),
+    makeMessage('assistant', 'old-2'),
+    makeMessage('user', 'old-3'),
+    makeMessage('user', 'recent-1'),
+  ];
+
+  it('passes history through when no compaction exists', () => {
+    expect(foldCompactions(history)).toEqual(history);
+  });
+
+  it('replaces the covered prefix with a rendered summary', () => {
+    const compaction = createCompaction({
+      items: history,
+      replacesUntil: 3,
+      summary: 'the user discussed old things',
+    });
+    const folded = foldCompactions([
+      ...history,
+      compactionAsItem(compaction),
+    ]);
+    expect(folded).toHaveLength(2); // summary + recent-1
+    expect(summaryTextOf(folded)).toContain('the user discussed old things');
+    expect(viewTexts(folded.slice(1))).toEqual([
+      'recent-1',
+    ]);
+  });
+
+  it('the highest replacesUntil wins when compactions stack', () => {
+    const first = createCompaction({
+      items: history,
+      replacesUntil: 2,
+      summary: 'first summary',
+    });
+    const log: Item[] = [
+      ...history,
+      compactionAsItem(first),
+      makeMessage('user', 'after-first'),
+    ];
+    const second = createCompaction({
+      items: log,
+      replacesUntil: 5, // covers history + first compaction
+      summary: 'second summary',
+    });
+    const folded = foldCompactions([
+      ...log,
+      compactionAsItem(second),
+    ]);
+    const summary = summaryTextOf(folded);
+    expect(summary).toContain('second summary');
+    expect(summary).not.toContain('first summary');
+    expect(viewTexts(folded.slice(1))).toEqual([
+      'after-first',
+    ]);
+  });
+
+  it('compaction items never leak into the folded view', () => {
+    const compaction = createCompaction({
+      items: history,
+      replacesUntil: 2,
+      summary: 's',
+    });
+    const folded = foldCompactions([
+      ...history,
+      compactionAsItem(compaction),
+    ]);
+    expect(folded.some((i) => i.type === COMPACTION_ITEM_TYPE)).toBe(false);
+  });
+
+  it('strips a tool call whose output the fold compacted away', () => {
+    // The call survives the fold boundary but its output does not — an
+    // unresolved call would make the provider reject the request.
+    const log: Item[] = [
+      makeFunctionCall('search', '{}', 'call-1'),
+      makeFunctionCallOutput('call_call-1', 'results'),
+      makeMessage('user', 'next'),
+    ];
+    const compaction = createCompaction({
+      items: log,
+      replacesUntil: 2,
+      summary: 'searched and got results',
+    });
+    const folded = foldCompactions([
+      ...log,
+      compactionAsItem(compaction),
+    ]);
+    expect(folded.some((i) => i.type === 'function_call')).toBe(false);
+    expect(folded.some((i) => i.type === 'function_call_output')).toBe(false);
+  });
+});
+
+describe('hasCompaction', () => {
+  it('is false for an uncompacted log and true once a record is present', () => {
+    const history = [
+      makeMessage('user', 'a'),
+    ];
+    expect(hasCompaction(history)).toBe(false);
+    const compaction = createCompaction({
+      items: history,
+      replacesUntil: 1,
+      summary: 's',
+    });
+    expect(
+      hasCompaction([
+        ...history,
+        compactionAsItem(compaction),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe('createCompaction', () => {
+  it('records replaced count and token savings', () => {
+    const items = [
+      makeMessage('user', 'a'.repeat(400)),
+      makeMessage('assistant', 'b'.repeat(400)),
+    ];
+    const compaction = createCompaction({
+      items,
+      replacesUntil: 2,
+      summary: 'short',
+    });
+    expect(compaction.type).toBe(COMPACTION_ITEM_TYPE);
+    expect(compaction.replacedCount).toBe(2);
+    expect(compaction.summary).toBe('short');
+    expect(compaction.tokensSaved).toBeGreaterThan(0);
+  });
+
+  it('tokensSaved floors at 0 when the summary is longer than what it replaces', () => {
+    const compaction = createCompaction({
+      items: [
+        makeMessage('user', 'hi'),
+      ],
+      replacesUntil: 1,
+      summary: 'x'.repeat(4_000),
+    });
+    expect(compaction.tokensSaved).toBe(0);
+  });
+});
+
+describe('compactHistory', () => {
+  const log = [
+    makeMessage('user', 'turn-1'),
+    makeMessage('assistant', 'turn-2'),
+    makeMessage('user', 'turn-3'),
+    makeMessage('user', 'turn-4'),
+  ];
+
+  it('summarizes everything but the most recent N items', async () => {
+    const compaction = await compactHistory({
+      log,
+      keepRecent: 1,
+      summarize: (replaced) => `summarized ${replaced.length}`,
+    });
+    assert(compaction !== null);
+    expect(compaction.replacesUntil).toBe(3);
+    expect(compaction.summary).toBe('summarized 3');
+    const folded = foldCompactions([
+      ...log,
+      compactionAsItem(compaction),
+    ]);
+    expect(viewTexts(folded.slice(1))).toEqual([
+      'turn-4',
+    ]);
+  });
+
+  it('returns null when keepRecent covers the whole log', async () => {
+    const compaction = await compactHistory({
+      log,
+      keepRecent: log.length,
+      summarize: () => 'unused',
+    });
+    expect(compaction).toBeNull();
+  });
+
+  it('awaits an async summarizer (an LLM step is the intended shape)', async () => {
+    const compaction = await compactHistory({
+      log,
+      keepRecent: 2,
+      summarize: async () => {
+        await Promise.resolve();
+        return 'async summary';
+      },
+    });
+    assert(compaction !== null);
+    expect(compaction.summary).toBe('async summary');
+  });
+});
+
+describe('historyPressure', () => {
+  const policy: ProjectionPolicy = {
+    tokenBudget: 1_000,
+    responseReserve: 200,
+    overflow: 'sliding_window',
+  };
+
+  it('reports under-threshold for small histories', () => {
+    const pressure = historyPressure(
+      [
+        makeMessage('user', 'hi'),
+      ],
+      policy,
+    );
+    expect(pressure.overThreshold).toBe(false);
+    expect(pressure.compactAt).toBe(Math.floor((1_000 - 200) * 0.8));
+  });
+
+  it('reports over-threshold when folded history exceeds compactAt', () => {
+    const big = Array.from(
+      {
+        length: 40,
+      },
+      (_, i) => makeMessage('user', `msg-${i} ${'y'.repeat(120)}`),
+    );
+    const pressure = historyPressure(big, policy);
+    expect(pressure.overThreshold).toBe(true);
+    expect(pressure.historyTokens).toBeGreaterThan(pressure.compactAt);
+  });
+
+  it('measures the FOLDED history — compaction relieves pressure', () => {
+    const big = Array.from(
+      {
+        length: 40,
+      },
+      (_, i) => makeMessage('user', `msg-${i} ${'z'.repeat(120)}`),
+    );
+    expect(historyPressure(big, policy).overThreshold).toBe(true);
+    const compaction = createCompaction({
+      items: big,
+      replacesUntil: 38,
+      summary: 'earlier messages summarized',
+    });
+    const relieved = historyPressure(
+      [
+        ...big,
+        compactionAsItem(compaction),
+      ],
+      policy,
+    );
+    expect(relieved.overThreshold).toBe(false);
+  });
+
+  it('respects an explicit compactAt override', () => {
+    const pressure = historyPressure(
+      [
+        makeMessage('user', 'x'.repeat(4_000)),
+      ],
+      {
+        tokenBudget: 1_000_000,
+        responseReserve: 0,
+        overflow: 'sliding_window',
+        compactAt: 100,
+      },
+    );
+    expect(pressure.compactAt).toBe(100);
+    expect(pressure.overThreshold).toBe(true);
+  });
+});
+
+// A compaction record is only worth writing down if it can actually be written
+// down: it has to pass the strict item-schema registry that guards every append,
+// or the "compaction survives checkpoint/resume" claim is false.
+describe('compaction in a real ItemLog', () => {
+  it('appends to a log under the default strict schema registry', () => {
+    const log = new ItemLogImpl();
+    log.append(makeMessage('user', 'turn-1'));
+    log.append(makeMessage('assistant', 'turn-2'));
+    const compaction = createCompaction({
+      items: log.items,
+      replacesUntil: 2,
+      summary: 'the opening exchange',
+    });
+    expect(() => log.append(compactionAsItem(compaction))).not.toThrow();
+    expect(log.items).toHaveLength(3);
+    expect(log.items[2].type).toBe(COMPACTION_ITEM_TYPE);
+  });
+
+  it('the compaction allowance did not open the gate for other unknown types', () => {
+    const log = new ItemLogImpl();
+    try {
+      // Structurally identical to a compaction record apart from the `type`
+      // string, so only the registry's allow-list can be what rejects it.
+      log.append(
+        frameworkCast<Item>({
+          id: 'y',
+          type: 'noetic:not_a_real_type',
+          status: 'completed',
+          replacesUntil: 0,
+          summary: '',
+          replacedCount: 0,
+        }),
+      );
+      expect.unreachable('should have thrown');
+    } catch (e) {
+      assert(isNoeticError(e));
+      expect(e.noeticError.kind).toBe('item_schema_mismatch');
+    }
+  });
+
+  it('a compacted log round-trips: the raw log keeps every item, the view shrinks', () => {
+    const log = new ItemLogImpl();
+    for (let i = 0; i < 10; i++) {
+      log.append(makeMessage('user', `turn-${i}`));
+    }
+    const before = foldCompactions(log.items);
+    expect(before).toHaveLength(10);
+
+    const compaction = createCompaction({
+      items: log.items,
+      replacesUntil: 8,
+      summary: 'turns 0 through 7',
+    });
+    log.append(compactionAsItem(compaction));
+
+    // The log is the durable record — nothing was destroyed, which is what makes
+    // this survive a checkpoint.
+    expect(log.items).toHaveLength(11);
+    // The model's view is what shrank.
+    const after = foldCompactions(log.items);
+    expect(after).toHaveLength(3); // summary + turn-8 + turn-9
+    expect(summaryTextOf(after)).toContain('turns 0 through 7');
+    expect(viewTexts(after.slice(1))).toEqual([
+      'turn-8',
+      'turn-9',
+    ]);
+  });
+
+  it('serializing and rehydrating a compacted log preserves the folded view', () => {
+    const log = new ItemLogImpl();
+    for (let i = 0; i < 6; i++) {
+      log.append(makeMessage('user', `turn-${i}`));
+    }
+    const compaction = createCompaction({
+      items: log.items,
+      replacesUntil: 4,
+      summary: 'the first four turns',
+    });
+    log.append(compactionAsItem(compaction));
+    const expected = foldCompactions(log.items);
+
+    // Round-trip through JSON the way a checkpoint does, then re-append through
+    // the registry — the compaction has to survive validation a second time.
+    const revived = new ItemLogImpl();
+    for (const item of JSON.parse(JSON.stringify(log.items))) {
+      revived.append(item);
+    }
+    expect(revived.items).toHaveLength(7);
+    const folded = foldCompactions(revived.items);
+    expect(folded).toHaveLength(expected.length);
+    expect(summaryTextOf(folded)).toContain('the first four turns');
+  });
+});
+
+// estimateTokens participates in the fold contract (tokensSaved) — pin its shape.
+describe('token estimation contract', () => {
+  it('longer content estimates more tokens', () => {
+    expect(estimateTokens('a'.repeat(1_000))).toBeGreaterThan(estimateTokens('a'));
+  });
+});

--- a/packages/types/src/schemas/item.ts
+++ b/packages/types/src/schemas/item.ts
@@ -21,6 +21,7 @@
 import { z } from 'zod';
 import { NoeticErrorImpl } from '../errors/noetic-error';
 import type { Item, ItemSchemaExtensions } from '../types/items';
+import { COMPACTION_ITEM_TYPE } from '../types/items';
 
 function isItemLike(value: unknown): value is Item {
   if (typeof value !== 'object' || value === null) {
@@ -100,6 +101,16 @@ function relevantCategories(value: unknown): ItemSchemaCategory[] {
   return categories;
 }
 
+const CompactionItemSchema = z.object({
+  id: z.string().min(1),
+  type: z.literal(COMPACTION_ITEM_TYPE),
+  status: z.literal('completed'),
+  replacesUntil: z.number().int().nonnegative(),
+  summary: z.string(),
+  replacedCount: z.number().int().nonnegative(),
+  tokensSaved: z.number().nonnegative().optional(),
+});
+
 function isKnownBaseType(type: string): boolean {
   return (
     type === 'message' ||
@@ -109,6 +120,12 @@ function isKnownBaseType(type: string): boolean {
     type === 'web_search_call' ||
     type === 'file_search_call' ||
     type === 'image_generation_call' ||
+    // A compaction record is a framework item, not a provider item: it is
+    // deliberately outside the `Item` union (nothing renders it directly — the
+    // projector folds it), but it MUST be appendable to a real item log or
+    // compaction cannot survive a checkpoint, which is the whole point of
+    // recording it in the log rather than in engine state.
+    type === COMPACTION_ITEM_TYPE ||
     type.startsWith('openrouter:')
   );
 }
@@ -153,6 +170,10 @@ export class ItemSchemaRegistry {
 
   parse(value: unknown): Item {
     const base = ItemSchema.parse(value);
+    if (base.type === COMPACTION_ITEM_TYPE) {
+      CompactionItemSchema.parse(value);
+      return base;
+    }
     const categories = relevantCategories(base);
     const schemas = categories.flatMap((category) => schemasForCategory(this.extensions, category));
 

--- a/packages/types/src/types/context-layer.ts
+++ b/packages/types/src/types/context-layer.ts
@@ -477,4 +477,14 @@ export interface ProjectionPolicy {
   overflow: 'truncate' | 'summarize' | 'sliding_window';
   overflowModel?: string;
   windowSize?: number;
+  /**
+   * History-token threshold that arms compaction. When the folded history
+   * exceeds this, `historyPressure` reports `overThreshold` so an agent (or
+   * the host app) can compact instead of letting the assembler silently drop
+   * the oldest turns. Compaction itself stays explicit: record a
+   * `CompactionItem` in the log (see `createCompaction` / `compactHistory`).
+   *
+   * Defaults to 80% of `tokenBudget - responseReserve` when omitted.
+   */
+  compactAt?: number;
 }

--- a/packages/types/src/types/items.ts
+++ b/packages/types/src/types/items.ts
@@ -152,6 +152,33 @@ export interface FunctionCallOutputItem {
 /** @public Item produced by an extension schema registered by a tool, context layer, or harness. */
 export type ExtensionItem = ItemBase & Record<string, unknown>;
 
+/** @public Item type identifying a recorded history compaction. */
+export const COMPACTION_ITEM_TYPE = 'noetic:compaction' as const;
+
+/**
+ * @public A recorded compaction: a summary that REPLACES a contiguous prefix of
+ * conversation history. Lives in the item log like any other item, so
+ * compaction survives checkpoints/resume for free and forked logs share it.
+ *
+ * `replacesUntil` is the item-log index (exclusive) of the last item the
+ * summary covers. Folding the log (`foldCompactions`) drops items before that
+ * index and renders the summary in their place. Compactions may stack: a later
+ * compaction with a higher `replacesUntil` subsumes an earlier one.
+ */
+export interface CompactionItem {
+  readonly id: string;
+  readonly type: typeof COMPACTION_ITEM_TYPE;
+  readonly status: 'completed';
+  /** Item-log index (exclusive) up to which history is replaced by `summary`. */
+  readonly replacesUntil: number;
+  /** The compacted summary of the replaced items. */
+  readonly summary: string;
+  /** Count of items replaced, for diagnostics. */
+  readonly replacedCount: number;
+  /** Estimated tokens saved by this compaction, for diagnostics. */
+  readonly tokensSaved?: number;
+}
+
 /** @public Developer-role message item refined by a context-layer extension schema. */
 export type DeveloperMessageExtensionItem = InputMessageItem & {
   readonly role: 'developer';

--- a/packages/web/content/docs/framework/api/context-layer-types.mdx
+++ b/packages/web/content/docs/framework/api/context-layer-types.mdx
@@ -284,6 +284,7 @@ interface ProjectionPolicy {
   overflow: 'truncate' | 'summarize' | 'sliding_window';
   overflowModel?: string;
   windowSize?: number;
+  compactAt?: number;
 }
 ```
 
@@ -294,6 +295,7 @@ interface ProjectionPolicy {
 | `overflow` | `'truncate' \| 'summarize' \| 'sliding_window'` | yes | Strategy when total recall exceeds budget |
 | `overflowModel` | `string` | no | Model for summarization overflow |
 | `windowSize` | `number` | no | Items to keep for sliding window overflow |
+| `compactAt` | `number` | no | Folded-history token threshold that arms compaction; `historyPressure` reports `overThreshold` above it. Defaults to 80% of `tokenBudget − responseReserve` |
 
 ## ContextCacheConfig
 

--- a/packages/web/content/docs/framework/api/items-and-events.mdx
+++ b/packages/web/content/docs/framework/api/items-and-events.mdx
@@ -254,6 +254,31 @@ interface FunctionCallOutputItem {
 | `output` | `string` | JSON-encoded tool output |
 | `status` | `string` | Lifecycle status. Includes `failed` as a Noetic extension. |
 
+### CompactionItem
+
+A recorded history compaction: a summary that replaces a contiguous prefix of conversation history. Deliberately **outside** the `Item` union — nothing renders it directly; the projector folds it (`foldCompactions`). It is registered with the strict item-schema registry so it can live in the `ItemLog`, which is what lets compaction survive checkpoint/resume and be shared by forked logs. See [History](../context-layers/history.mdx#compaction).
+
+```ts validate=none
+const COMPACTION_ITEM_TYPE = 'noetic:compaction';
+
+interface CompactionItem {
+  readonly id: string;
+  readonly type: typeof COMPACTION_ITEM_TYPE;
+  readonly status: 'completed';
+  readonly replacesUntil: number;
+  readonly summary: string;
+  readonly replacedCount: number;
+  readonly tokensSaved?: number;
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `replacesUntil` | `number` | Item-log index (exclusive) up to which history is replaced by `summary` |
+| `summary` | `string` | The compacted summary of the replaced items |
+| `replacedCount` | `number` | Count of items replaced (diagnostics) |
+| `tokensSaved` | `number` | Estimated tokens saved, floored at 0 (diagnostics, optional) |
+
 ### Item Union
 
 All item types that can appear in an `ItemLog`:

--- a/packages/web/content/docs/framework/context-layers/history.mdx
+++ b/packages/web/content/docs/framework/context-layers/history.mdx
@@ -50,6 +50,32 @@ The projection runs against `ctx.itemLog.items` but never mutates it. As a resul
 
 Within a single `callModel` invocation's tool loop, that round's own `function_call` and `function_call_output` items accumulate in the wire payload until the call returns. The cap fires at **turn boundaries**, not mid-call — capping mid-flight would corrupt the active tool flow.
 
+## Compaction
+
+Capping bounds item *count*; it cannot preserve what falls outside the window. A **recorded compaction** is the explicit alternative: a `CompactionItem` appended to the log declares "the first `replacesUntil` items are summarized by `summary`". The log stays append-only (checkpoints, forks, and audits keep the full record) while the folded view the model sees collapses the replaced prefix to a `<compacted_history>` developer message.
+
+The helpers live in `@noetic-tools/core` (re-exported from `@noetic-tools/context`):
+
+- `foldCompactions(items)` — project the model view from the raw log. Highest `replacesUntil` wins; compaction records never reach a provider; the fold seam strips orphan tool calls. Run it on history before `assembleView` — and before this layer's cap — so a compaction genuinely shrinks what has to fit.
+- `hasCompaction(items)` — cheap check to skip the fold on the common no-compaction path.
+- `historyPressure(historyItems, policy)` — measures the **folded** history against `policy.compactAt` (default 80% of `tokenBudget − responseReserve`), so writing a compaction genuinely relieves pressure.
+- `createCompaction({ items, replacesUntil, summary })` / `compactHistory({ log, keepRecent, summarize })` — build the record. The caller supplies the summary (an LLM step, a heuristic, a digest) and appends the record; the projector never mutates a log.
+- `compactionAsItem(compaction)` — the sanctioned bridge to `ctx.itemLog.append(...)`.
+
+```ts validate=none
+import { compactHistory, compactionAsItem, historyPressure } from '@noetic-tools/core';
+
+const pressure = historyPressure(ctx.itemLog.items, policy);
+if (pressure.overThreshold) {
+  const compaction = await compactHistory({
+    log: ctx.itemLog.items,
+    keepRecent: 20,
+    summarize: (replaced) => summarizeSomehow(replaced), // your LLM step or heuristic
+  });
+  if (compaction) ctx.itemLog.append(compactionAsItem(compaction));
+}
+```
+
 ## CLI configuration
 
 The CLI installs `history` only when `AgentConfig.history.maxItems` is set. When unset, history is uncapped (the pre-existing default behaviour). Configure it via:

--- a/specs/07-context-and-event-log.md
+++ b/specs/07-context-and-event-log.md
@@ -1,7 +1,7 @@
 # Context and Item Log
 
 > **Depends On:** `06-channels` (Channel — for send/recv/tryRecv signatures), `08-runtime` (AgentHarness — for harness reference), `10-observability` (Span)
-> **Exports:** `Context`, `ItemLog`, `Item`, `OutputItem`, `MessageItem`, `FunctionCallItem`, `FunctionCallOutputItem`, `ReasoningItem`, `WebSearchItem`, `FileSearchItem`, `ImageGenerationItem`, `ServerToolItem`, `InputMessageItem`, `ContentPart`, `OutputTextPart`, `RefusalPart`, `InputTextPart`, `InputImagePart`, `InputFilePart`, `InputContentPart`, `ReasoningTextPart`, `SummaryTextPart`, `StepMeta`, `TokenUsage`, `LLMResponse`, `LayerUsageEntry`, `LastLayerUsage`
+> **Exports:** `Context`, `ItemLog`, `Item`, `OutputItem`, `MessageItem`, `FunctionCallItem`, `FunctionCallOutputItem`, `ReasoningItem`, `WebSearchItem`, `FileSearchItem`, `ImageGenerationItem`, `ServerToolItem`, `InputMessageItem`, `ContentPart`, `OutputTextPart`, `RefusalPart`, `InputTextPart`, `InputImagePart`, `InputFilePart`, `InputContentPart`, `ReasoningTextPart`, `SummaryTextPart`, `CompactionItem`, `COMPACTION_ITEM_TYPE`, `StepMeta`, `TokenUsage`, `LLMResponse`, `LayerUsageEntry`, `LastLayerUsage`
 
 ---
 
@@ -220,6 +220,28 @@ type Item = OutputItem | InputMessageItem | FunctionCallOutputItem;
 ```
 
 Server tool items use the `prefix:name` convention established by the OpenResponses `ResponsesServerToolOutput` type. The prefix identifies the vendor or domain (e.g., `openrouter`, `noetic`, `myapp`) and the name identifies the specific item kind. None of the standard item types contain a colon, so the presence of `:` in the type string cleanly distinguishes server tool outputs from standard items.
+
+### Framework-owned Records: `CompactionItem`
+
+```typescript
+const COMPACTION_ITEM_TYPE = 'noetic:compaction';
+
+interface CompactionItem {
+  readonly id: string;
+  readonly type: typeof COMPACTION_ITEM_TYPE;
+  readonly status: 'completed';
+  /** Item-log index (exclusive) up to which history is replaced by `summary`. */
+  readonly replacesUntil: number;
+  /** The compacted summary of the replaced items. */
+  readonly summary: string;
+  /** Count of items replaced, for diagnostics. */
+  readonly replacedCount: number;
+  /** Estimated tokens saved by this compaction, for diagnostics. */
+  readonly tokensSaved?: number;
+}
+```
+
+A compaction record is a framework item, deliberately **outside** the `Item` union — nothing renders it directly; the projector folds it (see spec 11, *History Compaction*). It is registered with the strict item-schema registry (`isKnownBaseType`) so it can be appended to a real `ItemLog` — recording compaction in the log rather than in engine state is what makes it survive checkpoint/resume and shared by forked logs. The allowance is a single-type exception: other unknown `noetic:*` types are still rejected.
 
 ---
 

--- a/specs/11-context-layer-system.md
+++ b/specs/11-context-layer-system.md
@@ -2,7 +2,7 @@
 
 > **Module:** `@noetic-tools/context` (source at `packages/context/src/**`); the `ContextLayer` contract is owned by `@noetic-tools/types` (`packages/types/src/types/context-layer.ts`, also at the `@noetic-tools/types/contract` subpath). Both are re-exported by `@noetic-tools/core`.
 > **Depends On:** `07-context-and-event-log` (ItemLog, Item — type import only), `10-observability` (LayerTraceSpan, trace conventions), `04-spawn` (SpawnOpts — referenced in SpawnParams)
-> **Exports:** `ContextLayer`, `ContextLayerHooks`, `ContextScope`, `BudgetConfig`, `Slot`, `InitParams`, `InitResult`, `RecallParams`, `RecallResult`, `StoreParams`, `StoreResult`, `SpawnParams`, `SpawnResult`, `ReturnParams`, `ReturnResult`, `CompleteParams`, `DisposeParams`, `BeforeToolCallParams`, `BeforeToolCallResult`, `AfterModelCallParams`, `AfterModelCallResult`, `OnItemAppendParams`, `OnItemAppendResult`, `RerenderScope`, `ParentUpdateParams`, `ParentUpdateResult`, `ExecutionOutcome`, `ExecutionContext`, `ScopedStorage`, `StorageAdapter`, `ProjectionPolicy`, `LayerTimeouts`, `LayerProvides`, `LayerDataDecl`, `LayerFunctionDecl`, `ContextConfig`, `InferContext`, `InferContextShape`, `layerData`, `layerFunction`, `context`, `storageGetMany`, `LayerPlacement`, `RenderDeltaParams`, `ContextCacheConfig`, `ContextCacheStore`, `ContextEpoch`, `AnchorPin`, `LayerChurn`, `ReanchorReason`
+> **Exports:** `ContextLayer`, `ContextLayerHooks`, `ContextScope`, `BudgetConfig`, `Slot`, `InitParams`, `InitResult`, `RecallParams`, `RecallResult`, `StoreParams`, `StoreResult`, `SpawnParams`, `SpawnResult`, `ReturnParams`, `ReturnResult`, `CompleteParams`, `DisposeParams`, `BeforeToolCallParams`, `BeforeToolCallResult`, `AfterModelCallParams`, `AfterModelCallResult`, `OnItemAppendParams`, `OnItemAppendResult`, `RerenderScope`, `ParentUpdateParams`, `ParentUpdateResult`, `ExecutionOutcome`, `ExecutionContext`, `ScopedStorage`, `StorageAdapter`, `ProjectionPolicy`, `LayerTimeouts`, `LayerProvides`, `LayerDataDecl`, `LayerFunctionDecl`, `ContextConfig`, `InferContext`, `InferContextShape`, `layerData`, `layerFunction`, `context`, `storageGetMany`, `LayerPlacement`, `RenderDeltaParams`, `ContextCacheConfig`, `ContextCacheStore`, `ContextEpoch`, `AnchorPin`, `LayerChurn`, `ReanchorReason`, `foldCompactions`, `hasCompaction`, `historyPressure`, `HistoryPressure`, `createCompaction`, `CreateCompactionParams`, `compactHistory`, `CompactHistoryParams`, `compactionAsItem`
 
 ## Module Boundary
 
@@ -14,7 +14,7 @@ The context layer system lives in `@noetic-tools/context` (`packages/context/src
 | `ContextScope`, `ScopedStorage`, `StorageAdapter` | Projector (View assembly algorithm) in `projector.ts` |
 | `BudgetConfig`, `Slot` | budget algorithm; `allocateBudgets` in `budget.ts` |
 | `ExecutionContext` (layer-facing read-only view) | built-in layer factories under `context/layers/` |
-| `ProjectionPolicy` | Projector implementation in `projector.ts` |
+| `ProjectionPolicy` | Projector implementation in `projector.ts` (incl. the compaction helpers: `foldCompactions`, `historyPressure`, `createCompaction`, `compactHistory`, `hasCompaction`, `compactionAsItem`) |
 
 `Context` (the full execution object) lives in `@noetic-tools/core`'s `runtime/`; the `contextToExecCtx` mapping (Context → ExecutionContext) bridges core to the context contract.
 
@@ -758,6 +758,8 @@ interface ProjectionPolicy {
   overflow: 'truncate' | 'summarize' | 'sliding_window';
   overflowModel?: string;
   windowSize?: number;
+  compactAt?: number;  // folded-history token threshold that arms compaction;
+                       // defaults to 80% of (tokenBudget - responseReserve)
 }
 ```
 
@@ -773,6 +775,17 @@ interface ProjectionPolicy {
 6. Conversation history gets the remaining budget, with overflow policy applied
 7. Result is Item[] — directly passable to the LLM provider
 ```
+
+### History Compaction
+
+The item log is append-only; a **compaction** is an ordinary logged item (a `CompactionItem`, spec 07) declaring "the first `replacesUntil` items are summarized by `summary`". Folding keeps the log immutable — checkpoints, forks, and audits see the full record — while the model sees `[summary, ...items after replacesUntil]`. The projector owns the pure helpers; recording a compaction is always an explicit, caller-driven decision, never something the projector does behind the runtime's back.
+
+- `foldCompactions(items)` — projects the model view from the raw log. When multiple compactions exist the highest `replacesUntil` wins (later compactions subsume earlier ones). The replaced prefix collapses to a rendered `<compacted_history>` developer message; compaction records themselves never appear in the folded view, so one never reaches a provider un-folded. The fold seam strips unresolved tool calls, the same repair the history trimmer applies. Run it on history **before** the band assembler so a compaction genuinely reduces what `assembleView` has to fit.
+- `hasCompaction(items)` — cheap check that lets a caller skip the fold (and its copy) on the common no-compaction path.
+- `historyPressure(historyItems, policy)` — measures the **folded** history against `policy.compactAt` (default 80% of `tokenBudget − responseReserve`) and reports `{ historyTokens, compactAt, overThreshold }`. Measuring the folded view means writing a compaction genuinely relieves pressure. This is the observable complement of the assembler's silent front-drop: it says when the trim is coming so the caller can compact instead of losing the prefix.
+- `createCompaction({ items, replacesUntil, summary })` — builds the record (`replacedCount` + `tokensSaved` bookkeeping, floored at 0). The caller supplies the summary — an LLM call, a heuristic, or a verbatim digest; summarization is a composition point, not engine policy. `replacesUntil` indexes the RAW log, including earlier compaction items, so stacking compactions is well-defined.
+- `compactHistory({ log, keepRecent, summarize })` — thin convenience: works out `replacesUntil` from `keepRecent`, awaits `summarize` on exactly the replaced prefix, and returns the record for the **caller** to append (`ctx.itemLog.append(...)`). Returns `null` when there is nothing to compact.
+- `compactionAsItem(compaction)` — the one sanctioned bridge from `CompactionItem` to the `Item` that `ItemLog.append` takes; the type is registered with the schema registry so the append validates.
 
 ---
 
@@ -886,7 +899,7 @@ Set on the harness as `contextCache`. Anchoring is **on by default**; `enabled: 
 
 ### Limitation: History Overflow
 
-Once conversation history exceeds its budget, the projector drops from the front, which moves the anchor/history boundary and loses the history portion of the cache on every subsequent turn. The `[system][anchor]` prefix still caches. Pair anchoring with `history` (spec 12) to keep the boundary still.
+Once conversation history exceeds its budget, the projector drops from the front, which moves the anchor/history boundary and loses the history portion of the cache on every subsequent turn. The `[system][anchor]` prefix still caches. Pair anchoring with `history` (spec 12) to keep the boundary still, or record a compaction so the prefix collapses to a stable summary instead of sliding.
 
 ### Hard Token Cap (`assembleView`)
 

--- a/specs/12-builtin-context-layers.md
+++ b/specs/12-builtin-context-layers.md
@@ -331,6 +331,8 @@ function history(config?: { maxItems?: number }): ContextLayer<null>
 
 The CLI exposes the cap via `AgentConfig.history.maxItems`. When unset, the layer is not installed and history is uncapped.
 
+**Compaction composes with the cap**: `history()` bounds item *count*; a recorded compaction (spec 11, *History Compaction*) replaces the old prefix with a summary instead of dropping it. Fold first (`foldCompactions`), then cap — the fold seam and the slice boundary both strip orphan tool calls.
+
 ```typescript
 // Direct usage in core
 const layers = [


### PR DESCRIPTION
## What

- add a validated first-class `CompactionItem` that survives logs/checkpoints
- add pure helpers to fold stacked compactions into model history
- add `historyPressure`, `createCompaction`, `compactHistory`, and `compactionAsItem`
- add optional `ProjectionPolicy.compactAt` with an 80% effective-window default

## Why

History truncation loses old turns silently. Explicit compaction records preserve a summary in the canonical log and let callers decide when/how to summarize while projection remains pure. Stacked records allow later summaries to subsume earlier prefixes.

This semantically ports item 15 from `fork/port/openrouter-fixes` commits `3d65b3e2` and `135ac3fd`. Folding into model-call paths and `context_pressure` events remain item 16; allocator changes remain item 17.

## Test plan

- [x] 20 focused compaction tests
- [x] types tests/typecheck
- [x] context tests/typecheck
- [x] core typecheck and export-tag check
- [x] web docs snippet check — 358 snippets, 0 errors
- [x] root lint
- [x] `sentrux check .`
- [x] clean-context Pi review; added strict compaction shape validation and clamped degenerate pressure thresholds

## Compatibility

Additive API. Raw logs retain all original items plus compaction records; only callers that invoke `foldCompactions` see the projected summary.
