### PR TITLE
perf(core): batch checkpoint item logs safely

### DIFF
--- a/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
+++ b/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
@@ -138,9 +138,9 @@ Every retained implementation PR must:
 | 4 | `lukeparke/openrouter-eval-safety` | [#72](https://github.com/mattapperson/noetic/pull/72) | pending | no feedback | blocks 5 | 2026-08-12 opened |
 | 5 | — | — | — | — | blocked by 4 merge | 2026-08-12 audit complete |
 | 6 | `lukeparke/openrouter-openui-hardening` | [#73](https://github.com/mattapperson/noetic/pull/73) | pending | no feedback | independent | 2026-08-12 opened |
-| 7 | — | — | — | — | independent | 2026-08-12 audit complete |
-| 8 | — | — | — | — | independent | 2026-08-12 audit complete |
-| 9 | — | — | — | — | independent, breaking default | 2026-08-12 audit complete |
+| 7 | `lukeparke/openrouter-doom-loop` | [#74](https://github.com/mattapperson/noetic/pull/74) | pending | no feedback | independent | 2026-08-12 opened |
+| 8 | `lukeparke/openrouter-deferred-observations` | [#75](https://github.com/mattapperson/noetic/pull/75) | pending | no feedback | independent | 2026-08-12 opened |
+| 9 | `lukeparke/openrouter-filesystem-scoring` | [#76](https://github.com/mattapperson/noetic/pull/76) | pending | no feedback | breaking default | 2026-08-12 opened |
 | 10 | — | — | — | — | validation dropped via #67 | 2026-08-12 audit complete |
 | 11 | — | [#69 separate](https://github.com/mattapperson/noetic/pull/69) | #69 currently failing | — | avoid #69 behavior | 2026-08-12 audit complete |
 | 12 | — | — | — | — | independent; blocks 13 | 2026-08-12 audit complete |
@@ -149,7 +149,7 @@ Every retained implementation PR must:
 | 15 | — | — | — | — | independent; blocks 16 | 2026-08-12 audit complete |
 | 16 | — | — | — | — | blocked by 15 | 2026-08-12 audit complete |
 | 17 | — | — | — | — | blocked by 16; RFC/breaking | 2026-08-12 audit complete |
-| 18 | — | — | — | — | independent | 2026-08-12 audit complete |
+| 18 | `lukeparke/openrouter-context-input` | [#77](https://github.com/mattapperson/noetic/pull/77) | pending | no feedback | independent | 2026-08-12 opened |
 | 19 | — | — | — | — | design review required | 2026-08-12 audit complete |
 | 20 | — | — | — | — | blocked by 14 + 19 | 2026-08-12 audit complete |
 

--- a/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
+++ b/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
@@ -147,7 +147,7 @@ Every retained implementation PR must:
 | 13 | — | — | — | — | blocked by 12 | 2026-08-12 audit complete |
 | 14 | `lukeparke/openrouter-workflow-hardening` | [#84](https://github.com/mattapperson/noetic/pull/84) | pending | clean-context review addressed | blocks 20 | 2026-08-12 opened |
 | 15 | `lukeparke/openrouter-compaction-primitives` | [#80](https://github.com/mattapperson/noetic/pull/80) | pending | no feedback | blocks 16 | 2026-08-12 opened |
-| 16 | — | — | — | — | blocked by 15 | 2026-08-12 audit complete |
+| 16 | `lukeparke/openrouter-compaction-runtime` | [#85](https://github.com/mattapperson/noetic/pull/85) | pending | clean-context review addressed | depends on #80; rebase through main after merge | 2026-08-12 opened |
 | 17 | — | — | — | — | blocked by 16; RFC/breaking | 2026-08-12 audit complete |
 | 18 | `lukeparke/openrouter-context-input` | [#77](https://github.com/mattapperson/noetic/pull/77) | pending | no feedback | independent | 2026-08-12 opened |
 | 19 | — | — | — | — | proposal committed at `docs/plans/2026-08-12-002-multi-agent-patterns-proposal.md`; recommends examples/docs and rejects core policy reversal | 2026-08-12 design proposal complete |

--- a/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
+++ b/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
@@ -145,7 +145,7 @@ Every retained implementation PR must:
 | 11 | `lukeparke/openrouter-runtime-efficiency` | [#78](https://github.com/mattapperson/noetic/pull/78) | pending | no feedback | excludes [#69](https://github.com/mattapperson/noetic/pull/69) behavior | 2026-08-12 opened |
 | 12 | `lukeparke/openrouter-session-log` | [#79](https://github.com/mattapperson/noetic/pull/79) | pending | no feedback | blocks 13 | 2026-08-12 opened |
 | 13 | — | — | — | — | blocked by 12 | 2026-08-12 audit complete |
-| 14 | — | — | — | — | independent; blocks 20 | 2026-08-12 audit complete |
+| 14 | `lukeparke/openrouter-workflow-hardening` | [#84](https://github.com/mattapperson/noetic/pull/84) | pending | clean-context review addressed | blocks 20 | 2026-08-12 opened |
 | 15 | `lukeparke/openrouter-compaction-primitives` | [#80](https://github.com/mattapperson/noetic/pull/80) | pending | no feedback | blocks 16 | 2026-08-12 opened |
 | 16 | — | — | — | — | blocked by 15 | 2026-08-12 audit complete |
 | 17 | — | — | — | — | blocked by 16; RFC/breaking | 2026-08-12 audit complete |

--- a/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
+++ b/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
@@ -132,12 +132,12 @@ Every retained implementation PR must:
 
 | Item | Branch | PR | CI | Reviews | Merge SHA / dependency | Last update |
 |---:|---|---|---|---|---|---|
-| 1 | — | — | — | — | independent | 2026-08-12 audit complete |
+| 1 | `lukeparke/openrouter-file-storage` | [#70](https://github.com/mattapperson/noetic/pull/70) | CI/DCO/structural pass; compat blocked by missing upstream `OPENROUTER_API_KEY` | no feedback | review-ready; external compat dependency documented | 2026-08-12 opened |
 | 2 | — | — | — | — | soft after 1 | 2026-08-12 audit complete |
-| 3 | — | — | — | — | independent | 2026-08-12 audit complete |
-| 4 | — | — | — | — | independent; blocks 5 | 2026-08-12 audit complete |
-| 5 | — | — | — | — | blocked by 4 | 2026-08-12 audit complete |
-| 6 | — | — | — | — | independent | 2026-08-12 audit complete |
+| 3 | `lukeparke/openrouter-sub-harness-reliability` | [#71](https://github.com/mattapperson/noetic/pull/71) | pending | no feedback | independent | 2026-08-12 opened |
+| 4 | `lukeparke/openrouter-eval-safety` | [#72](https://github.com/mattapperson/noetic/pull/72) | pending | no feedback | blocks 5 | 2026-08-12 opened |
+| 5 | — | — | — | — | blocked by 4 merge | 2026-08-12 audit complete |
+| 6 | `lukeparke/openrouter-openui-hardening` | [#73](https://github.com/mattapperson/noetic/pull/73) | pending | no feedback | independent | 2026-08-12 opened |
 | 7 | — | — | — | — | independent | 2026-08-12 audit complete |
 | 8 | — | — | — | — | independent | 2026-08-12 audit complete |
 | 9 | — | — | — | — | independent, breaking default | 2026-08-12 audit complete |

--- a/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
+++ b/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
@@ -141,12 +141,12 @@ Every retained implementation PR must:
 | 7 | `lukeparke/openrouter-doom-loop` | [#74](https://github.com/mattapperson/noetic/pull/74) | pending | no feedback | independent | 2026-08-12 opened |
 | 8 | `lukeparke/openrouter-deferred-observations` | [#75](https://github.com/mattapperson/noetic/pull/75) | pending | no feedback | independent | 2026-08-12 opened |
 | 9 | `lukeparke/openrouter-filesystem-scoring` | [#76](https://github.com/mattapperson/noetic/pull/76) | pending | no feedback | breaking default | 2026-08-12 opened |
-| 10 | — | — | — | — | validation dropped via #67 | 2026-08-12 audit complete |
-| 11 | — | [#69 separate](https://github.com/mattapperson/noetic/pull/69) | #69 currently failing | — | avoid #69 behavior | 2026-08-12 audit complete |
-| 12 | — | — | — | — | independent; blocks 13 | 2026-08-12 audit complete |
+| 10 | — | — | — | — | deferred after review found function-tool correctness and mutation-contract gaps; validation dropped via #67 | 2026-08-12 implementation rejected pending redesign |
+| 11 | `lukeparke/openrouter-runtime-efficiency` | [#78](https://github.com/mattapperson/noetic/pull/78) | pending | no feedback | excludes [#69](https://github.com/mattapperson/noetic/pull/69) behavior | 2026-08-12 opened |
+| 12 | `lukeparke/openrouter-session-log` | [#79](https://github.com/mattapperson/noetic/pull/79) | pending | no feedback | blocks 13 | 2026-08-12 opened |
 | 13 | — | — | — | — | blocked by 12 | 2026-08-12 audit complete |
 | 14 | — | — | — | — | independent; blocks 20 | 2026-08-12 audit complete |
-| 15 | — | — | — | — | independent; blocks 16 | 2026-08-12 audit complete |
+| 15 | `lukeparke/openrouter-compaction-primitives` | [#80](https://github.com/mattapperson/noetic/pull/80) | pending | no feedback | blocks 16 | 2026-08-12 opened |
 | 16 | — | — | — | — | blocked by 15 | 2026-08-12 audit complete |
 | 17 | — | — | — | — | blocked by 16; RFC/breaking | 2026-08-12 audit complete |
 | 18 | `lukeparke/openrouter-context-input` | [#77](https://github.com/mattapperson/noetic/pull/77) | pending | no feedback | independent | 2026-08-12 opened |

--- a/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
+++ b/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
@@ -1,0 +1,162 @@
+# OpenRouter fork upstreaming plan
+
+Status: active
+Owner: Pi orchestrator in Herdr workspace `w10`
+Upstream base: `origin/main` at `8a6665ba`
+Source: `fork/port/openrouter-fixes` at `6df9b785` (old base `ead54108`)
+
+## Objective
+
+Semantically port the non-Standard-Schema improvements from `fork/port/openrouter-fixes` onto current `mattapperson/noetic` architecture as focused, independently reviewable pull requests. Historical commits are provenance, not patches: current source, specs, package boundaries, Standard Schema support from #67, and naming cutover from #68 are authoritative.
+
+The program is complete only when every retained ledger item is either:
+
+1. merged upstream;
+2. an open, green, review-ready upstream PR with no unresolved feedback and explicit dependency state; or
+3. dropped with concrete supersession or current-main evidence.
+
+## Current-main overlap audit
+
+Audit performed after fetching both remotes. `HEAD` and `origin/main` were both `8a6665ba`; source tip was `6df9b785`. Four independent read-only Pi audits compared the ledger against current symbols, specs, #67, #68, and PR #69.
+
+### Naming and architecture adaptations
+
+Historical names must not return:
+
+| Historical source | Current main |
+|---|---|
+| `llm` / `step.llm` | `callModel` |
+| `provide` | `withContext` |
+| `every` | `schedule` |
+| `branch` | `conditional` |
+| `fork` | `inParallel` |
+| `run` | `runCode` |
+| memory / working-memory symbols | context / `scratchpad` / current layer names |
+| `patterns/dynamic-workflow` | `builders/dynamic-workflow` |
+
+`packages/context` remains dependent only on `packages/types`. Core must not import platform, OpenUI, or sub-harness adapter packages. Workflow ports must not recreate the historical builder-to-adapter Sentrux violation.
+
+### Already upstream, superseded, or intentionally dropped
+
+| Source/change | Disposition | Evidence |
+|---|---|---|
+| Standard Schema work | Dropped | Merged in #67 (`1751b6a9`); current OpenRouter adapter uses the shared Standard Schema validation path. |
+| Tool-argument validation from `0e63664d` | Validation half dropped | Equivalent validation is in #67. Only resolved-tool lookup/memoization remains eligible under item 10. |
+| `a792e90a` baseline cleanup | Dropped as a commit | Its old `fork` test hunk is superseded by #68 `inParallel`/`frameworkCast`; eval provider setup is now `callModelDefaults` + `resolveEnvLlm`; the lifecycle type widening is unrelated and has no demonstrated current failure. |
+| Historical `UPSTREAMING.md` | Not ported | Used only for intent/provenance; durable facts belong in owning PR bodies, specs, docs, and tests. |
+| Branch-specific drift tests | Not ported | Current behavior receives focused regression tests in each owning PR. |
+| Unsupported `~60x` checkpoint claim | Omitted | Item 13 may make complexity claims; quantified claims require a committed reproducible benchmark. |
+| Public bundled pattern layout from item 19 | Not ported without design approval | #68 removed `packages/core/src/patterns`; `specs/13-patterns.md` normatively says core ships no bundled agent patterns. |
+| PR #69 behavior | Separate | [#69](https://github.com/mattapperson/noetic/pull/69) owns EventBroadcaster watermark trimming and latest-only generator progress. Item 11 must not touch those behaviors/files. |
+
+### Item-by-item audit and PR ledger
+
+States: `queued`, `implementing`, `review`, `open`, `merged`, `dropped`, `design-review`, `blocked`.
+
+| # | Planned PR | Current-main audit | Dependencies | State | Branch / PR / evidence |
+|---:|---|---|---|---|---|
+| 1 | File-storage encoding, async writes, legacy reads | Absent: `packages/platform-node/src/file-storage.ts` still uses lossy single-phase encoding and sync filesystem operations; no legacy fallback. | none | queued | source `b9905ac5` + `653b3986` |
+| 2 | Durable queue and subprocess IPC ordering | Absent: queue `clear()` resets sequence, ack scans storage, IPC dispatch is unsequenced, error frames are uncorrelated, subprocess identity uses spawned `ps`. Keep as one platform PR unless review shows queue vs IPC is materially clearer split. | soft after 1 to reduce platform conflicts | queued | remainder of `b9905ac5` |
+| 3 | Sub-harness session/turn reliability | Absent: session cache stores sessions rather than in-flight promises; no turn idle watchdog, error-finish failure, or reasoning item retention. | none | queued | `0fd1b9ef` |
+| 4 | Eval dirty-write guard and bounded case concurrency | Absent: no write guard/run pool, suite cases remain serial, dead `--budget` remains. | none | queued | first part of `aedf712f` |
+| 5 | GEPA discovery, traversal, judge reuse | Absent: scope discovery, stable tool paths, composite traversal, and harness reuse gaps remain. Port traversal with current step kinds only. | 4 merged | blocked | remainder of `aedf712f` |
+| 6 | OpenUI transport/state hardening | Absent: parser lacks prose-safe statement detection; surface has one global sequence watermark and unrestricted set events; state reads are not thread-keyed. | none | queued | `b095d1f5` |
+| 7 | Result-aware configurable doom-loop protection | Absent: no round fingerprint or configurable identical-round threshold. | none | queued | `3fc95caf` + `33f44721` |
+| 8 | Deferred observation distillation | Absent: `observations()` awaits its observer in the append path and carries long append timeouts. | none | queued | relevant `fb22ac35`; adapt observation naming |
+| 9 | Opt-in filesystem/file-reference LLM scoring | Absent: `filesystem()` still defaults to Haiku scoring. Explicit breaking default: heuristic unless a model is configured. | none | queued | relevant `fb22ac35` |
+| 10 | Memoized unified tools and SDK conversion | Partial: validation is upstream via #67, but tool collection/conversion is repeated and resolution remains linear. | none | queued | relevant `fb22ac35`; validation excluded |
+| 11 | Channel reaping, loop snapshot efficiency, deterministic park jitter, inline dispatch | Absent in channel store/control/subprocess paths. Must not duplicate #69 EventBroadcaster or latest-yield changes. | coordinate with #69 only | queued | `27ddda8e` |
+| 12 | Session-owned logs and warm layer hydration | Absent: sessions copy `accumulatedItems`; no session-owned log, truncation rollback, or scope-keyed warm hydration. | none | queued | `fc89dbab` + relevant `796f7ec2` fixes |
+| 13 | Delta checkpoint batches, rollback-safe stitching, ledger continuity | Absent: checkpoints still embed the full item log; no batch stitching/truncation repair. | 12 merged | blocked | remaining `fc89dbab` + `796f7ec2`; benchmark before numeric claims |
+| 14 | Declarative workflow runtime hardening | Absent: tool nodes bypass the shared execution path; no exact route mode, duplicate-id protection, dynamic path cache, size cap, or hydration-error revision loop. | none; blocks 20 | queued | `4cb90e35`; Sentrux-safe seam; regenerate both schemas when Zod changes |
+| 15 | Compaction records, projection, pressure helpers | Absent: no compaction item/schema/projector helpers. | none | queued | `3d65b3e2` + `135ac3fd` |
+| 16 | Fold compactions into model calls; emit context pressure | Absent. Folding must occur before system/history partitioning and pressure latch only on emission. | 15 merged | blocked | `1761e6b7` + `b83bdd91` |
+| 17 | Deterministic minimum-first allocator | Absent: allocator remains 60/40 with unbounded `auto` and a `historyBudget` result. Explicit breaking/RFC review for the 2,000-token cap and interface removal. | 16 merged | blocked | `d8fb4f34` + `59497c48` |
+| 18 | Assignable `context()` output at attachment seams | Absent: seams still use invariant `ContextConfig | ContextLayer[]`; port structural `ContextInput` to `withContext` and current names. | none | queued | `efc2b689` |
+| 19 | Native multi-agent patterns | Primitives remain expressive, but a literal core pattern module conflicts with #68 and `specs/13-patterns.md`. Start with a proposal choosing examples/docs, a separate package, or a deliberate policy reversal. Standard Schema and current names are mandatory. | primitives stable; design approval | design-review | source `4cccf95d` |
+| 20 | Declarative multi-agent nodes/hydrator seam | Absent and intentionally blocked. JSON nodes need an accepted item 19 registry/API and item 14's hardened hydrator seam. | 14 + accepted 19 merged | blocked | `77cb290d` + `928d63c3`; regenerate both schema artifacts and inspector glyphs |
+
+## Dependency graph
+
+```text
+origin/main @ 8a6665ba
+├─ 1 ──(soft conflict reduction)──► 2
+├─ 3
+├─ 4 ─────────────────────────────► 5
+├─ 6
+├─ 7
+├─ 8
+├─ 9
+├─ 10
+├─ 11  (parallel to #69; disjoint behavior)
+├─ 12 ────────────────────────────► 13
+├─ 14 ───────────────┐
+├─ 15 ───────────────► 16 ────────► 17
+├─ 18                │
+└─ 19 design review ─┴────────────► 20
+```
+
+Dependent tranches `12→13`, `15→16→17`, and `14 + 19→20` sequence through merged upstream `main`; they are not maintained as long stacked diffs.
+
+## First independent implementation wave
+
+Delegate in parallel to isolated general-profile Pi workers, each based semantically on current main:
+
+1. item 1 — platform-node file storage;
+2. item 3 — sub-harness reliability;
+3. item 4 — eval guard/concurrency; and
+4. item 6 — OpenUI hardening.
+
+These touch different primary packages and have no hard dependencies. Each worker implements and verifies only its bounded item. The orchestrator inspects every diff, runs a separate clean-context review, applies/fixes confirmed findings, performs fresh verification, creates signed DCO commits, pushes to `fork`, opens an upstream PR, and attaches monitoring.
+
+The next independent wave is selected from items 7, 8, 9, 10, 11, 12, 14, 15, and 18 based on review/CI bandwidth. Item 5 waits for 4; item 2 follows 1 to avoid avoidable platform-node conflicts.
+
+## Per-PR acceptance criteria
+
+Every retained implementation PR must:
+
+- be based on current merged `origin/main`, with dependent tranches rebased only after prerequisites merge;
+- contain a semantic port, not a blind cherry-pick;
+- use current public names and package boundaries;
+- include focused regression tests and required spec/docs/skill changes;
+- regenerate both workflow schema artifacts in the same commit when the workflow Zod schema changes;
+- pass affected package tests and typecheck, root lint, relevant root/full tests, `sentrux check .`, and applicable local `agent-ci` workflows;
+- receive a separate review-profile Pi review for standards, spec, correctness, and port completeness, with confirmed findings fixed and reverified;
+- use Conventional Commit PR titles and signed, DCO-signed-off commits;
+- explain what/why, source provenance, behavior or breaking changes, and test evidence;
+- make no quantified performance claim without a reproducible benchmark;
+- remain monitored for CI, merge conflicts, and review feedback; agent-authored GitHub messages begin with `Agent:`; and
+- be recorded below with branch, URL, CI/review state, and merge SHA or concrete drop evidence.
+
+## Live PR ledger
+
+| Item | Branch | PR | CI | Reviews | Merge SHA / dependency | Last update |
+|---:|---|---|---|---|---|---|
+| 1 | — | — | — | — | independent | 2026-08-12 audit complete |
+| 2 | — | — | — | — | soft after 1 | 2026-08-12 audit complete |
+| 3 | — | — | — | — | independent | 2026-08-12 audit complete |
+| 4 | — | — | — | — | independent; blocks 5 | 2026-08-12 audit complete |
+| 5 | — | — | — | — | blocked by 4 | 2026-08-12 audit complete |
+| 6 | — | — | — | — | independent | 2026-08-12 audit complete |
+| 7 | — | — | — | — | independent | 2026-08-12 audit complete |
+| 8 | — | — | — | — | independent | 2026-08-12 audit complete |
+| 9 | — | — | — | — | independent, breaking default | 2026-08-12 audit complete |
+| 10 | — | — | — | — | validation dropped via #67 | 2026-08-12 audit complete |
+| 11 | — | [#69 separate](https://github.com/mattapperson/noetic/pull/69) | #69 currently failing | — | avoid #69 behavior | 2026-08-12 audit complete |
+| 12 | — | — | — | — | independent; blocks 13 | 2026-08-12 audit complete |
+| 13 | — | — | — | — | blocked by 12 | 2026-08-12 audit complete |
+| 14 | — | — | — | — | independent; blocks 20 | 2026-08-12 audit complete |
+| 15 | — | — | — | — | independent; blocks 16 | 2026-08-12 audit complete |
+| 16 | — | — | — | — | blocked by 15 | 2026-08-12 audit complete |
+| 17 | — | — | — | — | blocked by 16; RFC/breaking | 2026-08-12 audit complete |
+| 18 | — | — | — | — | independent | 2026-08-12 audit complete |
+| 19 | — | — | — | — | design review required | 2026-08-12 audit complete |
+| 20 | — | — | — | — | blocked by 14 + 19 | 2026-08-12 audit complete |
+
+## Program risks
+
+- The plan is intentionally broad; concurrency is bounded by review and CI capacity rather than worker count.
+- Public behavior changes in items 9 and 17 require explicit reviewer attention and release notes.
+- Items 12–17 modify state/persistence semantics; compatibility and rollback tests are required, not just happy-path coverage.
+- Item 14 must use or extract an allowed shared tool-dispatch seam instead of importing upward across Sentrux layers.
+- Item 19 may be rejected as a core API on policy grounds. That is an acceptable documented drop; item 20 is then deferred or redesigned rather than forced through.

--- a/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
+++ b/docs/plans/2026-08-12-001-openrouter-fork-upstreaming-plan.md
@@ -133,7 +133,7 @@ Every retained implementation PR must:
 | Item | Branch | PR | CI | Reviews | Merge SHA / dependency | Last update |
 |---:|---|---|---|---|---|---|
 | 1 | `lukeparke/openrouter-file-storage` | [#70](https://github.com/mattapperson/noetic/pull/70) | CI/DCO/structural pass; compat blocked by missing upstream `OPENROUTER_API_KEY` | no feedback | review-ready; external compat dependency documented | 2026-08-12 opened |
-| 2 | — | — | — | — | soft after 1 | 2026-08-12 audit complete |
+| 2 | `lukeparke/openrouter-queue-ipc` | [#81](https://github.com/mattapperson/noetic/pull/81) | pending | no feedback | independent of #70 after split | 2026-08-12 opened |
 | 3 | `lukeparke/openrouter-sub-harness-reliability` | [#71](https://github.com/mattapperson/noetic/pull/71) | pending | no feedback | independent | 2026-08-12 opened |
 | 4 | `lukeparke/openrouter-eval-safety` | [#72](https://github.com/mattapperson/noetic/pull/72) | pending | no feedback | blocks 5 | 2026-08-12 opened |
 | 5 | — | — | — | — | blocked by 4 merge | 2026-08-12 audit complete |
@@ -150,8 +150,8 @@ Every retained implementation PR must:
 | 16 | — | — | — | — | blocked by 15 | 2026-08-12 audit complete |
 | 17 | — | — | — | — | blocked by 16; RFC/breaking | 2026-08-12 audit complete |
 | 18 | `lukeparke/openrouter-context-input` | [#77](https://github.com/mattapperson/noetic/pull/77) | pending | no feedback | independent | 2026-08-12 opened |
-| 19 | — | — | — | — | design review required | 2026-08-12 audit complete |
-| 20 | — | — | — | — | blocked by 14 + 19 | 2026-08-12 audit complete |
+| 19 | — | — | — | — | proposal committed at `docs/plans/2026-08-12-002-multi-agent-patterns-proposal.md`; recommends examples/docs and rejects core policy reversal | 2026-08-12 design proposal complete |
+| 20 | — | — | — | — | deferred/redesign required: examples cannot be declarative hydration targets; requires accepted package/registry plus item 14 | 2026-08-12 explicitly blocked |
 
 ## Program risks
 

--- a/docs/plans/2026-08-12-002-multi-agent-patterns-proposal.md
+++ b/docs/plans/2026-08-12-002-multi-agent-patterns-proposal.md
@@ -1,0 +1,98 @@
+# Design Proposal: Multi-Agent Patterns (Item 19)
+
+- **Status:** proposal — design review, no runtime code
+- **Source:** fork commit `4cccf95d` (`feat(core): native multi-agent patterns — defineAgent, asTool, handoff, quorum, teammate`, ported from OpenRouter `fa8a9d24`)
+- **Plan item:** 19 in `2026-08-12-001-openrouter-fork-upstreaming-plan.md`
+- **Constraints:** PR #68 removed `packages/core/src/patterns` and cut naming over; `specs/13-patterns.md` normatively states **core ships no bundled agent patterns**; PR #67 made Standard Schema v1 the schema contract.
+
+## Problem
+
+The fork shipped a bundled multi-agent module (`defineAgent`, `asTool`, `handoff`, `quorum`, `teammate`) inside `@noetic-tools/core`. Upstream policy (#68 + spec 13) forbids exactly this: a pattern baked into the framework fixes its termination rules, context boundaries, and feedback shape, and becomes an obstacle when users need to change one of them. Item 19 is therefore a design decision, not a port: where — if anywhere — does this functionality live? This document inventories what the source actually contains and recommends one of three resolutions: examples/docs, a separate package, or a deliberate policy reversal.
+
+## Source inventory (4cccf95d)
+
+773 lines, one file, zero new runtime machinery — every export compiles to existing primitives:
+
+| Export | Shape | Composed from | Reduces to existing runnable composition? |
+|---|---|---|---|
+| `defineAgent(def)` | The "agent noun": name/description/model/instructions/tools/context/until/output, compiled once to a reusable `StepLoop` | `loop` + `step.llm` + `any(noToolCalls, maxSteps(10))`, optional `spawn` | Yes — this is the ReAct recipe with a config bag |
+| `asTool(agent, opts)` | Agent exposed as a `Tool` (`{task: string}` in, text out); sync via `harness.run`, or `detached: true` via `detachedSpawn` + optional result channel | `tool` + `spawn` + `detachedSpawn` + `channel` | Yes — `sync-delegate.ts` and `async-delegate.ts` already demonstrate both halves |
+| `handoff(agents, opts)` | Routing swarm: per-agent `transfer_to_<peer>` tools, active agent swapped via `ctx.state` + `Lazy` model/instructions/tools, shared ItemLog | `loop` + `step.llm` + custom `until` + `prepareNext` | Partially — the `Lazy`-re-resolution trick over `ctx.state` is novel and worth documenting |
+| `quorum(agents, {vote})` | Fan-out panel with `majority` / `first` / `all` / `judge` reduction | `fork('settle')` + merge fn; judge = `loop` of fan-out then one judge turn | Mostly — `parallel-research.ts` + `dynamic-judge-workflow.ts` cover fan-out and judge separately |
+| `teammate(agent, task, toolCtx)` | Named background worker: detached thread, queue-mode inbox/outbox channels, `send`/`status`/`result` handle, failures surface on outbox | `detachedSpawn` + `spawn` + two `channel`s + inbox-parked `loop` | Partially — `async-delegate.ts` shows detached+inbox; the parked-on-inbox loop and status handle are the delta |
+
+The genuinely reusable deltas over today's examples are: (a) the handoff swarm's per-iteration `Lazy` swap, (b) the teammate's parked inbox loop with a status handle, (c) the judge-vote reducer. Everything else is recipe composition the spec already demonstrates.
+
+## Required adaptation if any code ships
+
+- **Naming cutover (#68):** `step.llm` → `callModel`; `fork({mode:'settle'})` → `inParallel(..., 'settle')`; `frameworkCast` only where genuinely needed. Loop `inbox`/`parkTimeout` and `detachedSpawn` survive unchanged.
+- **Standard Schema (#67):** `AgentDef.output?: ZodType` → `StandardSchemaV1<unknown, O>` (spec 02); `tool({input/output})` likewise. The `z.object({task})` internal input schemas can stay Zod (fast path) but the public types must accept any Standard Schema validator — and `defineAgent` must propagate `outputJsonSchema` for validation-only schemas or hit `MISSING_JSON_SCHEMA` at runtime.
+- **No `packages/core/src/patterns` directory** under any option except a policy reversal; `.sentrux/rules.toml` and `specs/13-patterns.md` would both need edits in the same commit.
+
+### Naming / CLI collision check
+
+`teammate` collides with an established CLI-domain concept: the Noetic CLI (noetic-internal, spec 22, `packages/web/content/docs/code-agent-cli/`) already uses "teammate" for sub-agent presets spawned via its `agent` tool, with `send_message` / `check_agent` companions, and `spawn.mdx` documents per-teammate session logs. A core export named `teammate()` would shadow that vocabulary at a different layer with different semantics (channel-addressable worker vs. CLI sub-agent preset). If the shape ships, rename to `backgroundAgent()` / `worker()`; keep `teammate` reserved for the CLI domain. `handoff` and `quorum` are collision-free; `asTool` reads fine; `defineAgent` is the most builder-flavored name and the one spec 13's philosophy most objects to (see options).
+
+## Options
+
+### Option A — Examples + docs recipes (recommended)
+
+Port the four shapes as **runnable compositions**: `defineAgent` dissolved back into the ReAct recipe (it is one), plus new examples `handoff-swarm.ts`, `quorum-panel.ts`, `background-agent.ts` under `packages/core/examples/`, and matching rows + prose in `specs/13-patterns.md` ("Runnable Compositions" table). Web docs get a "Multi-agent patterns" guide under `packages/web/content/docs/framework/`.
+
+- **Acceptance criteria:** each example compiles and has a test; spec 13 table updated in the same commit; no new core exports; docs use post-#68 names and Standard Schema.
+- **Rejection criteria:** the examples duplicate >100 lines of non-trivial shared logic across copies, or consumers demonstrably need stable cross-version behavior (semver) for the vote reducers/handle semantics — that's the signal for Option B.
+
+### Option B — Separate `@noetic-tools/patterns` package
+
+Ship the compositions as **copy-ready source with tests** (not re-exported builders), per spec 13's own "Future considerations". Depends on `core` only; new `[[layers]]` entry + boundary in `.sentrux/rules.toml`.
+
+- **Acceptance criteria:** Option A's rejection criteria trigger, OR two or more downstream consumers vendor the same recipe. Public surface is small and explicitly recipe-flavored: `reactAgent()`, `handoffSwarm()`, `panel()` (not `quorum`, to avoid implying consensus machinery it doesn't have), `backgroundAgent()`. No `defineAgent` noun — pass plain config objects.
+- **Rejection criteria:** the package just re-exports thin wrappers users could paste; publish/maintenance cost exceeds the value; or it drifts into fixing termination/context policy per user (spec 13's original objection).
+
+### Option C — Policy reversal: restore bundled patterns in core
+
+Re-add `packages/core/src/patterns/agents.ts` behind `@public` exports, edit spec 13 and `.sentrux/rules.toml` in the same commit.
+
+- **Acceptance criteria (all required):** written rationale superseding spec 13's "patterns are compositions" argument; maintainer sign-off that core's API surface should grow by 5 exports + 3 types; a demonstrated consumer that cannot use examples or a side package.
+- **Rejection criteria:** any of the above missing. On current evidence none are met — this option exists to make the rejection explicit and documented, which the plan (line 162) already sanctions as an acceptable outcome.
+
+## Recommendation
+
+**Option A now, Option B as a triggered evolution, reject C on the record.** The source commit itself is the proof: 773 lines composing only builders, with no interpreter/runtime change — which is spec 13's thesis. The novel deltas (Lazy handoff swap, parked-inbox teammate, judge reducer) are exactly the kind of thing runnable examples teach better than frozen builders.
+
+## Concrete API alternatives (if B ever triggers)
+
+```ts
+// @noetic-tools/patterns — recipes, not builders; Standard Schema throughout
+import { callModel, inParallel, loop, spawn, until } from '@noetic-tools/core';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+
+reactAgent({ model, instructions, tools, maxSteps?, maxCost?, context? });      // = today's ReAct recipe
+handoffSwarm(agents: AgentConfig[], { entry?, until?, maxIterations? });        // Lazy swap over ctx.state
+panel(agents: AgentConfig[], { vote: 'majority' | 'first' | 'all' | { judge } });
+backgroundAgent(agent: AgentConfig, task, toolCtx): { send, status, result, outbox };
+
+interface AgentConfig {
+  name: string;                                  // tool-name-safe
+  description?: string;
+  model: Lazy<string>;
+  instructions?: Lazy<string | undefined>;
+  tools?: Tool[];
+  context?: ContextConfig | ContextLayer[];
+  output?: StandardSchemaV1<unknown, unknown>;   // + outputJsonSchema for validation-only schemas
+}
+```
+
+Note what is absent vs. the fork: no `Agent` wrapper type, no memoized `agent.step`, no `defineAgent`. The recipe takes config and returns a `Step`; the user owns the noun.
+
+## Implications for item 20 (declarative multi-agent nodes)
+
+Item 20 (JSON workflow nodes for multi-agent shapes) is blocked on this decision because a JSON node must hydrate against a **registered, versioned API** — examples cannot be hydration targets.
+
+- **Option A (chosen):** item 20 is deferred or redesigned. A JSON `handoff`/`quorum` node has nothing stable to hydrate to; the honest resolution is to extend the JSON schema's existing node set only when/if Option B lands. This matches plan line 162 ("item 20 is then deferred or redesigned rather than forced through").
+- **Option B (if triggered later):** item 20 unblocks cleanly — add `handoff`/`panel`/`background-agent` node types whose hydrator resolves against `@noetic-tools/patterns` via the registry seam from item 14, regenerating both `noetic-workflow.schema.json` artifacts (`bun run gen:schema`) and inspector glyphs in the same commit.
+- **Option C:** same as B but against core; rejected for the reasons above.
+
+## Decision requested
+
+Approve Option A and record the rejection of Option C, or direct Option B with the naming adjustments above.

--- a/packages/context/src/context/layer-lifecycle.ts
+++ b/packages/context/src/context/layer-lifecycle.ts
@@ -480,8 +480,14 @@ export async function initLayers({ layers, ctx, storage, store }: InitLayersPara
  * and `store()` hooks — are mirrored durably; `store()` is not special.
  * 'execution' scope is excluded: its scope key rotates each run, so there is
  * nothing durable to mirror.
+ *
+ * Exported (rather than private to `initLayers`) because a host that carries
+ * layer state forward across executions — warm hydration, see
+ * `AgentHarness.ensureLayersInit` — has to re-point write-through at the new
+ * executionId WITHOUT re-running `init`, which is the whole point of carrying
+ * state forward.
  */
-function registerDurableTargets({
+export function registerDurableTargets({
   layers,
   ctx,
   storage,

--- a/packages/core/src/harness/agent-harness.ts
+++ b/packages/core/src/harness/agent-harness.ts
@@ -60,6 +60,8 @@ import {
   filterReasoningStream,
   filterTextStream,
   ItemLogImpl,
+  ItemLogPersistence,
+  itemLogOwnerKey,
   resolveStepLedgerRetention,
   restoreFromCheckpoint,
   SessionRunner,
@@ -427,6 +429,11 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
    */
   readonly stepLedgerStore?: StepLedgerStore;
   /**
+   * Per-harness item-log persistence watermarks for O(delta) checkpoint batches.
+   * @internal
+   */
+  readonly itemLogPersistence = new ItemLogPersistence();
+  /**
    * Resolved retention bounds for that ledger. Validated at construction so a bad cap
    * is a loud config error rather than a run that silently records nothing.
    * @internal
@@ -679,6 +686,13 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
       validated.append(item);
     }
     session.log.truncateTo(0);
+    this.itemLogPersistence.rollback(
+      itemLogOwnerKey({
+        threadId,
+        id: '',
+      }),
+      0,
+    );
     for (const item of validated.items) {
       session.log.append(item);
     }
@@ -740,6 +754,13 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
         },
         rollbackTurn: () => {
           sessionLog.truncateTo(turnWatermark);
+          this.itemLogPersistence.rollback(
+            itemLogOwnerKey({
+              threadId,
+              id: '',
+            }),
+            turnWatermark,
+          );
         },
         runTurn: async (ctx, _turn, signal) => {
           if (!this.agentGraph) {

--- a/packages/core/src/harness/agent-harness.ts
+++ b/packages/core/src/harness/agent-harness.ts
@@ -26,7 +26,9 @@ import {
   recallLayers,
   recallLayersAtomic,
   recallLayersEventual,
+  registerDurableTargets,
   resolveLayerTools,
+  resolveScopeKey,
   runAppendPipeline,
   storeLayers,
 } from './deps/context';
@@ -57,6 +59,7 @@ import {
   createStepLedgerStore,
   filterReasoningStream,
   filterTextStream,
+  ItemLogImpl,
   resolveStepLedgerRetention,
   restoreFromCheckpoint,
   SessionRunner,
@@ -206,7 +209,14 @@ interface AgentHarnessOpts<TParams extends Record<string, unknown> = Record<stri
 
 interface Session {
   readonly runner: SessionRunner;
-  accumulatedItems: Item[];
+  /**
+   * The single session-owned conversation log. Every turn's context shares
+   * this instance by reference — there is no per-turn copy-forward or
+   * copy-back, and `previewRequestItems` reads the same object the turn
+   * writes. Failed/aborted turns are rolled back to a watermark by the
+   * runner so they leave no trace, preserving the old copy semantics.
+   */
+  readonly log: ItemLogImpl;
 }
 
 //#endregion
@@ -455,6 +465,26 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
    * `ctx.id` (the layer-state store's executionId).
    */
   private readonly initializedExecutions = new Set<string>();
+  /**
+   * `<layerId>@<scopeKey>` → the execution that last hydrated that layer's state
+   * (warm layer-state carry-forward).
+   *
+   * Keyed by BUCKET, not by thread. A layer's state lives under
+   * `resolveScopeKey(layer.scope, ctx)`, and for 'resource' and 'global' scope
+   * that key is not a function of the thread: two turns on one thread with
+   * different `resourceId`s address different resource buckets, and every thread
+   * in the process shares the one global bucket. Keying on thread identity gets
+   * both wrong in opposite directions — it carries state ACROSS resource buckets
+   * (one tenant's state into another's, then persisted there, because
+   * `registerDurableTargets` re-points write-through at the new scope key), and
+   * it FAILS to carry state across threads sharing the global bucket (each
+   * thread resumes its own stale copy, so the write-through mirror makes the last
+   * writer win and drops the others' updates).
+   *
+   * Keying by bucket makes both a function of the same fact: a layer continues
+   * from whatever execution last touched the bucket it is about to read.
+   */
+  private readonly hydratedLayers = new Map<string, string>();
   readonly traceExporter: TraceExporter;
   /**
    * Long-lived shared cwd state. The same reference is seeded into every
@@ -466,6 +496,13 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
    *  in `runtime/durable/` (restore) can parse persisted items. Do not
    *  access from outside core. */
   readonly itemSchemas: ItemSchemaRegistry;
+  /**
+   * Memoized harness-base ∪ harness-layer item registry, used for the shared
+   * session log. `_contextLayers` is readonly and set once in the constructor,
+   * so the extension is a pure function of construction options — see
+   * `sessionItemSchemas`.
+   */
+  private _sessionItemSchemasCache?: ItemSchemaRegistry;
 
   constructor(opts: AgentHarnessOpts<TParams>) {
     const validatedParams = opts.paramsSchema ? opts.paramsSchema.parse(opts.params) : opts.params;
@@ -635,9 +672,16 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
 
   seedSessionHistory(threadId: string, items: ReadonlyArray<Item>): void {
     const session = this.getOrCreateSession(threadId);
-    session.accumulatedItems = [
-      ...items,
-    ];
+    // Validate the entire replacement first so one bad item cannot destroy
+    // existing history or leave a partially seeded shared log.
+    const validated = new ItemLogImpl(this.sessionItemSchemas());
+    for (const item of items) {
+      validated.append(item);
+    }
+    session.log.truncateTo(0);
+    for (const item of validated.items) {
+      session.log.append(item);
+    }
   }
 
   private getOrCreateSession(threadId: string): Session {
@@ -646,8 +690,17 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
       return existing;
     }
 
+    // The LAYER-EXTENDED registry, not the harness base. The session log is
+    // shared with every context this thread builds, and `createContext` extends
+    // the base with the layers' `itemSchemas` — so a log bound to the base would
+    // reject exactly the custom item types those layers declare, on both the
+    // `seedSessionHistory` path and mid-turn (`onItemAppend`, tool results).
+    const sessionLog = new ItemLogImpl(this.sessionItemSchemas());
+    // Watermark captured at turn start (before the turn's input lands); a
+    // failed turn truncates back to it so partial items leave no trace.
+    let turnWatermark = 0;
     const session: Session = {
-      accumulatedItems: [],
+      log: sessionLog,
       runner: new SessionRunner({
         threadId,
         agentName: this.config.name,
@@ -658,12 +711,14 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
         // time and doesn't apply here.
         createContext: (items, _turnId, messages) => {
           const perTurnOptions: ExecuteOptions = messages[0]?.options ?? {};
-          const allItems: Item[] = [
-            ...session.accumulatedItems,
-            ...items,
-          ];
+          // Append this turn's input to the SESSION log and hand the same log
+          // to the context — single owner, zero per-turn copies.
+          turnWatermark = sessionLog.length;
+          for (const item of items) {
+            sessionLog.append(item);
+          }
           const ctx = this.createContext({
-            items: allItems,
+            itemLog: sessionLog,
             threadId,
             resourceId: perTurnOptions.resourceId,
             state: perTurnOptions.state,
@@ -682,6 +737,9 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
             ]);
           }
           return ctx;
+        },
+        rollbackTurn: () => {
+          sessionLog.truncateTo(turnWatermark);
         },
         runTurn: async (ctx, _turn, signal) => {
           if (!this.agentGraph) {
@@ -706,10 +764,6 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
             );
           }
           const result = await this.initAndRun(this.agentGraph, '', ctx);
-          // Snapshot final items into session history for the next turn.
-          session.accumulatedItems = [
-            ...ctx.itemLog.items,
-          ];
           return result;
         },
       }),
@@ -815,8 +869,19 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
    * treated as disabled. Guarded so nested/repeated `run()` calls and the
    * session turn path never re-init — re-init would re-hydrate from storage and
    * clobber accumulated in-memory state.
+   *
+   * Turns addressing the same layer scope bucket take the WARM path: layer
+   * state carries forward in-memory rather than being re-read from storage
+   * (sequential reads, each with a 10s timeout, every turn). `transient: true`
+   * opts a throwaway context out of publishing itself as a warm source — see
+   * `previewRequestItems`, which tears its execution's state down again.
    */
-  private async ensureLayersInit(ctx: Context): Promise<void> {
+  private async ensureLayersInit(
+    ctx: Context,
+    opts?: {
+      transient?: boolean;
+    },
+  ): Promise<void> {
     const layers = ctx.layers;
     const storage = this.config.storage;
     if (!layers || layers.length === 0 || !storage) {
@@ -826,7 +891,162 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
       return;
     }
     this.initializedExecutions.add(ctx.id);
-    await this.initLayers(layers, ctx, storage);
+    const warmKeys = this.resolveWarmKeys(layers, ctx);
+    await this.tryWarmInit({
+      warmKeys,
+      layers,
+      ctx,
+      storage,
+    });
+    if (!opts?.transient) {
+      for (const [layerId, warmKey] of warmKeys) {
+        // Only publish for layers this execution actually holds state for; a
+        // layer whose init failed with `onInitError: 'disable'` has nothing to
+        // hand the next turn.
+        if (this.layerStateStore.has?.(ctx.id, layerId)) {
+          this.hydratedLayers.set(warmKey, ctx.id);
+        }
+      }
+    }
+  }
+
+  /**
+   * The warm-cache key for each layer: its id plus the storage bucket it
+   * resolves to for `ctx`. Execution-scoped layers are omitted — they never
+   * carry forward, and their scope key is `ctx.id`, so an entry would be a
+   * per-run leak.
+   */
+  private resolveWarmKeys(
+    layers: ReadonlyArray<ContextLayer>,
+    ctx: Context,
+  ): ReadonlyMap<string, string> {
+    const execCtx = this.toExecCtx(ctx);
+    const keys = new Map<string, string>();
+    for (const layer of layers) {
+      if (layer.scope === 'execution') {
+        continue;
+      }
+      keys.set(layer.id, `${layer.id}@${resolveScopeKey(layer.scope, execCtx)}`);
+    }
+    return keys;
+  }
+
+  /**
+   * Warm path: some previous execution already hydrated these layers from
+   * storage. Copy the live in-memory state forward to the new executionId
+   * instead of re-running every init. The state store is the source of truth
+   * between turns — its durable write-through keeps storage in sync.
+   *
+   * Resolved PER LAYER against `(layer, scopeKey)`, which is the identity of the
+   * storage bucket the layer's state actually lives in. A layer therefore carries
+   * forward from the last execution that touched ITS bucket, whatever thread that
+   * was: a resource-scoped layer on a turn with a new `resourceId` finds no entry
+   * for the new bucket and cold-inits from it, while a global-scoped layer shares
+   * one entry across every thread, so an increment on thread B is what thread A's
+   * next turn continues from. Execution-scoped layers are per-run by contract and
+   * never carry forward.
+   *
+   * Every layer this did not carry forward is cold-inited here, so the caller
+   * needs no fallback — the return value is informational.
+   */
+  private async tryWarmInit({
+    warmKeys,
+    layers,
+    ctx,
+    storage,
+  }: {
+    warmKeys: ReadonlyMap<string, string>;
+    layers: ContextLayer[];
+    ctx: Context;
+    storage: StorageAdapter;
+  }): Promise<boolean> {
+    const carried = this.carryLayerStateForward({
+      warmKeys,
+      layers,
+      ctx,
+    });
+    // Cold-init covers execution-scoped layers, layers whose bucket has no warm
+    // entry, and layers that were never hydrated in the first place.
+    const cold = layers.filter(
+      (l) => l.scope === 'execution' || !this.layerStateStore.has?.(ctx.id, l.id),
+    );
+    if (cold.length > 0) {
+      await this.initLayers(cold, ctx, storage);
+    }
+    if (carried === 0) {
+      // `initLayers` already registered durable targets for every layer it ran,
+      // which — with nothing carried — is all of them.
+      return false;
+    }
+    // Re-point write-through at the new execution id for the carried layers too,
+    // so their state keeps mirroring durably without a re-`init`.
+    registerDurableTargets({
+      layers: layers.filter((l) => l.scope !== 'execution'),
+      ctx: this.toExecCtx(ctx),
+      storage,
+      store: this.layerStateStore,
+    });
+    return true;
+  }
+
+  /**
+   * Copy each layer's live state forward from whichever execution last hydrated
+   * that layer's bucket. Returns how many layers were carried.
+   */
+  private carryLayerStateForward({
+    warmKeys,
+    layers,
+    ctx,
+  }: {
+    warmKeys: ReadonlyMap<string, string>;
+    layers: ReadonlyArray<ContextLayer>;
+    ctx: Context;
+  }): number {
+    let copied = 0;
+    for (const layer of layers) {
+      const warmKey = warmKeys.get(layer.id);
+      if (warmKey === undefined) {
+        // Execution scope — `resolveWarmKeys` omits it.
+        continue;
+      }
+      const warm = this.hydratedLayers.get(warmKey);
+      // `warm === ctx.id` is a re-entrant init of the same execution: there is
+      // nothing to copy, and copying onto itself would be a no-op anyway.
+      if (warm === undefined || warm === ctx.id) {
+        continue;
+      }
+      if (!this.layerStateStore.has?.(warm, layer.id)) {
+        // The warm execution's state was torn down (dispose/cleanup). Drop the
+        // stale pointer so later turns stop probing it.
+        this.hydratedLayers.delete(warmKey);
+        continue;
+      }
+      this.layerStateStore.set(ctx.id, layer.id, this.layerStateStore.get(warm, layer.id));
+      copied++;
+    }
+    return copied;
+  }
+
+  /**
+   * Item registry for the SHARED SESSION LOG: the harness base extended with
+   * the harness-level context layers' `itemSchemas`.
+   *
+   * Deliberately keyed to the HARNESS layer set, not a turn's. `createContext`
+   * lets a caller pass per-turn `contextLayers`, and those layers' item types
+   * are validated by that context's own (wider) registry on the paths that build
+   * one — but the log outlives any single turn and is shared by all of them, so
+   * binding it to one turn's layer set would make what the log accepts depend on
+   * whichever turn happened to create the session. Harness-level layers are the
+   * stable set every turn on the thread has, so they are the log's contract; a
+   * per-turn layer that declares a brand-new item type and appends it to the
+   * shared log must also be declared at harness level.
+   */
+  private sessionItemSchemas(): ItemSchemaRegistry {
+    this._sessionItemSchemasCache ??= buildItemSchemaRegistry({
+      base: this.itemSchemas,
+      layers: this._contextLayers,
+    });
+    return this._sessionItemSchemasCache;
   }
 
   detachedSpawn<I, O>(
@@ -845,6 +1065,8 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
   createContext(opts?: {
     parent?: Context;
     items?: Item[];
+    /** @internal Share the session-owned log instead of seeding from `items`. */
+    itemLog?: ItemLogImpl;
     state?: unknown;
     threadId?: string;
     resourceId?: string;
@@ -1045,7 +1267,7 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
     const existingSession = this.sessions.get(threadId);
     const historyItems: Item[] = existingSession
       ? [
-          ...existingSession.accumulatedItems,
+          ...existingSession.log.items,
         ]
       : [];
     const ctx = this.createContext({
@@ -1058,7 +1280,14 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
       return historyItems;
     }
     try {
-      await this.ensureLayersInit(ctx);
+      /* `transient`: this context's state is torn down in the `finally` below, so
+       * it must NOT become a warm-hydration source — a real turn that followed
+       * it would find a pointer to wiped state, carry nothing forward, and
+       * silently cold-init (correct, but the warm win evaporates after any
+       * preview, which a TUI may issue on every keystroke). */
+      await this.ensureLayersInit(ctx, {
+        transient: true,
+      });
       const recallResults = await this.recallLayers(layers, '', ctx);
       // Band the output the way a real turn would, but read-only: a preview
       // must not pin, count churn, or age the epoch, or looking at a
@@ -1116,6 +1345,14 @@ export class AgentHarness<TParams extends Record<string, unknown> = Record<strin
     // Drop the init guard so a deliberate dispose→run cycle re-hydrates from
     // storage (disposeLayers also clears the layer-state store for this id).
     this.initializedExecutions.delete(ctx.id);
+    // ...and any warm pointer aimed at this execution, whose state is about to
+    // be wiped. A stale pointer only degrades to a cold init, but dropping it
+    // here keeps the two guards from disagreeing about what is hydrated.
+    for (const [warmKey, executionId] of this.hydratedLayers) {
+      if (executionId === ctx.id) {
+        this.hydratedLayers.delete(warmKey);
+      }
+    }
     await disposeLayers({
       layers,
       ctx: this.toExecCtx(ctx),

--- a/packages/core/src/harness/deps/context.ts
+++ b/packages/core/src/harness/deps/context.ts
@@ -17,7 +17,9 @@ export {
   recallLayers,
   recallLayersAtomic,
   recallLayersEventual,
+  registerDurableTargets,
   resolveLayerTools,
+  resolveScopeKey,
   runAppendPipeline,
   storeLayers,
 } from '@noetic-tools/context';

--- a/packages/core/src/harness/deps/runtime.ts
+++ b/packages/core/src/harness/deps/runtime.ts
@@ -20,6 +20,7 @@ export {
 } from '../../runtime/durable/step-ledger';
 export type { EventBroadcaster } from '../../runtime/event-broadcaster';
 export { createInMemoryStorage } from '../../runtime/in-memory-storage';
+export { ItemLogImpl } from '../../runtime/item-log-impl';
 export type { QueuedMessage } from '../../runtime/message-queue';
 export { SessionRunner } from '../../runtime/session-runner';
 export {

--- a/packages/core/src/harness/deps/runtime.ts
+++ b/packages/core/src/harness/deps/runtime.ts
@@ -6,6 +6,8 @@ export type { RestoreCheckpointOptions } from '../../runtime/durable/harness-che
 export {
   captureCheckpoint,
   clearCheckpoint,
+  ItemLogPersistence,
+  itemLogOwnerKey,
   restoreFromCheckpoint,
 } from '../../runtime/durable/harness-checkpoints';
 export type {

--- a/packages/core/src/runtime/context-impl.ts
+++ b/packages/core/src/runtime/context-impl.ts
@@ -155,6 +155,13 @@ export class ContextImpl implements Context<ContextData> {
     harness: AgentHarnessContract;
     parent?: Context;
     items?: Item[];
+    /**
+     * Share an existing log instead of building a fresh one from `items`.
+     * The session runner passes its session-owned log here so every turn in a
+     * thread appends to ONE log — no copy-forward/copy-back per turn.
+     * Mutually exclusive with `items`.
+     */
+    itemLog?: ItemLogImpl;
     state?: unknown;
     threadId?: string;
     resourceId?: string;
@@ -200,13 +207,17 @@ export class ContextImpl implements Context<ContextData> {
     };
     this._broadcaster = opts._broadcaster;
 
-    const log = new ItemLogImpl(this.itemSchemas);
-    if (opts.items) {
-      for (const item of opts.items) {
-        log.append(item);
+    if (opts.itemLog) {
+      this.itemLog = opts.itemLog;
+    } else {
+      const log = new ItemLogImpl(this.itemSchemas);
+      if (opts.items) {
+        for (const item of opts.items) {
+          log.append(item);
+        }
       }
+      this.itemLog = log;
     }
-    this.itemLog = log;
 
     // Join the parent's abort cascade last, so the child is fully constructed
     // before an already-aborted parent aborts it.

--- a/packages/core/src/runtime/durable/checkpoint-store.ts
+++ b/packages/core/src/runtime/durable/checkpoint-store.ts
@@ -1,4 +1,5 @@
 import type { StorageAdapter } from '@noetic-tools/context';
+import { storageGetMany } from '@noetic-tools/context';
 import { NoeticConfigError } from '@noetic-tools/types';
 import type { CheckpointSnapshot } from '../../types/checkpoint';
 import { CheckpointSnapshotSchema } from '../../types/checkpoint';
@@ -52,6 +53,31 @@ export interface CheckpointStore {
   save(snapshot: CheckpointSnapshot): Promise<void>;
   /** Load the snapshot for an execution, or `null` if none is recorded. */
   load(executionId: string): Promise<CheckpointSnapshot | null>;
+  /**
+   * Append an item-log batch starting at item index `offset`. Batches are the
+   * O(delta) alternative to inlining the whole log in every snapshot; the
+   * batch key embeds `offset` so a retried write is idempotent.
+   *
+   * `ownerKey` is an opaque owner identity, not an execution id — the session
+   * owns the log across every turn in a thread, so callers pass
+   * `thread:<threadId>` (falling back to `execution:<id>` for threadless
+   * one-shot contexts).
+   */
+  appendItems?(ownerKey: string, offset: number, items: unknown[]): Promise<void>;
+  /**
+   * Load and stitch persisted item batches, returning the first `count` items
+   * in order.
+   *
+   * Stitching is continuity-checked: a batch is accepted only when its start
+   * offset equals the number of items stitched so far. The first gap or
+   * overlap ends the stitch, returning a short but contiguous prefix.
+   */
+  loadItems?(ownerKey: string, count: number): Promise<unknown[]>;
+  /**
+   * Drop every persisted item batch for `ownerKey` whose start offset is at or
+   * beyond `offset`, trimming the one batch that straddles the cut.
+   */
+  truncateItems?(ownerKey: string, offset: number): Promise<void>;
   /** List every `executionId` that has a persisted snapshot. */
   list(): Promise<
     ReadonlyArray<{
@@ -73,6 +99,29 @@ export interface CreateCheckpointStoreOptions {
 
 function snapshotKey(executionId: string): string {
   return `${EXEC_KEY_PREFIX}${executionId}${SNAPSHOT_SUFFIX}`;
+}
+
+/** Prefix owning every item-log batch for one log owner. */
+function itemBatchPrefix(ownerKey: string): string {
+  return `${EXEC_KEY_PREFIX}${ownerKey}${ITEM_LOG_SUFFIX}:`;
+}
+
+/** Zero-padded so lexicographic key order matches item order under `list()`. */
+function itemBatchKey(ownerKey: string, offset: number): string {
+  return `${itemBatchPrefix(ownerKey)}${String(offset).padStart(8, '0')}`;
+}
+
+/** The start offset a batch key encodes, or null when the suffix is not one. */
+function itemBatchOffset(ownerKey: string, key: string): number | null {
+  const prefix = itemBatchPrefix(ownerKey);
+  if (!key.startsWith(prefix)) {
+    return null;
+  }
+  const suffix = key.slice(prefix.length);
+  if (suffix.length === 0 || !/^\d+$/.test(suffix)) {
+    return null;
+  }
+  return Number(suffix);
 }
 
 function executionIdFromSnapshotKey(key: string): string | null {
@@ -149,6 +198,63 @@ export function createCheckpointStore(options: CreateCheckpointStoreOptions): Ch
     return out;
   }
 
+  async function appendItems(ownerKey: string, offset: number, items: unknown[]): Promise<void> {
+    await storage.set(itemBatchKey(ownerKey, offset), items);
+  }
+
+  async function loadItems(ownerKey: string, count: number): Promise<unknown[]> {
+    const keys = (await storage.list(itemBatchPrefix(ownerKey))).sort();
+    const batches = await storageGetMany<unknown[]>(storage, keys);
+    const out: unknown[] = [];
+    for (const key of keys) {
+      const offset = itemBatchOffset(ownerKey, key);
+      if (offset === null || offset !== out.length) {
+        break;
+      }
+      const batch = batches.get(key);
+      if (!batch) {
+        break;
+      }
+      out.push(...batch);
+      if (out.length >= count) {
+        break;
+      }
+    }
+    return out.slice(0, count);
+  }
+
+  async function truncateItems(ownerKey: string, offset: number): Promise<void> {
+    const keyed: Array<{
+      key: string;
+      offset: number;
+    }> = [];
+    for (const key of await storage.list(itemBatchPrefix(ownerKey))) {
+      const batchOffset = itemBatchOffset(ownerKey, key);
+      if (batchOffset === null) {
+        continue;
+      }
+      keyed.push({
+        key,
+        offset: batchOffset,
+      });
+    }
+    keyed.sort((a, b) => a.offset - b.offset);
+    const straddleCandidate = keyed.filter((entry) => entry.offset < offset).pop();
+    for (const entry of keyed) {
+      if (entry.offset >= offset) {
+        await storage.delete(entry.key);
+      }
+    }
+    if (!straddleCandidate) {
+      return;
+    }
+    const batch = await storage.get<unknown[]>(straddleCandidate.key);
+    if (!batch || straddleCandidate.offset + batch.length <= offset) {
+      return;
+    }
+    await storage.set(straddleCandidate.key, batch.slice(0, offset - straddleCandidate.offset));
+  }
+
   async function clear(executionId: string): Promise<void> {
     await storage.delete(snapshotKey(executionId));
   }
@@ -156,6 +262,9 @@ export function createCheckpointStore(options: CreateCheckpointStoreOptions): Ch
   return {
     save,
     load,
+    appendItems,
+    loadItems,
+    truncateItems,
     list,
     clear,
   };

--- a/packages/core/src/runtime/durable/checkpoint-store.ts
+++ b/packages/core/src/runtime/durable/checkpoint-store.ts
@@ -223,36 +223,51 @@ export function createCheckpointStore(options: CreateCheckpointStoreOptions): Ch
     return out.slice(0, count);
   }
 
-  async function truncateItems(ownerKey: string, offset: number): Promise<void> {
-    const keyed: Array<{
+  async function listItemBatches(ownerKey: string): Promise<
+    Array<{
       key: string;
       offset: number;
-    }> = [];
-    for (const key of await storage.list(itemBatchPrefix(ownerKey))) {
-      const batchOffset = itemBatchOffset(ownerKey, key);
-      if (batchOffset === null) {
-        continue;
-      }
-      keyed.push({
-        key,
-        offset: batchOffset,
-      });
-    }
-    keyed.sort((a, b) => a.offset - b.offset);
-    const straddleCandidate = keyed.filter((entry) => entry.offset < offset).pop();
-    for (const entry of keyed) {
-      if (entry.offset >= offset) {
-        await storage.delete(entry.key);
-      }
-    }
-    if (!straddleCandidate) {
+    }>
+  > {
+    const entries = (await storage.list(itemBatchPrefix(ownerKey))).flatMap((key) => {
+      const offset = itemBatchOffset(ownerKey, key);
+      return offset === null
+        ? []
+        : [
+            {
+              key,
+              offset,
+            },
+          ];
+    });
+    return entries.sort((a, b) => a.offset - b.offset);
+  }
+
+  async function trimStraddlingBatch(
+    candidate:
+      | {
+          key: string;
+          offset: number;
+        }
+      | undefined,
+    offset: number,
+  ): Promise<void> {
+    if (!candidate) {
       return;
     }
-    const batch = await storage.get<unknown[]>(straddleCandidate.key);
-    if (!batch || straddleCandidate.offset + batch.length <= offset) {
-      return;
+    const batch = await storage.get<unknown[]>(candidate.key);
+    if (batch && candidate.offset + batch.length > offset) {
+      await storage.set(candidate.key, batch.slice(0, offset - candidate.offset));
     }
-    await storage.set(straddleCandidate.key, batch.slice(0, offset - straddleCandidate.offset));
+  }
+
+  async function truncateItems(ownerKey: string, offset: number): Promise<void> {
+    const entries = await listItemBatches(ownerKey);
+    const straddling = entries.filter((entry) => entry.offset < offset).pop();
+    await Promise.all(
+      entries.filter((entry) => entry.offset >= offset).map((entry) => storage.delete(entry.key)),
+    );
+    await trimStraddlingBatch(straddling, offset);
   }
 
   async function clear(executionId: string): Promise<void> {

--- a/packages/core/src/runtime/durable/harness-checkpoints.ts
+++ b/packages/core/src/runtime/durable/harness-checkpoints.ts
@@ -33,6 +33,7 @@ export type RestoreCheckpointOptions = RestoreContextOptions & {
  */
 export interface CheckpointHarnessHandle {
   readonly checkpointStore?: CheckpointStore;
+  readonly itemLogPersistence: ItemLogPersistence;
   readonly stepLedgerStore?: StepLedgerStore;
   readonly stepLedgerRetention?: StepLedgerRetention;
   readonly layerStateStore: LayerStateStore;
@@ -51,6 +52,70 @@ export interface CheckpointHarnessHandle {
 
 //#region captureCheckpoint
 
+export class ItemLogPersistence {
+  private readonly counts = new Map<string, number>();
+  private readonly dirtyFrom = new Map<string, number>();
+
+  get(ownerKey: string): number {
+    return this.counts.get(ownerKey) ?? 0;
+  }
+
+  set(ownerKey: string, count: number): void {
+    this.counts.set(ownerKey, count);
+  }
+
+  rollback(ownerKey: string, length: number): void {
+    const current = this.counts.get(ownerKey);
+    if (current === undefined || current <= length) {
+      return;
+    }
+    this.counts.set(ownerKey, length);
+    const existing = this.dirtyFrom.get(ownerKey);
+    this.dirtyFrom.set(ownerKey, existing === undefined ? length : Math.min(existing, length));
+  }
+
+  dirtyOffset(ownerKey: string): number | undefined {
+    return this.dirtyFrom.get(ownerKey);
+  }
+
+  clearDirty(ownerKey: string): void {
+    this.dirtyFrom.delete(ownerKey);
+  }
+
+  delete(ownerKey: string): void {
+    this.counts.delete(ownerKey);
+    this.dirtyFrom.delete(ownerKey);
+  }
+}
+
+export function itemLogOwnerKey(owner: { threadId?: string; id: string }): string {
+  return owner.threadId ? `thread:${owner.threadId}` : `execution:${owner.id}`;
+}
+
+async function discardRolledBackBatches(
+  h: CheckpointHarnessHandle,
+  store: CheckpointStore,
+  ownerKey: string,
+): Promise<void> {
+  const dirtyFrom = h.itemLogPersistence.dirtyOffset(ownerKey);
+  if (dirtyFrom === undefined) {
+    return;
+  }
+  if (!store.truncateItems) {
+    h.itemLogPersistence.clearDirty(ownerKey);
+    return;
+  }
+  try {
+    await store.truncateItems(ownerKey, dirtyFrom);
+    h.itemLogPersistence.clearDirty(ownerKey);
+  } catch (err) {
+    console.warn(
+      `AgentHarness.checkpoint: failed to discard rolled-back item batches for "${ownerKey}":`,
+      err,
+    );
+  }
+}
+
 /**
  * Snapshot the execution state at a checkpoint boundary. No-op when no
  * `CheckpointStore` is configured — zero-config harnesses preserve
@@ -66,12 +131,32 @@ export async function captureCheckpoint(h: CheckpointHarnessHandle, ctx: Context
     return;
   }
   const impl = ctx instanceof ContextImpl ? ctx : null;
-  const frontier: FrontierFrame[] = impl ? impl.serialiseFrontier() : [];
+  const frontier: FrontierFrame[] = impl
+    ? impl.serialiseFrontier().map((frame) => ({
+        stepId: frame.stepId,
+        input: undefined,
+      }))
+    : [];
   const layers: Record<string, unknown> = {};
   for (const layer of ctx.layers ?? []) {
     const state = h.layerStateStore.get<unknown>(ctx.id, layer.id);
     if (state !== undefined) {
       layers[layer.id] = state;
+    }
+  }
+  const allItems = ctx.itemLog.items;
+  const ownerKey = itemLogOwnerKey(ctx);
+  await discardRolledBackBatches(h, store, ownerKey);
+  const already = h.itemLogPersistence.get(ownerKey);
+  if (allItems.length > already && store.appendItems) {
+    const batch = allItems.slice(already);
+    try {
+      await store.appendItems(ownerKey, already, [
+        ...batch,
+      ]);
+      h.itemLogPersistence.set(ownerKey, allItems.length);
+    } catch (err) {
+      console.warn(`AgentHarness.checkpoint: failed to persist item batch for "${ownerKey}":`, err);
     }
   }
   const snapshot: CheckpointSnapshot = {
@@ -85,16 +170,17 @@ export async function captureCheckpoint(h: CheckpointHarnessHandle, ctx: Context
       current: ctx.cwdState.cwd,
       previous: ctx.cwdState.previousCwd,
     },
-    // Ask-user queue snapshot is empty at the core layer — the code-agent
-    // host is responsible for pushing pending prompts through this store
-    // via `AskUserService` integration. Carrying the shape from day one
-    // means future producers don't bump the schema version.
     askUser: [],
-    itemLog: {
-      items: [
-        ...ctx.itemLog.items,
-      ],
-    },
+    itemLog: store.appendItems
+      ? {
+          items: [],
+          persistedCount: h.itemLogPersistence.get(ownerKey),
+        }
+      : {
+          items: [
+            ...allItems,
+          ],
+        },
     capturedAt: new Date().toISOString(),
   };
   try {
@@ -148,7 +234,17 @@ export async function restoreFromCheckpoint(
   for (const [layerId, state] of Object.entries(snapshot.layers)) {
     h.layerStateStore.set(executionId, layerId, state);
   }
-  const items: Item[] = h.itemSchemas.parseMany(snapshot.itemLog.items);
+  let rawItems: unknown[] = snapshot.itemLog.items;
+  const persistedCount = snapshot.itemLog.persistedCount ?? 0;
+  if (persistedCount > 0 && store.loadItems) {
+    const ownerKey = itemLogOwnerKey({
+      threadId: snapshot.threadId,
+      id: executionId,
+    });
+    rawItems = await store.loadItems(ownerKey, persistedCount);
+    h.itemLogPersistence.set(ownerKey, Math.min(persistedCount, rawItems.length));
+  }
+  const items: Item[] = h.itemSchemas.parseMany(rawItems);
   const cwdInit = snapshot.cwd?.current ?? undefined;
   /* Caller wiring first, snapshot second: a host may legitimately swap the context
    * layers or hang the restored execution under a new parent, but it must never be

--- a/packages/core/src/runtime/durable/step-ledger.ts
+++ b/packages/core/src/runtime/durable/step-ledger.ts
@@ -270,6 +270,8 @@ export class StepLedger {
   private seq: number;
   /** Lowest sequence number still in storage — advances as eviction proceeds. */
   private oldestSeq: number;
+  /** Sequence numbers reserved by failed appends — gaps with no stored row. */
+  private readonly gapSeqs = new Set<number>();
   private readonly store?: StepLedgerStore;
   private readonly executionId: string;
   private readonly retention: Required<StepLedgerRetention>;
@@ -352,14 +354,14 @@ export class StepLedger {
     }
     /* Reserve the sequence number BEFORE awaiting: concurrent inParallel legs record through
      * the one shared ledger, and two of them reading the same counter would write the
-     * same key, silently overwriting a sibling's entry. A write that then fails leaves a
-     * gap, which only makes the window below a slight over-estimate of the live count —
-     * eviction runs marginally early, never late. */
+     * same key, silently overwriting a sibling's entry. Failed writes are tracked as
+     * gaps so eviction does not count them as live entries. */
     const seq = this.seq;
     this.seq = seq + 1;
     try {
       await this.store.append(this.executionId, seq, entry);
     } catch (error) {
+      this.gapSeqs.add(seq);
       console.warn(
         `StepLedger: failed to record "${entry.path}":`,
         error instanceof Error ? error.message : String(error),
@@ -409,8 +411,12 @@ export class StepLedger {
     if (!store) {
       return;
     }
-    while (this.seq - this.oldestSeq > this.retention.maxEntries) {
+    while (this.seq - this.oldestSeq - this.gapCountInWindow() > this.retention.maxEntries) {
       const victim = this.oldestSeq;
+      if (this.gapSeqs.delete(victim)) {
+        this.oldestSeq = victim + 1;
+        continue;
+      }
       try {
         await store.delete(this.executionId, victim);
       } catch (error) {
@@ -425,6 +431,21 @@ export class StepLedger {
       this.oldestSeq = victim + 1;
       this.counts.evicted += 1;
     }
+  }
+
+  private gapCountInWindow(): number {
+    if (this.gapSeqs.size === 0) {
+      return 0;
+    }
+    let n = 0;
+    for (const gap of this.gapSeqs) {
+      if (gap >= this.oldestSeq) {
+        n += 1;
+      } else {
+        this.gapSeqs.delete(gap);
+      }
+    }
+    return n;
   }
 
   /** One warning per reason per execution — a long run would otherwise flood the log. */

--- a/packages/core/src/runtime/item-log-impl.ts
+++ b/packages/core/src/runtime/item-log-impl.ts
@@ -24,4 +24,23 @@ export class ItemLogImpl implements ItemLog {
     this._items.push(this.itemSchemas.parse(item));
     this._frozenCache = null;
   }
+
+  /** @internal Current length — used as a rollback watermark by the session runner. */
+  get length(): number {
+    return this._items.length;
+  }
+
+  /**
+   * @internal Roll the log back to a previously-captured watermark. Used ONLY
+   * by the session runner to discard a failed/aborted turn's partial items so
+   * a shared session log preserves the same "failed turns leave no trace"
+   * semantics the copy-based history had.
+   */
+  truncateTo(watermark: number): void {
+    if (watermark < 0 || watermark >= this._items.length) {
+      return;
+    }
+    this._items.length = watermark;
+    this._frozenCache = null;
+  }
 }

--- a/packages/core/src/runtime/session-runner.ts
+++ b/packages/core/src/runtime/session-runner.ts
@@ -42,6 +42,13 @@ export interface SessionRunnerOpts {
   readonly agentName: string;
   readonly runTurn: RunTurnFn;
   readonly createContext: CreateContextFn;
+  /**
+   * Roll back session-owned state after a failed/aborted turn. With a shared
+   * session log (single-owner history), a failed turn's partial items must be
+   * discarded explicitly to preserve the "failed turns leave no trace"
+   * contract the old copy-back gave for free.
+   */
+  readonly rollbackTurn?: () => void;
 }
 
 //#endregion
@@ -111,6 +118,7 @@ export class SessionRunner {
   private readonly agentName: string;
   private readonly runTurn: RunTurnFn;
   private readonly createContext: CreateContextFn;
+  private readonly rollbackTurn?: () => void;
 
   private status: HarnessStatus = {
     kind: 'idle',
@@ -139,6 +147,7 @@ export class SessionRunner {
     this.agentName = opts.agentName;
     this.runTurn = opts.runTurn;
     this.createContext = opts.createContext;
+    this.rollbackTurn = opts.rollbackTurn;
 
     this.queue.subscribe(() => {
       this.kick();
@@ -245,37 +254,39 @@ export class SessionRunner {
     // the harness's createContext callback receives Item[] directly and
     // seeds the context without re-converting.
     const items = mergeInputsToItems(messages);
-    const ctx = this.createContext(items, turnId, messages);
-    this.currentCtx = ctx;
+    let ctx: Context | undefined;
 
-    emitFrameworkEvent({
-      broadcaster: this.broadcaster,
-      agentName: this.agentName,
-      eventType: 'turn_started',
-      data: {
-        turnId,
-        messageIds: messages.map((m) => m.id),
-      },
-    });
-    // Input items never appear in the SDK stream — item_appended is what
-    // carries them into getItemStream (and any other log-faithful consumer).
-    for (const item of items) {
+    try {
+      ctx = this.createContext(items, turnId, messages);
+      this.currentCtx = ctx;
+
       emitFrameworkEvent({
         broadcaster: this.broadcaster,
         agentName: this.agentName,
-        eventType: 'item_appended',
+        eventType: 'turn_started',
         data: {
-          item,
+          turnId,
+          messageIds: messages.map((m) => m.id),
         },
       });
-    }
+      // Input items never appear in the SDK stream — item_appended is what
+      // carries them into getItemStream (and any other log-faithful consumer).
+      for (const item of items) {
+        emitFrameworkEvent({
+          broadcaster: this.broadcaster,
+          agentName: this.agentName,
+          eventType: 'item_appended',
+          data: {
+            item,
+          },
+        });
+      }
 
-    const turn: TurnContext = {
-      turnId,
-      session: this,
-    };
+      const turn: TurnContext = {
+        turnId,
+        session: this,
+      };
 
-    try {
       const text = await this.runTurn(ctx, turn, controller.signal);
       const response = buildResponse(text, ctx);
       this.lastResponse = response;
@@ -299,6 +310,7 @@ export class SessionRunner {
     } catch (err: unknown) {
       const error = err instanceof Error ? err : new Error(String(err));
       this.lastError = error;
+      this.rollbackTurn?.();
       emitFrameworkEvent({
         broadcaster: this.broadcaster,
         agentName: this.agentName,
@@ -312,14 +324,16 @@ export class SessionRunner {
     } finally {
       // Accumulate the turn's token accounting whatever the outcome — an
       // aborted turn still consumed whatever the model billed before the cut.
-      this.totalInputTokens += ctx.tokens.input;
-      this.totalOutputTokens += ctx.tokens.output;
-      // Only ever leave `undefined` behind when NO turn reported a figure —
-      // a turn that reported 0 must surface as 0, not "unreported".
-      if (ctx.tokens.cached !== undefined) {
-        this.totalCachedTokens = (this.totalCachedTokens ?? 0) + ctx.tokens.cached;
+      if (ctx) {
+        this.totalInputTokens += ctx.tokens.input;
+        this.totalOutputTokens += ctx.tokens.output;
+        // Only ever leave `undefined` behind when NO turn reported a figure —
+        // a turn that reported 0 must surface as 0, not "unreported".
+        if (ctx.tokens.cached !== undefined) {
+          this.totalCachedTokens = (this.totalCachedTokens ?? 0) + ctx.tokens.cached;
+        }
+        this.totalCost += ctx.cost;
       }
-      this.totalCost += ctx.cost;
       this.currentCtx = undefined;
       this.currentController = undefined;
       this.status = {

--- a/packages/core/src/types/checkpoint.ts
+++ b/packages/core/src/types/checkpoint.ts
@@ -82,6 +82,12 @@ export type PendingAskUserSnapshot = z.infer<typeof PendingAskUserSnapshotSchema
  */
 export const ItemLogSnapshotSchema = z.object({
   items: z.array(z.unknown()),
+  /**
+   * When present, the log itself lives outside the snapshot as append-only
+   * batches and this counts the durable items to stitch back on restore.
+   * Absent on legacy inline snapshots.
+   */
+  persistedCount: z.number().int().nonnegative().optional(),
 });
 
 /** @public Item log portion of a snapshot. */

--- a/packages/core/test/bench/checkpoint-item-batches.bench.test.ts
+++ b/packages/core/test/bench/checkpoint-item-batches.bench.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Opt-in checkpoint item-batch benchmark.
+ *
+ * Compares repeated checkpoints on a growing session transcript between the
+ * legacy inline-snapshot store and the batched CheckpointStore.
+ *
+ * Run with:
+ *   NOETIC_RUN_BENCH=1 bun test packages/core/test/bench/checkpoint-item-batches.bench.test.ts
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { LLMResponse, MessageItem, StorageAdapter } from '@noetic-tools/types';
+import { AgentHarness } from '../../src/harness/agent-harness';
+import { createCheckpointStore } from '../../src/runtime/durable/checkpoint-store';
+import { createInMemoryStorage } from '../../src/runtime/in-memory-storage';
+import { assistantMessage } from '../_helpers';
+
+const SHOULD_RUN = process.env.NOETIC_RUN_BENCH === '1';
+const TURNS = 150;
+
+function harnessWithStore(storage: StorageAdapter, batched: boolean): AgentHarness {
+  const full = createCheckpointStore({
+    storage,
+  });
+  const checkpointStore = batched
+    ? full
+    : {
+        save: full.save,
+        load: full.load,
+        list: full.list,
+        clear: full.clear,
+      };
+  let call = 0;
+  return new AgentHarness({
+    name: batched ? 'bench-batched' : 'bench-inline',
+    params: {},
+    agentGraph: {
+      kind: 'callModel',
+      id: 'chat',
+      model: 'test/scripted',
+      tools: [],
+    },
+    environment: {
+      storage: {
+        adapter: storage,
+        checkpointStore,
+      },
+    },
+    _testCallModel: async (): Promise<LLMResponse> => {
+      const message: MessageItem = assistantMessage(`answer ${call}`, `resp-${call}`);
+      call += 1;
+      return {
+        items: [
+          message,
+        ],
+        usage: {
+          inputTokens: 0,
+          outputTokens: 1,
+        },
+      };
+    },
+  });
+}
+
+async function runSession(harness: AgentHarness, threadId: string): Promise<number> {
+  const start = performance.now();
+  for (let i = 0; i < TURNS; i++) {
+    await harness.execute(`turn ${i}`, {
+      threadId,
+    });
+    await harness.getAgentResponse({
+      threadId,
+    });
+  }
+  return performance.now() - start;
+}
+
+describe.skipIf(!SHOULD_RUN)('checkpoint item batches benchmark', () => {
+  it('logs batched vs inline checkpoint time on a growing transcript', async () => {
+    const batchedMs = await runSession(harnessWithStore(createInMemoryStorage(), true), 'bench');
+    const inlineMs = await runSession(harnessWithStore(createInMemoryStorage(), false), 'bench');
+
+    console.log(
+      `checkpoint batches benchmark: batched=${batchedMs.toFixed(2)}ms inline=${inlineMs.toFixed(2)}ms turns=${TURNS}`,
+    );
+
+    expect(Number.isFinite(batchedMs)).toBe(true);
+    expect(Number.isFinite(inlineMs)).toBe(true);
+    expect(batchedMs).toBeGreaterThan(0);
+    expect(inlineMs).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/test/context/warm-layer-hydration.test.ts
+++ b/packages/core/test/context/warm-layer-hydration.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Warm layer hydration: successive turns addressing the same layer scope bucket
+ * carry non-execution-scoped layer state forward IN MEMORY instead of re-reading
+ * it from storage.
+ *
+ * Cold-initing every turn cost one sequential storage read per layer — each with
+ * its own 10s timeout — on every single turn, for state the state store already
+ * held. Execution-scoped layers are exempt: their scope key rotates per run, so
+ * they must still init per turn by contract.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { ContextData, ContextLayer } from '@noetic-tools/context';
+import type { LLMResponse, MessageItem, Step } from '@noetic-tools/types';
+import { AgentHarness } from '../../src/harness/agent-harness';
+import { assistantMessage, makeStorage } from '../_helpers';
+
+interface CountState {
+  count: number;
+}
+
+interface Probe {
+  readonly layer: ContextLayer<CountState>;
+  readonly inits: () => number;
+}
+
+/** A layer that counts how many times `init` ran, and bumps state per turn. */
+function countingLayer(scope: 'thread' | 'execution'): Probe {
+  let inits = 0;
+  const layer: ContextLayer<CountState> = {
+    id: `counter-${scope}`,
+    slot: 100,
+    scope,
+    hooks: {
+      async init({ storage }) {
+        inits += 1;
+        const saved = await storage.get<CountState>('state');
+        return {
+          state: saved ?? {
+            count: 0,
+          },
+        };
+      },
+      async recall({ state }) {
+        return `count=${state.count}`;
+      },
+      async store({ state }) {
+        return {
+          state: {
+            count: (state?.count ?? 0) + 1,
+          },
+        };
+      },
+    },
+  };
+  return {
+    layer,
+    inits: () => inits,
+  };
+}
+
+const chatStep: Step<ContextData, string, string> = {
+  kind: 'callModel',
+  id: 'chat',
+  model: 'test/scripted',
+  tools: [],
+};
+
+function harnessWith(layers: ContextLayer[]): AgentHarness {
+  let call = 0;
+  return new AgentHarness({
+    name: 'warm-test',
+    params: {},
+    agentGraph: chatStep,
+    environment: {
+      storage: {
+        adapter: makeStorage(),
+      },
+    },
+    contextLayers: layers,
+    _testCallModel: async (): Promise<LLMResponse> => {
+      const message: MessageItem = assistantMessage(`answer ${call}`, `resp-${call}`);
+      call += 1;
+      return {
+        items: [
+          message,
+        ],
+        usage: {
+          inputTokens: 0,
+          outputTokens: 1,
+        },
+      };
+    },
+  });
+}
+
+async function runTurns(harness: AgentHarness, threadId: string, count: number): Promise<void> {
+  for (let i = 0; i < count; i++) {
+    await harness.execute(`turn ${i}`, {
+      threadId,
+    });
+    await harness.getAgentResponse({
+      threadId,
+    });
+  }
+}
+
+describe('warm layer hydration across turns on one thread', () => {
+  it('a thread-scoped layer inits once per thread, not once per turn', async () => {
+    const probe = countingLayer('thread');
+    const harness = harnessWith([
+      probe.layer,
+    ]);
+    await runTurns(harness, 'warm', 3);
+    expect(probe.inits()).toBe(1);
+  });
+
+  it('carried-forward state keeps accumulating across turns', async () => {
+    const probe = countingLayer('thread');
+    const harness = harnessWith([
+      probe.layer,
+    ]);
+    await runTurns(harness, 'warm', 3);
+    // `store` bumps the counter once per turn, and the warm path hands the live
+    // state to the next turn — so a cold re-init would reset visible progress.
+    const items = await harness.previewRequestItems({
+      threadId: 'warm',
+    });
+    const texts = items.flatMap((item) =>
+      item.type === 'message'
+        ? item.content.flatMap((part) =>
+            part.type === 'input_text' || part.type === 'output_text'
+              ? [
+                  part.text,
+                ]
+              : [],
+          )
+        : [],
+    );
+    expect(texts.some((t) => t.includes('count=3'))).toBe(true);
+  });
+
+  it('an execution-scoped layer still inits every turn', async () => {
+    const probe = countingLayer('execution');
+    const harness = harnessWith([
+      probe.layer,
+    ]);
+    await runTurns(harness, 'warm', 3);
+    expect(probe.inits()).toBe(3);
+  });
+
+  it('separate threads hydrate independently', async () => {
+    const probe = countingLayer('thread');
+    const harness = harnessWith([
+      probe.layer,
+    ]);
+    await runTurns(harness, 'thread-a', 2);
+    await runTurns(harness, 'thread-b', 2);
+    // One cold init per thread — the scope key is thread-scoped, so thread B
+    // cannot ride thread A's carry-forward.
+    expect(probe.inits()).toBe(2);
+  });
+
+  it('a preview between turns does not poison the thread warm pointer', async () => {
+    /* `previewRequestItems` inits layers on a THROWAWAY context and tears that
+     * execution's state down in its `finally`. If the preview published itself as
+     * the bucket's warm source, the next real turn would find a pointer to wiped
+     * state, carry nothing forward, and silently cold-init — correct, but the
+     * warm win would evaporate after any preview (a TUI may issue one per
+     * keystroke). */
+    const probe = countingLayer('thread');
+    const harness = harnessWith([
+      probe.layer,
+    ]);
+    await runTurns(harness, 'warm', 1);
+    expect(probe.inits()).toBe(1);
+
+    // Previews themselves ride the warm path off turn 1, so they add no inits...
+    await harness.previewRequestItems({
+      threadId: 'warm',
+    });
+    await harness.previewRequestItems({
+      threadId: 'warm',
+    });
+    expect(probe.inits()).toBe(1);
+
+    // ...and, crucially, they did not become the bucket's warm SOURCE. Turn 2
+    // still resolves to turn 1's live state. Were the preview the source, its
+    // `finally` (flush + cleanup) would have wiped that execution's state, the
+    // warm copy would find nothing, and this turn would cold-init to 2.
+    await runTurns(harness, 'warm', 1);
+    expect(probe.inits()).toBe(1);
+  });
+});

--- a/packages/core/test/interpreter/execute-run.test.ts
+++ b/packages/core/test/interpreter/execute-run.test.ts
@@ -41,7 +41,7 @@ function interceptDelays(): {
   };
 }
 
-describe('executeRunCode', () => {
+describe.serial('executeRunCode', () => {
   it('calls execute function and returns output', async () => {
     const s: StepRunCode<ContextData, string, number> = {
       kind: 'runCode',

--- a/packages/core/test/runtime/checkpoint-batch-stitching.test.ts
+++ b/packages/core/test/runtime/checkpoint-batch-stitching.test.ts
@@ -1,0 +1,584 @@
+/**
+ * Item-log batch stitching and truncation behavior.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import assert from 'node:assert';
+import type { ContextData, StorageAdapter } from '@noetic-tools/context';
+import type { Item, LLMResponse, MessageItem, Step } from '@noetic-tools/types';
+import { defaultItemSchemaRegistry } from '@noetic-tools/types';
+import { loop } from '../../src/builders/loop-builder';
+import { runCode } from '../../src/builders/step-builders';
+import { AgentHarness } from '../../src/harness/agent-harness';
+import { createCheckpointStore } from '../../src/runtime/durable/checkpoint-store';
+import { createInMemoryStorage } from '../../src/runtime/in-memory-storage';
+import { until } from '../../src/until/predicates';
+import { assistantMessage } from '../_helpers';
+
+function itemTexts(item: Item): string[] {
+  if (item.type !== 'message') {
+    return [];
+  }
+  const texts: string[] = [];
+  for (const part of item.content) {
+    if (part.type === 'input_text' || part.type === 'output_text') {
+      texts.push(part.text);
+    }
+  }
+  return texts;
+}
+
+function durableTexts(raw: readonly unknown[]): string[] {
+  return defaultItemSchemaRegistry.parseMany(raw).flatMap(itemTexts);
+}
+
+let uniq = 0;
+type ScriptedCall = number | 'fail';
+
+function makeHarness(script: ScriptedCall[]): {
+  harness: AgentHarness;
+  checkpointStore: ReturnType<typeof createCheckpointStore>;
+  storage: StorageAdapter;
+} {
+  const storage = createInMemoryStorage();
+  const checkpointStore = createCheckpointStore({
+    storage,
+  });
+  let call = 0;
+  const n = uniq++;
+  const body: Step<ContextData, string, string> = loop<ContextData, string, string>({
+    id: `turn-body-${n}`,
+    steps: [
+      runCode<ContextData, string, string>({
+        id: `pre-${n}`,
+        execute: async (input) => input,
+      }),
+      {
+        kind: 'callModel',
+        id: `chat-${n}`,
+        model: 'test/scripted',
+        tools: [],
+      },
+    ],
+    until: until.maxSteps(3),
+    maxIterations: 3,
+  });
+  const harness = new AgentHarness({
+    name: 'stitch-test',
+    params: {},
+    agentGraph: body,
+    environment: {
+      storage: {
+        adapter: storage,
+        checkpointStore,
+      },
+    },
+    _testCallModel: async (): Promise<LLMResponse> => {
+      const mode = script[Math.min(call, script.length - 1)] ?? 1;
+      const i = call++;
+      if (mode === 'fail') {
+        throw new Error(`scripted turn failure #${i}`);
+      }
+      const items: MessageItem[] = [];
+      for (let k = 0; k < mode; k++) {
+        items.push(assistantMessage(`answer ${i}.${k}`, `resp-${i}-${k}`));
+      }
+      return {
+        items,
+        usage: {
+          inputTokens: 0,
+          outputTokens: 1,
+        },
+      };
+    },
+  });
+  return {
+    harness,
+    checkpointStore,
+    storage,
+  };
+}
+
+async function runTurn(harness: AgentHarness, threadId: string, text: string): Promise<void> {
+  await harness.execute(text, {
+    threadId,
+  });
+  await harness
+    .getAgentResponse({
+      threadId,
+    })
+    .catch(() => undefined);
+}
+
+describe('loadItems stitches only contiguous batches', () => {
+  it('a shorter batch at offset 0 does not leave the old longer batch stitchable', async () => {
+    const storage = createInMemoryStorage();
+    const store = createCheckpointStore({
+      storage,
+    });
+    assert(store.appendItems);
+    assert(store.loadItems);
+    const owner = 'thread:reseeded';
+
+    await store.appendItems(owner, 0, [
+      'old0',
+      'old1',
+    ]);
+    await store.appendItems(owner, 2, [
+      'old2',
+      'old3',
+      'old4',
+    ]);
+    await store.appendItems(owner, 5, [
+      'old5',
+      'old6',
+    ]);
+    await store.appendItems(owner, 0, [
+      'new0',
+      'new1',
+      'new2',
+    ]);
+    await store.appendItems(owner, 3, [
+      'new3',
+      'new4',
+      'new5',
+    ]);
+
+    const stitched = await store.loadItems(owner, 6);
+    expect(stitched).toEqual([
+      'new0',
+      'new1',
+      'new2',
+    ]);
+    expect(stitched).not.toContain('old2');
+    expect(stitched).not.toContain('old5');
+  });
+
+  it('and the reseed path deletes those batches, so the full new log stitches', async () => {
+    const storage = createInMemoryStorage();
+    const store = createCheckpointStore({
+      storage,
+    });
+    assert(store.appendItems);
+    assert(store.loadItems);
+    assert(store.truncateItems);
+    const owner = 'thread:reseeded-clean';
+
+    await store.appendItems(owner, 0, [
+      'old0',
+      'old1',
+    ]);
+    await store.appendItems(owner, 2, [
+      'old2',
+      'old3',
+      'old4',
+    ]);
+    await store.appendItems(owner, 5, [
+      'old5',
+      'old6',
+    ]);
+    await store.truncateItems(owner, 0);
+    await store.appendItems(owner, 0, [
+      'new0',
+      'new1',
+      'new2',
+    ]);
+    await store.appendItems(owner, 3, [
+      'new3',
+      'new4',
+      'new5',
+    ]);
+
+    expect(await store.loadItems(owner, 6)).toEqual([
+      'new0',
+      'new1',
+      'new2',
+      'new3',
+      'new4',
+      'new5',
+    ]);
+  });
+
+  it('an overlapping stale batch ends the stitch instead of appending after the good items', async () => {
+    const storage = createInMemoryStorage();
+    const store = createCheckpointStore({
+      storage,
+    });
+    assert(store.appendItems);
+    assert(store.loadItems);
+    const owner = 'thread:overlap';
+
+    await store.appendItems(owner, 2, [
+      'stale2',
+      'stale3',
+    ]);
+    await store.appendItems(owner, 0, [
+      'good0',
+      'good1',
+      'good2',
+    ]);
+
+    expect(await store.loadItems(owner, 4)).toEqual([
+      'good0',
+      'good1',
+      'good2',
+    ]);
+  });
+
+  it('a missing leading batch is a short read, not a silent re-positioning', async () => {
+    const storage = createInMemoryStorage();
+    const store = createCheckpointStore({
+      storage,
+    });
+    assert(store.appendItems);
+    assert(store.loadItems);
+    const owner = 'thread:hole';
+
+    await store.appendItems(owner, 0, [
+      'i0',
+      'i1',
+      'i2',
+      'i3',
+      'i4',
+    ]);
+    await store.appendItems(owner, 5, [
+      'i5',
+      'i6',
+      'i7',
+    ]);
+    for (const key of await storage.list(`execution:${owner}:itemLog:`)) {
+      if (key.endsWith('00000000')) {
+        await storage.delete(key);
+      }
+    }
+
+    expect(await store.loadItems(owner, 8)).toEqual([]);
+  });
+
+  it('a missing middle batch does not weld the two sides together', async () => {
+    const storage = createInMemoryStorage();
+    const store = createCheckpointStore({
+      storage,
+    });
+    assert(store.appendItems);
+    assert(store.loadItems);
+    const owner = 'thread:middle-hole';
+
+    await store.appendItems(owner, 0, [
+      'a',
+      'b',
+    ]);
+    await store.appendItems(owner, 2, [
+      'c',
+      'd',
+    ]);
+    await store.appendItems(owner, 4, [
+      'e',
+      'f',
+    ]);
+    for (const key of await storage.list(`execution:${owner}:itemLog:`)) {
+      if (key.endsWith('00000002')) {
+        await storage.delete(key);
+      }
+    }
+
+    expect(await store.loadItems(owner, 6)).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('contiguous batches still stitch to the full log', async () => {
+    const storage = createInMemoryStorage();
+    const store = createCheckpointStore({
+      storage,
+    });
+    assert(store.appendItems);
+    assert(store.loadItems);
+    const owner = 'thread:happy';
+
+    await store.appendItems(owner, 0, [
+      'a',
+      'b',
+    ]);
+    await store.appendItems(owner, 2, [
+      'c',
+    ]);
+    await store.appendItems(owner, 3, [
+      'd',
+      'e',
+    ]);
+
+    expect(await store.loadItems(owner, 5)).toEqual([
+      'a',
+      'b',
+      'c',
+      'd',
+      'e',
+    ]);
+    expect(await store.loadItems(owner, 3)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+  });
+});
+
+describe('truncateItems removes the batches a rollback orphaned', () => {
+  it('drops whole batches at or past the cut and trims a straddling one', async () => {
+    const storage = createInMemoryStorage();
+    const store = createCheckpointStore({
+      storage,
+    });
+    assert(store.appendItems);
+    assert(store.loadItems);
+    assert(store.truncateItems);
+    const owner = 'thread:truncate';
+
+    await store.appendItems(owner, 0, [
+      'a',
+      'b',
+    ]);
+    await store.appendItems(owner, 2, [
+      'c',
+      'd',
+      'e',
+    ]);
+    await store.appendItems(owner, 5, [
+      'f',
+    ]);
+    await store.truncateItems(owner, 3);
+
+    expect(await store.loadItems(owner, 6)).toEqual([
+      'a',
+      'b',
+      'c',
+    ]);
+    await store.appendItems(owner, 3, [
+      'C',
+      'D',
+    ]);
+    expect(await store.loadItems(owner, 5)).toEqual([
+      'a',
+      'b',
+      'c',
+      'C',
+      'D',
+    ]);
+  });
+
+  it('a cut on a batch boundary leaves the prefix byte-identical', async () => {
+    const storage = createInMemoryStorage();
+    const store = createCheckpointStore({
+      storage,
+    });
+    assert(store.appendItems);
+    assert(store.loadItems);
+    assert(store.truncateItems);
+    const owner = 'thread:boundary';
+
+    await store.appendItems(owner, 0, [
+      'a',
+      'b',
+    ]);
+    await store.appendItems(owner, 2, [
+      'c',
+      'd',
+    ]);
+    await store.truncateItems(owner, 2);
+
+    expect(await store.loadItems(owner, 4)).toEqual([
+      'a',
+      'b',
+    ]);
+  });
+
+  it('a cut at 0 clears the owner entirely', async () => {
+    const storage = createInMemoryStorage();
+    const store = createCheckpointStore({
+      storage,
+    });
+    assert(store.appendItems);
+    assert(store.loadItems);
+    assert(store.truncateItems);
+    const owner = 'thread:wipe';
+
+    await store.appendItems(owner, 0, [
+      'a',
+      'b',
+    ]);
+    await store.appendItems(owner, 2, [
+      'c',
+    ]);
+    await store.truncateItems(owner, 0);
+
+    expect(await storage.list(`execution:${owner}:itemLog:`)).toEqual([]);
+    expect(await store.loadItems(owner, 3)).toEqual([]);
+  });
+});
+
+describe('a rolled-back turn leaves no durable trace at any checkpoint cadence', () => {
+  it('the stitched durable log equals the live log when the recovery turn writes longer batches', async () => {
+    const { harness, checkpointStore } = makeHarness([
+      1,
+      1,
+      1,
+      1,
+      1,
+      'fail',
+      3,
+      1,
+      1,
+      1,
+      1,
+      1,
+    ]);
+    const threadId = 'cadence-longer';
+
+    await runTurn(harness, threadId, 'turn one');
+    await runTurn(harness, threadId, 'turn two (will fail)');
+    await runTurn(harness, threadId, 'turn three');
+    await runTurn(harness, threadId, 'turn four');
+
+    assert(checkpointStore.loadItems);
+    const watermark = harness.itemLogPersistence.get(`thread:${threadId}`);
+    const raw = await checkpointStore.loadItems(`thread:${threadId}`, watermark);
+    const live = await harness.previewRequestItems({
+      threadId,
+    });
+    expect(durableTexts(raw)).toEqual(live.flatMap(itemTexts));
+    expect(raw.length).toBe(watermark);
+    const texts = durableTexts(raw);
+    expect(texts).toContain('turn one');
+    expect(texts).toContain('turn three');
+    expect(texts).toContain('turn four');
+    expect(texts).not.toContain('turn two (will fail)');
+  });
+
+  it('and when the recovery turn writes shorter batches than the aborted one', async () => {
+    const { harness, checkpointStore } = makeHarness([
+      1,
+      1,
+      1,
+      1,
+      3,
+      'fail',
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+    ]);
+    const threadId = 'cadence-shorter';
+
+    await runTurn(harness, threadId, 'alpha');
+    await runTurn(harness, threadId, 'beta (will fail)');
+    await runTurn(harness, threadId, 'gamma');
+    await runTurn(harness, threadId, 'delta');
+
+    assert(checkpointStore.loadItems);
+    const watermark = harness.itemLogPersistence.get(`thread:${threadId}`);
+    const raw = await checkpointStore.loadItems(`thread:${threadId}`, watermark);
+    const live = await harness.previewRequestItems({
+      threadId,
+    });
+
+    expect(durableTexts(raw)).toEqual(live.flatMap(itemTexts));
+    expect(durableTexts(raw)).toContain('alpha');
+    expect(durableTexts(raw)).toContain('gamma');
+    expect(durableTexts(raw)).not.toContain('beta (will fail)');
+  });
+
+  it('a restarted host restores exactly the live transcript after a failed turn', async () => {
+    const { harness, checkpointStore, storage } = makeHarness([
+      1,
+      1,
+      1,
+      1,
+      1,
+      'fail',
+      3,
+      1,
+      1,
+    ]);
+    const threadId = 'restart-after-fail';
+
+    await runTurn(harness, threadId, 'kept one');
+    await runTurn(harness, threadId, 'discarded (will fail)');
+    await runTurn(harness, threadId, 'kept two');
+
+    const live = await harness.previewRequestItems({
+      threadId,
+    });
+    const ids = await checkpointStore.list();
+    const executionId = ids[ids.length - 1]?.executionId;
+    assert(executionId);
+
+    const resumed = new AgentHarness({
+      name: 'stitch-resumed',
+      params: {},
+      environment: {
+        storage: {
+          adapter: storage,
+          checkpointStore: createCheckpointStore({
+            storage,
+          }),
+        },
+      },
+    });
+    const restored = await resumed.restore(executionId);
+    assert(restored);
+
+    expect(restored.itemLog.items.flatMap(itemTexts)).toEqual(live.flatMap(itemTexts));
+    const restoredTexts = restored.itemLog.items.flatMap(itemTexts);
+    expect(restoredTexts).toContain('kept one');
+    expect(restoredTexts).toContain('kept two');
+    expect(restoredTexts).not.toContain('discarded (will fail)');
+  });
+
+  it('reseeded history does not resurrect the pre-seed transcript on restore', async () => {
+    const { harness, checkpointStore, storage } = makeHarness([
+      1,
+      1,
+      1,
+      1,
+      1,
+      1,
+    ]);
+    const threadId = 'reseed-restore';
+
+    await runTurn(harness, threadId, 'pre-seed history');
+    harness.seedSessionHistory(threadId, [
+      assistantMessage('seeded A', 'seed-a'),
+      assistantMessage('seeded B', 'seed-b'),
+      assistantMessage('seeded C', 'seed-c'),
+    ]);
+    await runTurn(harness, threadId, 'post-seed turn');
+
+    const live = await harness.previewRequestItems({
+      threadId,
+    });
+    const ids = await checkpointStore.list();
+    const executionId = ids[ids.length - 1]?.executionId;
+    assert(executionId);
+
+    const resumed = new AgentHarness({
+      name: 'reseed-resumed',
+      params: {},
+      environment: {
+        storage: {
+          adapter: storage,
+          checkpointStore: createCheckpointStore({
+            storage,
+          }),
+        },
+      },
+    });
+    const restored = await resumed.restore(executionId);
+    assert(restored);
+
+    expect(restored.itemLog.items.flatMap(itemTexts)).toEqual(live.flatMap(itemTexts));
+    expect(restored.itemLog.items.flatMap(itemTexts)).not.toContain('pre-seed history');
+  });
+});

--- a/packages/core/test/runtime/checkpoint-item-batches.test.ts
+++ b/packages/core/test/runtime/checkpoint-item-batches.test.ts
@@ -1,0 +1,242 @@
+/**
+ * O(delta) item-log checkpoints: the snapshot carries a COUNT, the transcript
+ * lives outside it as append-only batches keyed by the log's owner.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import assert from 'node:assert';
+import type { StorageAdapter } from '@noetic-tools/context';
+import type { LLMResponse, MessageItem } from '@noetic-tools/types';
+import { AgentHarness } from '../../src/harness/agent-harness';
+import { createCheckpointStore } from '../../src/runtime/durable/checkpoint-store';
+import { createInMemoryStorage } from '../../src/runtime/in-memory-storage';
+import { assistantMessage, makeMessage } from '../_helpers';
+
+function meteringStorage(): {
+  adapter: StorageAdapter;
+  writes: Array<{
+    key: string;
+    bytes: number;
+  }>;
+} {
+  const inner = createInMemoryStorage();
+  const writes: Array<{
+    key: string;
+    bytes: number;
+  }> = [];
+  const adapter: StorageAdapter = {
+    get: (key) => inner.get(key),
+    set: async (key, value) => {
+      writes.push({
+        key,
+        bytes: JSON.stringify(value).length,
+      });
+      return inner.set(key, value);
+    },
+    delete: (key) => inner.delete(key),
+    list: (prefix) => inner.list(prefix),
+  };
+  return {
+    adapter,
+    writes,
+  };
+}
+
+function scriptedHarness(storage: StorageAdapter): {
+  harness: AgentHarness;
+  checkpointStore: ReturnType<typeof createCheckpointStore>;
+} {
+  const checkpointStore = createCheckpointStore({
+    storage,
+  });
+  let call = 0;
+  const harness = new AgentHarness({
+    name: 'batches-test',
+    params: {},
+    agentGraph: {
+      kind: 'callModel',
+      id: 'chat',
+      model: 'test/scripted',
+      tools: [],
+    },
+    environment: {
+      storage: {
+        adapter: storage,
+        checkpointStore,
+      },
+    },
+    _testCallModel: async (): Promise<LLMResponse> => {
+      const message: MessageItem = assistantMessage(`answer ${call}`, `resp-${call}`);
+      call += 1;
+      return {
+        items: [
+          message,
+        ],
+        usage: {
+          inputTokens: 0,
+          outputTokens: 1,
+        },
+      };
+    },
+  });
+  return {
+    harness,
+    checkpointStore,
+  };
+}
+
+function batchOffsets(
+  writes: ReadonlyArray<{
+    key: string;
+  }>,
+  ownerKey: string,
+): number[] {
+  const prefix = `execution:${ownerKey}:itemLog:`;
+  return writes
+    .filter((w) => w.key.startsWith(prefix))
+    .map((w) => Number(w.key.slice(prefix.length)));
+}
+
+describe('item-log checkpoint batches are O(delta) and thread-keyed', () => {
+  it('each turn appends at a strictly increasing offset, never re-writing from 0', async () => {
+    const metering = meteringStorage();
+    const { harness } = scriptedHarness(metering.adapter);
+    const threadId = 'delta-thread';
+
+    for (const text of [
+      'one',
+      'two',
+      'three',
+      'four',
+    ]) {
+      await harness.execute(text, {
+        threadId,
+      });
+      await harness.getAgentResponse({
+        threadId,
+      });
+    }
+
+    const offsets = batchOffsets(metering.writes, `thread:${threadId}`);
+    expect(offsets.length).toBe(4);
+    expect(offsets.filter((o) => o === 0)).toHaveLength(1);
+    for (let i = 1; i < offsets.length; i++) {
+      expect(offsets[i]).toBeGreaterThan(offsets[i - 1] ?? -1);
+    }
+    expect(harness.itemLogPersistence.get(`thread:${threadId}`)).toBe(8);
+  });
+
+  it('later turns write less than the whole transcript (bytes stay per-delta)', async () => {
+    const metering = meteringStorage();
+    const { harness } = scriptedHarness(metering.adapter);
+    const threadId = 'bytes-thread';
+    const prefix = `execution:thread:${threadId}:itemLog:`;
+
+    const perTurnBytes: number[] = [];
+    for (const text of [
+      'one',
+      'two',
+      'three',
+      'four',
+      'five',
+      'six',
+    ]) {
+      const before = metering.writes.length;
+      await harness.execute(text, {
+        threadId,
+      });
+      await harness.getAgentResponse({
+        threadId,
+      });
+      perTurnBytes.push(
+        metering.writes
+          .slice(before)
+          .filter((w) => w.key.startsWith(prefix))
+          .reduce((sum, w) => sum + w.bytes, 0),
+      );
+    }
+
+    const first = perTurnBytes[0] ?? 0;
+    const last = perTurnBytes[perTurnBytes.length - 1] ?? 0;
+    expect(first).toBeGreaterThan(0);
+    expect(last).toBeLessThan(first * 2);
+  });
+
+  it('the snapshot carries persistedCount, not the transcript', async () => {
+    const { harness, checkpointStore } = scriptedHarness(createInMemoryStorage());
+    const threadId = 'count-thread';
+    await harness.execute('hello', {
+      threadId,
+    });
+    await harness.getAgentResponse({
+      threadId,
+    });
+
+    const ids = await checkpointStore.list();
+    expect(ids.length).toBeGreaterThan(0);
+    const executionId = ids[ids.length - 1]?.executionId;
+    assert(executionId);
+    const snapshot = await checkpointStore.load(executionId);
+    assert(snapshot);
+    expect(snapshot.itemLog.items).toEqual([]);
+    expect(snapshot.itemLog.persistedCount).toBe(2);
+  });
+
+  it('restore stitches the batches back through the thread owner key', async () => {
+    const storage = createInMemoryStorage();
+    const { harness, checkpointStore } = scriptedHarness(storage);
+    const threadId = 'restore-thread';
+    await harness.execute('remembered before the crash', {
+      threadId,
+    });
+    await harness.getAgentResponse({
+      threadId,
+    });
+
+    const ids = await checkpointStore.list();
+    const executionId = ids[ids.length - 1]?.executionId;
+    assert(executionId);
+
+    const resumed = scriptedHarness(storage).harness;
+    const restored = await resumed.restore(executionId);
+    assert(restored);
+    expect(restored.itemLog.items.length).toBe(2);
+    expect(resumed.itemLogPersistence.get(`thread:${threadId}`)).toBe(2);
+  });
+
+  it('a legacy store without appendItems keeps the inline snapshot shape', async () => {
+    const storage = createInMemoryStorage();
+    const full = createCheckpointStore({
+      storage,
+    });
+    const legacy = {
+      save: full.save,
+      load: full.load,
+      list: full.list,
+      clear: full.clear,
+    };
+    const harness = new AgentHarness({
+      name: 'legacy-store',
+      params: {},
+      environment: {
+        storage: {
+          adapter: storage,
+          checkpointStore: legacy,
+        },
+      },
+    });
+    const ctx = harness.createContext({
+      threadId: 'legacy-thread',
+      items: [
+        makeMessage('user', 'inline me'),
+      ],
+    });
+    await harness.checkpoint(ctx);
+
+    const snapshot = await legacy.load(ctx.id);
+    assert(snapshot);
+    expect(snapshot.itemLog.items).toHaveLength(1);
+    expect(snapshot.itemLog.persistedCount).toBeUndefined();
+    expect(await storage.list('execution:thread:legacy-thread:itemLog:')).toEqual([]);
+  });
+});

--- a/packages/core/test/runtime/checkpoint-restore.test.ts
+++ b/packages/core/test/runtime/checkpoint-restore.test.ts
@@ -131,6 +131,41 @@ describe('CheckpointStore', () => {
     await store.clear('x');
     expect(await store.load('x')).toBeNull();
   });
+
+  it('clear does not remove thread-owned item batches', async () => {
+    const storage = createInMemoryStorage();
+    const store = createCheckpointStore({
+      storage,
+    });
+    assert(store.appendItems);
+    assert(store.loadItems);
+    await store.save({
+      schemaVersion: 2,
+      executionId: 'x',
+      threadId: 'main',
+      frontier: [],
+      layers: {},
+      cwd: null,
+      askUser: [],
+      itemLog: {
+        items: [],
+        persistedCount: 2,
+      },
+      capturedAt: new Date().toISOString(),
+    });
+    await store.appendItems('thread:main', 0, [
+      'a',
+      'b',
+    ]);
+
+    await store.clear('x');
+
+    expect(await store.load('x')).toBeNull();
+    expect(await store.loadItems('thread:main', 2)).toEqual([
+      'a',
+      'b',
+    ]);
+  });
 });
 
 describe('AgentHarness.checkpoint + restore', () => {

--- a/packages/core/test/runtime/checkpoint-rollback.test.ts
+++ b/packages/core/test/runtime/checkpoint-rollback.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Durable execution × failed turns: the item-log persistence watermark must
+ * follow the session log through rollback truncation, and remain harness-scoped.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import assert from 'node:assert';
+import type { ContextData } from '@noetic-tools/context';
+import type { Item, LLMResponse, MessageItem, Step } from '@noetic-tools/types';
+import { defaultItemSchemaRegistry } from '@noetic-tools/types';
+import { loop } from '../../src/builders/loop-builder';
+import { runCode } from '../../src/builders/step-builders';
+import { AgentHarness } from '../../src/harness/agent-harness';
+import { createCheckpointStore } from '../../src/runtime/durable/checkpoint-store';
+import { ItemLogPersistence, itemLogOwnerKey } from '../../src/runtime/durable/harness-checkpoints';
+import { createInMemoryStorage } from '../../src/runtime/in-memory-storage';
+import { until } from '../../src/until/predicates';
+import { assistantMessage } from '../_helpers';
+
+let uniq = 0;
+const ITEMS_PER_TURN = 4;
+
+function itemTexts(item: Item): string[] {
+  if (item.type !== 'message') {
+    return [];
+  }
+  const texts: string[] = [];
+  for (const part of item.content) {
+    if (part.type === 'input_text' || part.type === 'output_text') {
+      texts.push(part.text);
+    }
+  }
+  return texts;
+}
+
+function durableTexts(raw: readonly unknown[]): string[] {
+  return defaultItemSchemaRegistry.parseMany(raw).flatMap(itemTexts);
+}
+
+function makeHarness(opts?: { responses?: Array<'ok' | 'fail'> }): {
+  harness: AgentHarness;
+  checkpointStore: ReturnType<typeof createCheckpointStore>;
+} {
+  const storage = createInMemoryStorage();
+  const checkpointStore = createCheckpointStore({
+    storage,
+  });
+  const script = opts?.responses ?? [
+    'ok',
+  ];
+  let call = 0;
+  const n = uniq++;
+  const body: Step<ContextData, string, string> = loop<ContextData, string, string>({
+    id: `turn-body-${n}`,
+    steps: [
+      runCode<ContextData, string, string>({
+        id: `pre-${n}`,
+        execute: async (input) => input,
+      }),
+      {
+        kind: 'callModel',
+        id: `chat-${n}`,
+        model: 'test/scripted',
+        tools: [],
+      },
+    ],
+    until: until.maxSteps(2),
+    maxIterations: 2,
+  });
+  const harness = new AgentHarness({
+    name: 'rollback-test',
+    params: {},
+    agentGraph: body,
+    environment: {
+      storage: {
+        adapter: storage,
+        checkpointStore,
+      },
+    },
+    _testCallModel: async (): Promise<LLMResponse> => {
+      const mode = script[Math.min(call, script.length - 1)];
+      const i = call++;
+      if (mode === 'fail') {
+        throw new Error(`scripted turn failure #${i}`);
+      }
+      const message: MessageItem = assistantMessage(`answer ${i}`, `resp-${i}`);
+      return {
+        items: [
+          message,
+        ],
+        usage: {
+          inputTokens: 0,
+          outputTokens: 1,
+        },
+      };
+    },
+  });
+  return {
+    harness,
+    checkpointStore,
+  };
+}
+
+describe('item-log persistence watermark under turn rollback (D1)', () => {
+  it('a failed turn rolls the persistence watermark back with the log', async () => {
+    const { harness } = makeHarness({
+      responses: [
+        'ok',
+        'ok',
+        'ok',
+        'fail',
+        'ok',
+        'ok',
+      ],
+    });
+
+    await harness.execute('turn one', {
+      threadId: 't-roll',
+    });
+    await harness.getAgentResponse({
+      threadId: 't-roll',
+    });
+    const afterTurn1 = harness.itemLogPersistence.get('thread:t-roll');
+    expect(afterTurn1).toBe(ITEMS_PER_TURN);
+
+    await harness.execute('turn two (will fail)', {
+      threadId: 't-roll',
+    });
+    await harness
+      .getAgentResponse({
+        threadId: 't-roll',
+      })
+      .catch(() => undefined);
+    const afterFail = harness.itemLogPersistence.get('thread:t-roll');
+    expect(afterFail).toBeLessThanOrEqual(afterTurn1);
+
+    await harness.execute('turn three', {
+      threadId: 't-roll',
+    });
+    const resp = await harness.getAgentResponse({
+      threadId: 't-roll',
+    });
+    expect(resp.text).toContain('answer');
+    expect(harness.itemLogPersistence.get('thread:t-roll')).toBe(ITEMS_PER_TURN * 2);
+  });
+
+  it('restore never resurrects a rolled-back turn (durable = live)', async () => {
+    const { harness, checkpointStore } = makeHarness({
+      responses: [
+        'ok',
+        'ok',
+        'ok',
+        'fail',
+        'ok',
+        'ok',
+      ],
+    });
+    const threadId = 't-resurrect';
+    await harness.execute('turn one', {
+      threadId,
+    });
+    await harness.getAgentResponse({
+      threadId,
+    });
+    await harness.execute('turn two (will fail)', {
+      threadId,
+    });
+    await harness
+      .getAgentResponse({
+        threadId,
+      })
+      .catch(() => undefined);
+    await harness.execute('turn three', {
+      threadId,
+    });
+    await harness.getAgentResponse({
+      threadId,
+    });
+
+    assert(checkpointStore.loadItems);
+    const raw = await checkpointStore.loadItems(
+      `thread:${threadId}`,
+      harness.itemLogPersistence.get(`thread:${threadId}`),
+    );
+    const texts = durableTexts(raw);
+    expect(texts).toContain('turn one');
+    expect(texts).toContain('turn three');
+    expect(texts).not.toContain('turn two (will fail)');
+  });
+});
+
+describe('watermarks are harness-scoped, not module-global (D2)', () => {
+  it('two harnesses with the same threadId keep independent watermarks', async () => {
+    const a = makeHarness();
+    const b = makeHarness();
+
+    await a.harness.execute('only harness A speaks', {
+      threadId: 'main',
+    });
+    await a.harness.getAgentResponse({
+      threadId: 'main',
+    });
+
+    expect(a.harness.itemLogPersistence.get('thread:main')).toBe(ITEMS_PER_TURN);
+    expect(b.harness.itemLogPersistence.get('thread:main')).toBe(0);
+  });
+});
+
+describe('ItemLogPersistence contract', () => {
+  it('an unknown owner reads as zero', () => {
+    const p = new ItemLogPersistence();
+    expect(p.get('thread:nobody')).toBe(0);
+  });
+
+  it('set then get round-trips per owner', () => {
+    const p = new ItemLogPersistence();
+    p.set('thread:a', 7);
+    p.set('thread:b', 2);
+    expect(p.get('thread:a')).toBe(7);
+    expect(p.get('thread:b')).toBe(2);
+  });
+
+  it('rollback clamps a watermark that is ahead of the live log', () => {
+    const p = new ItemLogPersistence();
+    p.set('thread:a', 9);
+    p.rollback('thread:a', 4);
+    expect(p.get('thread:a')).toBe(4);
+  });
+
+  it('rollback never raises a watermark that is already at or below the log', () => {
+    const p = new ItemLogPersistence();
+    p.set('thread:a', 3);
+    p.rollback('thread:a', 5);
+    expect(p.get('thread:a')).toBe(3);
+    p.rollback('thread:a', 3);
+    expect(p.get('thread:a')).toBe(3);
+  });
+
+  it('rollback on an unseen owner records nothing (stays zero)', () => {
+    const p = new ItemLogPersistence();
+    p.rollback('thread:unseen', 6);
+    expect(p.get('thread:unseen')).toBe(0);
+  });
+
+  it('delete drops an owner back to zero', () => {
+    const p = new ItemLogPersistence();
+    p.set('thread:a', 5);
+    p.delete('thread:a');
+    expect(p.get('thread:a')).toBe(0);
+  });
+});
+
+describe('itemLogOwnerKey', () => {
+  it('keys on the thread when there is one', () => {
+    expect(
+      itemLogOwnerKey({
+        threadId: 'main',
+        id: 'exec-1',
+      }),
+    ).toBe('thread:main');
+  });
+
+  it('falls back to the execution for a threadless one-shot context', () => {
+    expect(
+      itemLogOwnerKey({
+        id: 'exec-1',
+      }),
+    ).toBe('execution:exec-1');
+  });
+
+  it('capture and restore derive the same key from their different inputs', () => {
+    const fromContext = itemLogOwnerKey({
+      threadId: 't',
+      id: 'exec-live',
+    });
+    const fromSnapshot = itemLogOwnerKey({
+      threadId: 't',
+      id: 'exec-restored',
+    });
+    expect(fromContext).toBe(fromSnapshot);
+  });
+});

--- a/packages/core/test/runtime/checkpoint-schema-mismatch.test.ts
+++ b/packages/core/test/runtime/checkpoint-schema-mismatch.test.ts
@@ -103,4 +103,26 @@ describe('CheckpointSnapshot schema version', () => {
     }
     expect(isNoeticConfigError(thrown)).toBe(true);
   });
+
+  it('load accepts v2 snapshots carrying persistedCount on itemLog', async () => {
+    const storage = createInMemoryStorage();
+    await storage.set(`${CheckpointKeys.ExecPrefix}exec-batches${CheckpointKeys.SnapshotSuffix}`, {
+      schemaVersion: 2,
+      executionId: 'exec-batches',
+      frontier: [],
+      layers: {},
+      cwd: null,
+      askUser: [],
+      itemLog: {
+        items: [],
+        persistedCount: 3,
+      },
+      capturedAt: new Date().toISOString(),
+    });
+    const store = createCheckpointStore({
+      storage,
+    });
+    const loaded = await store.load('exec-batches');
+    expect(loaded?.itemLog.persistedCount).toBe(3);
+  });
 });

--- a/packages/core/test/runtime/context-impl.test.ts
+++ b/packages/core/test/runtime/context-impl.test.ts
@@ -4,6 +4,7 @@ import { isNoeticError } from '@noetic-tools/types';
 import { z } from 'zod';
 import { ChannelStore } from '../../src/runtime/channel-store';
 import { ContextImpl, collectContextTree } from '../../src/runtime/context-impl';
+import { ItemLogImpl } from '../../src/runtime/item-log-impl';
 import { makeMockContext, makeMockHarness } from '../_helpers';
 
 function makeTestItem(): InputMessageItem {
@@ -472,5 +473,51 @@ describe('collectContextTree', () => {
     expect(collectContextTree(foreign)).toEqual([
       foreign,
     ]);
+  });
+});
+
+describe('ContextImpl shared itemLog option', () => {
+  /**
+   * The session runner hands every turn's context the ONE session-owned log.
+   * Appending through the context must land on the shared instance, and reads
+   * through either handle must observe the other's writes — that identity is
+   * what replaces the old copy-forward/copy-back history.
+   */
+  test('a context constructed with `itemLog` shares the instance by reference', () => {
+    const shared = new ItemLogImpl();
+    shared.append(makeTestItem());
+    const ctx = new ContextImpl({
+      harness: makeMockHarness(),
+      itemLog: shared,
+    });
+
+    expect(ctx.itemLog).toBe(shared);
+    expect(ctx.itemLog.items).toHaveLength(1);
+
+    // Writes through the context land on the shared log...
+    ctx.itemLog.append({
+      ...makeTestItem(),
+      id: 'item-2',
+    });
+    expect(shared.items).toHaveLength(2);
+
+    // ...and a rollback through the shared handle is visible to the context.
+    shared.truncateTo(1);
+    expect(ctx.itemLog.items).toHaveLength(1);
+  });
+
+  test('without `itemLog`, a context still builds its own log from `items`', () => {
+    const ctx = new ContextImpl({
+      harness: makeMockHarness(),
+      items: [
+        makeTestItem(),
+      ],
+    });
+    expect(ctx.itemLog.items).toHaveLength(1);
+    // Mutating the context's log must not reach into any other instance.
+    const other = new ContextImpl({
+      harness: makeMockHarness(),
+    });
+    expect(other.itemLog.items).toHaveLength(0);
   });
 });

--- a/packages/core/test/runtime/item-log-impl.test.ts
+++ b/packages/core/test/runtime/item-log-impl.test.ts
@@ -143,3 +143,83 @@ describe('ItemLogImpl', () => {
     expect(log.items[4].type).toBe('openrouter:datetime');
   });
 });
+
+describe('ItemLogImpl.length + truncateTo (session rollback watermark)', () => {
+  const seed = (count: number): ItemLogImpl => {
+    const log = new ItemLogImpl();
+    for (let i = 0; i < count; i++) {
+      log.append(makeInputMessage(`m${i}`));
+    }
+    return log;
+  };
+
+  it('length tracks appends', () => {
+    const log = new ItemLogImpl();
+    expect(log.length).toBe(0);
+    log.append(makeInputMessage('m1'));
+    expect(log.length).toBe(1);
+    log.append(makeInputMessage('m2'));
+    expect(log.length).toBe(2);
+  });
+
+  it('truncateTo drops every item at or after the watermark', () => {
+    const log = seed(3);
+    log.truncateTo(1);
+    expect(log.length).toBe(1);
+    expect(log.items.map((i) => ('id' in i ? i.id : ''))).toEqual([
+      'm0',
+    ]);
+  });
+
+  it('truncateTo(0) empties the log', () => {
+    const log = seed(2);
+    log.truncateTo(0);
+    expect(log.length).toBe(0);
+    expect(log.items).toEqual([]);
+  });
+
+  it('invalidates the frozen snapshot so a later read sees the truncation', () => {
+    const log = seed(2);
+    // Materialise the cache first — a stale cache would keep returning 2 items.
+    expect(log.items).toHaveLength(2);
+    log.truncateTo(1);
+    expect(log.items).toHaveLength(1);
+  });
+
+  // Boundary sweep at N-1 / N / N+1 around the current length (N = 3): only
+  // watermarks strictly below the length truncate; >= length and negative are
+  // no-ops so a stale/out-of-range watermark can never grow or corrupt the log.
+  it('truncateTo(length - 1) truncates', () => {
+    const log = seed(3);
+    log.truncateTo(2);
+    expect(log.length).toBe(2);
+  });
+
+  it('truncateTo(length) is a no-op', () => {
+    const log = seed(3);
+    log.truncateTo(3);
+    expect(log.length).toBe(3);
+  });
+
+  it('truncateTo(length + 1) is a no-op', () => {
+    const log = seed(3);
+    log.truncateTo(4);
+    expect(log.length).toBe(3);
+  });
+
+  it('truncateTo(negative) is a no-op', () => {
+    const log = seed(3);
+    log.truncateTo(-1);
+    expect(log.length).toBe(3);
+  });
+
+  it('appending after a truncation continues from the watermark', () => {
+    const log = seed(3);
+    log.truncateTo(1);
+    log.append(makeInputMessage('after'));
+    expect(log.items.map((i) => ('id' in i ? i.id : ''))).toEqual([
+      'm0',
+      'after',
+    ]);
+  });
+});

--- a/packages/core/test/runtime/session-layer-identity.test.ts
+++ b/packages/core/test/runtime/session-layer-identity.test.ts
@@ -1,0 +1,526 @@
+/**
+ * Two things a session's identity has to get right, both of which the shared
+ * session log / warm-hydration optimisations quietly got wrong:
+ *
+ *  1. WHAT the shared log accepts. Every turn's context validates items against
+ *     the harness base registry EXTENDED with its context layers' `itemSchemas`,
+ *     but the session-owned log is created once per thread. Bind it to the base
+ *     registry and every item type a layer declares is rejected — on the seeding
+ *     path (`seedSessionHistory`, which the chat host calls on first contact for
+ *     every thread) and mid-turn alike. The seeding failure is caught and logged
+ *     upstream, so the symptom is not a crash but a thread that silently loses
+ *     its history on every message, forever.
+ *
+ *  2. WHICH bucket a warm turn inherits. Layer state lives under
+ *     `resolveScopeKey(layer.scope, ctx)`, and for 'resource' and 'global' scope
+ *     that key is not a function of the thread. Keying warm carry-forward on
+ *     threadId alone therefore hands one bucket's state to a turn addressing a
+ *     different one — and because write-through is then re-pointed at the NEW
+ *     scope key, the mismatch is persisted rather than staying in memory.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import assert from 'node:assert';
+import type { ContextData, ContextLayer, StorageAdapter } from '@noetic-tools/context';
+import type { Item, LLMResponse, MessageItem, Step } from '@noetic-tools/types';
+import { frameworkCast } from '@noetic-tools/types';
+import { z } from 'zod';
+import { AgentHarness } from '../../src/harness/agent-harness';
+import { assistantMessage, makeStorage } from '../_helpers';
+
+//#region Helpers
+
+/** A custom item type contributed by a layer, not known to the base registry. */
+const NoteItemSchema = z.object({
+  type: z.literal('myapp:note'),
+  id: z.string(),
+  note: z.string(),
+});
+
+/**
+ * A custom item, shaped by the layer's own schema. `frameworkCast` is the seam a
+ * host crosses when handing its own declared item type to the framework: the
+ * registry is a shape GATE rather than a normalizer, so the item travels through
+ * the log as authored and `Item` cannot enumerate every extension type.
+ */
+function noteItem(id: string, note: string): Item {
+  return frameworkCast<Item>(
+    NoteItemSchema.parse({
+      type: 'myapp:note',
+      id,
+      note,
+    }),
+  );
+}
+
+/** An item whose type NO configured layer declares. */
+function undeclaredItem(): Item {
+  return frameworkCast<Item>({
+    type: 'myapp:unknown',
+    id: 'u1',
+  });
+}
+
+/** A layer that declares `myapp:note` as an item type. */
+function noteDeclaringLayer(): ContextLayer {
+  return {
+    id: 'notes',
+    slot: 100,
+    scope: 'thread',
+    itemSchemas: {
+      items: [
+        NoteItemSchema,
+      ],
+    },
+    hooks: {
+      async recall() {
+        return 'notes layer';
+      },
+    },
+  };
+}
+
+const chatStep: Step<ContextData, string, string> = {
+  kind: 'callModel',
+  id: 'chat',
+  model: 'test/scripted',
+  tools: [],
+};
+
+function harnessWith(opts: { layers?: ContextLayer[]; storage?: StorageAdapter }): AgentHarness {
+  let call = 0;
+  return new AgentHarness({
+    name: 'session-identity',
+    params: {},
+    agentGraph: chatStep,
+    environment: {
+      storage: {
+        adapter: opts.storage ?? makeStorage(),
+      },
+    },
+    contextLayers: opts.layers,
+    _testCallModel: async (): Promise<LLMResponse> => {
+      const message: MessageItem = assistantMessage(`answer ${call}`, `resp-${call}`);
+      call += 1;
+      return {
+        items: [
+          message,
+        ],
+        usage: {
+          inputTokens: 0,
+          outputTokens: 1,
+        },
+      };
+    },
+  });
+}
+
+interface SeenState {
+  seen: string[];
+}
+
+/**
+ * A layer at `scope` that records, in its own state, every event it saw — so a
+ * leak across scope boundaries is visible as one bucket's state containing
+ * another's marks. `tag` is whatever the current turn calls itself.
+ */
+function seenLayer(
+  scope: 'resource' | 'global' | 'thread',
+  tag: () => string,
+): {
+  layer: ContextLayer<SeenState>;
+  inits: () => number;
+} {
+  let inits = 0;
+  const layer: ContextLayer<SeenState> = {
+    id: 'seen',
+    slot: 100,
+    scope,
+    hooks: {
+      async init({ storage }) {
+        inits += 1;
+        const saved = await storage.get<SeenState>('state');
+        return {
+          state: saved ?? {
+            seen: [
+              `init@${tag()}`,
+            ],
+          },
+        };
+      },
+      async recall({ state }) {
+        return `seen=${state.seen.join(',')}`;
+      },
+      async store({ state }) {
+        return {
+          state: {
+            seen: [
+              ...(state?.seen ?? []),
+              `store@${tag()}`,
+            ],
+          },
+        };
+      },
+    },
+  };
+  return {
+    layer,
+    inits: () => inits,
+  };
+}
+
+async function runTurn(
+  harness: AgentHarness,
+  scope: {
+    threadId: string;
+    resourceId?: string;
+  },
+  text: string,
+): Promise<void> {
+  await harness.execute(text, scope);
+  await harness.getAgentResponse({
+    threadId: scope.threadId,
+  });
+}
+
+/** A layer's persisted state for one scope bucket, straight out of storage. */
+async function persistedState(
+  storage: StorageAdapter,
+  layerId: string,
+  scopeKey: string,
+): Promise<SeenState | null> {
+  return storage.get<SeenState>(`layers/${layerId}/${scopeKey}/state`);
+}
+
+//#endregion
+
+describe('the session-owned log honours the layers item registry', () => {
+  it('seedSessionHistory accepts an item type a context layer declares', async () => {
+    const harness = harnessWith({
+      layers: [
+        noteDeclaringLayer(),
+      ],
+    });
+    // Bound to the BASE registry this throws `item_schema_mismatch` from inside
+    // `seedSessionHistory` — swallowed by the caller upstream, so a thread's
+    // history vanishes silently on every message instead of failing loudly.
+    harness.seedSessionHistory('seeded', [
+      noteItem('n1', 'remembered'),
+    ]);
+
+    const items = await harness.previewRequestItems({
+      threadId: 'seeded',
+    });
+    expect(items.map((i) => i.type)).toContain('myapp:note');
+  });
+
+  it('a layer-declared item survives a full turn on the shared log', async () => {
+    const harness = harnessWith({
+      layers: [
+        noteDeclaringLayer(),
+      ],
+    });
+    harness.seedSessionHistory('turning', [
+      noteItem('n1', 'before the turn'),
+    ]);
+    await runTurn(
+      harness,
+      {
+        threadId: 'turning',
+      },
+      'hello',
+    );
+
+    const types = (
+      await harness.previewRequestItems({
+        threadId: 'turning',
+      })
+    ).map((i) => i.type);
+    // The custom item is still there, and the turn's own items landed alongside it.
+    expect(types).toContain('myapp:note');
+    expect(types).toContain('message');
+  });
+
+  it('an item type NO layer declares is still rejected', () => {
+    // The fix widens the log to the layers' registry — it must not widen it to
+    // anything, or `strictItemSchemas` would stop meaning anything on this path.
+    const harness = harnessWith({
+      layers: [
+        noteDeclaringLayer(),
+      ],
+    });
+    expect(() =>
+      harness.seedSessionHistory('rejecting', [
+        undeclaredItem(),
+      ]),
+    ).toThrow(/myapp:unknown/);
+  });
+
+  it('a harness with no layers still rejects an undeclared type', () => {
+    const harness = harnessWith({});
+    expect(() =>
+      harness.seedSessionHistory('bare', [
+        noteItem('n1', 'nobody declared me'),
+      ]),
+    ).toThrow(/myapp:note/);
+  });
+});
+
+describe('warm hydration respects each layers resolved scope key', () => {
+  it('a resource-scoped layer cold-inits when resourceId changes (no cross-tenant leak)', async () => {
+    /* The verified cross-tenant repro: one resource-scoped layer, one thread,
+     * turn 1 as 'alice' and turn 2 as 'bob'. Keyed on threadId alone, bob's turn
+     * took the warm path and inherited alice's state — then
+     * `registerDurableTargets` re-pointed write-through at scopeKey 'bob', so
+     * storage ended with bob's bucket holding alice's marks. */
+    const storage = makeStorage();
+    let tag = 'alice';
+    const probe = seenLayer('resource', () => tag);
+    const harness = harnessWith({
+      layers: [
+        probe.layer,
+      ],
+      storage,
+    });
+
+    await runTurn(
+      harness,
+      {
+        threadId: 'shared',
+        resourceId: 'alice',
+      },
+      'from alice',
+    );
+    tag = 'bob';
+    await runTurn(
+      harness,
+      {
+        threadId: 'shared',
+        resourceId: 'bob',
+      },
+      'from bob',
+    );
+
+    // Two buckets, each holding only its own marks.
+    const alice = await persistedState(storage, 'seen', 'alice');
+    const bob = await persistedState(storage, 'seen', 'bob');
+    assert(alice);
+    assert(bob);
+    expect(alice.seen).toEqual([
+      'init@alice',
+      'store@alice',
+    ]);
+    expect(bob.seen).toEqual([
+      'init@bob',
+      'store@bob',
+    ]);
+    // Explicitly: nothing of alice's reached bob's persisted record.
+    expect(bob.seen.some((s) => s.includes('alice'))).toBe(false);
+    // Bob's turn had to cold-init to read his own (empty) bucket.
+    expect(probe.inits()).toBe(2);
+  });
+
+  it('the same resourceId still warm-carries (the fix is not a blanket cold-init)', async () => {
+    const storage = makeStorage();
+    const probe = seenLayer('resource', () => 'alice');
+    const harness = harnessWith({
+      layers: [
+        probe.layer,
+      ],
+      storage,
+    });
+
+    for (const text of [
+      'one',
+      'two',
+      'three',
+    ]) {
+      await runTurn(
+        harness,
+        {
+          threadId: 'shared',
+          resourceId: 'alice',
+        },
+        text,
+      );
+    }
+
+    // One cold init for three turns — the whole point of the warm path.
+    expect(probe.inits()).toBe(1);
+    const alice = await persistedState(storage, 'seen', 'alice');
+    assert(alice);
+    // ...and state accumulated across them rather than resetting each turn.
+    expect(alice.seen.filter((s) => s.startsWith('store@'))).toHaveLength(3);
+  });
+
+  it('a resource-scoped layer returning to an earlier resourceId re-reads that bucket', async () => {
+    // alice → bob → alice. The final turn must resume ALICE's accumulated state,
+    // not bob's, and not a fresh init that discards hers.
+    const storage = makeStorage();
+    let tag = 'alice';
+    const probe = seenLayer('resource', () => tag);
+    const harness = harnessWith({
+      layers: [
+        probe.layer,
+      ],
+      storage,
+    });
+
+    await runTurn(
+      harness,
+      {
+        threadId: 'shared',
+        resourceId: 'alice',
+      },
+      'a1',
+    );
+    tag = 'bob';
+    await runTurn(
+      harness,
+      {
+        threadId: 'shared',
+        resourceId: 'bob',
+      },
+      'b1',
+    );
+    tag = 'alice';
+    await runTurn(
+      harness,
+      {
+        threadId: 'shared',
+        resourceId: 'alice',
+      },
+      'a2',
+    );
+
+    const alice = await persistedState(storage, 'seen', 'alice');
+    const bob = await persistedState(storage, 'seen', 'bob');
+    assert(alice);
+    assert(bob);
+    // Alice's two turns both stored; her bucket never saw bob.
+    expect(alice.seen.filter((s) => s === 'store@alice')).toHaveLength(2);
+    expect(alice.seen.some((s) => s.includes('bob'))).toBe(false);
+    expect(bob.seen.some((s) => s.includes('alice'))).toBe(false);
+  });
+
+  it('a global-scoped layer does not lose another threads update', async () => {
+    /* The verified lost-update repro: a global-scoped counter, thread A for three
+     * turns, thread B for one, then thread A again. A's warm entry held an
+     * in-memory copy predating B's increment, and the write-through mirror made
+     * that stale value win — turning a shared global bucket into a silent
+     * last-writer-wins race between threads. */
+    const storage = makeStorage();
+    let tag = 'A';
+    const probe = seenLayer('global', () => tag);
+    const harness = harnessWith({
+      layers: [
+        probe.layer,
+      ],
+      storage,
+    });
+
+    for (const text of [
+      'a1',
+      'a2',
+      'a3',
+    ]) {
+      await runTurn(
+        harness,
+        {
+          threadId: 'A',
+        },
+        text,
+      );
+    }
+    tag = 'B';
+    await runTurn(
+      harness,
+      {
+        threadId: 'B',
+      },
+      'b1',
+    );
+    tag = 'A';
+    await runTurn(
+      harness,
+      {
+        threadId: 'A',
+      },
+      'a4',
+    );
+
+    const global = await persistedState(storage, 'seen', '__global__');
+    assert(global);
+    // Five turns stored into the one shared bucket; none of them lost. The bug
+    // dropped B's, leaving four.
+    expect(global.seen.filter((s) => s.startsWith('store@'))).toHaveLength(5);
+    expect(global.seen).toContain('store@B');
+  });
+
+  it('a thread-scoped layer still warm-carries across turns (regression guard)', async () => {
+    // 'thread' is the scope where threadId happens to BE the scope key, so the
+    // pre-fix behaviour was already correct here. It must stay correct: the fix
+    // narrows carry-forward, and narrowing it too far would silently reintroduce
+    // a cold storage read per turn per layer.
+    const storage = makeStorage();
+    const probe = seenLayer('thread', () => 'T');
+    const harness = harnessWith({
+      layers: [
+        probe.layer,
+      ],
+      storage,
+    });
+
+    for (const text of [
+      'one',
+      'two',
+      'three',
+    ]) {
+      await runTurn(
+        harness,
+        {
+          threadId: 'T',
+        },
+        text,
+      );
+    }
+
+    expect(probe.inits()).toBe(1);
+    const state = await persistedState(storage, 'seen', 'T');
+    assert(state);
+    expect(state.seen.filter((s) => s.startsWith('store@'))).toHaveLength(3);
+  });
+
+  it('a resource-scoped layer with no resourceId falls back to the thread bucket', async () => {
+    // `resolveScopeKey('resource', ctx)` is `resourceId ?? threadId`, so turns
+    // without a resourceId all address the thread bucket and must warm-carry.
+    const storage = makeStorage();
+    const probe = seenLayer('resource', () => 'T');
+    const harness = harnessWith({
+      layers: [
+        probe.layer,
+      ],
+      storage,
+    });
+
+    await runTurn(
+      harness,
+      {
+        threadId: 'T',
+      },
+      'one',
+    );
+    await runTurn(
+      harness,
+      {
+        threadId: 'T',
+      },
+      'two',
+    );
+
+    expect(probe.inits()).toBe(1);
+    const state = await persistedState(storage, 'seen', 'T');
+    assert(state);
+    expect(state.seen.filter((s) => s.startsWith('store@'))).toHaveLength(2);
+  });
+});

--- a/packages/core/test/runtime/session-owned-log.test.ts
+++ b/packages/core/test/runtime/session-owned-log.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The session-owned item log: one `ItemLogImpl` per thread, shared by reference
+ * with every turn's context. Two semantics the old copy-out/copy-back history
+ * gave for free must be preserved explicitly:
+ *
+ *  1. A FAILED turn leaves no trace. With a single shared log, the turn's
+ *     partial items (its input, anything appended before the failure) are
+ *     already in the log when the error hits — the runner rolls back to a
+ *     watermark captured at turn start instead of relying on never-copied-back.
+ *  2. History accumulates across turns by identity: turn N's context reads and
+ *     appends the same log turns 1..N-1 wrote, with no per-turn array spreads.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { ContextData } from '@noetic-tools/context';
+import type { CallModelRequest, Item, LLMResponse, Step } from '@noetic-tools/types';
+import { AgentHarness } from '../../src/harness/agent-harness';
+import { textOnlyResponse } from '../_helpers';
+
+const echoStep: Step<ContextData, string, string> = {
+  kind: 'callModel',
+  id: 'echo',
+  model: 'test/echo',
+  tools: [],
+};
+
+function itemTexts(items: ReadonlyArray<Item>): string[] {
+  return items.flatMap((item) =>
+    item.type === 'message'
+      ? item.content.flatMap((part) =>
+          part.type === 'input_text' || part.type === 'output_text'
+            ? [
+                part.text,
+              ]
+            : [],
+        )
+      : [],
+  );
+}
+
+describe('session-owned item log', () => {
+  it('history accumulates across turns on one thread', async () => {
+    const captured: string[][] = [];
+    const harness = new AgentHarness({
+      name: 'test',
+      agentGraph: echoStep,
+      params: {},
+      _testCallModel: async (request: CallModelRequest): Promise<LLMResponse> => {
+        captured.push(itemTexts(request.items));
+        return textOnlyResponse(`reply ${captured.length}`);
+      },
+    });
+
+    await harness.execute('first');
+    await harness.getAgentResponse();
+    await harness.execute('second');
+    await harness.getAgentResponse();
+
+    expect(captured).toHaveLength(2);
+    // Turn 2 saw turn 1's input AND its reply — the shared log carried both
+    // forward without any copy-back step.
+    expect(captured[1]).toContain('first');
+    expect(captured[1]).toContain('reply 1');
+    expect(captured[1]).toContain('second');
+  });
+
+  it('a failed turn leaves no trace in the session history', async () => {
+    const captured: string[][] = [];
+    let fail = true;
+    const harness = new AgentHarness({
+      name: 'test',
+      agentGraph: echoStep,
+      params: {},
+      _testCallModel: async (request: CallModelRequest): Promise<LLMResponse> => {
+        captured.push(itemTexts(request.items));
+        if (fail) {
+          throw new Error('model exploded');
+        }
+        return textOnlyResponse('recovered');
+      },
+    });
+
+    await harness.execute('doomed turn');
+    await expect(harness.getAgentResponse()).rejects.toThrow('model exploded');
+
+    fail = false;
+    await harness.execute('next turn');
+    const response = await harness.getAgentResponse();
+    expect(response.text).toBe('recovered');
+
+    // The recovery turn's request contains neither the failed turn's input nor
+    // any partial output — the rollback restored the pre-turn watermark.
+    expect(captured).toHaveLength(2);
+    expect(captured[1]).toContain('next turn');
+    expect(captured[1]).not.toContain('doomed turn');
+  });
+
+  it('the failure rollback preserves earlier successful turns', async () => {
+    const captured: string[][] = [];
+    let fail = false;
+    const harness = new AgentHarness({
+      name: 'test',
+      agentGraph: echoStep,
+      params: {},
+      _testCallModel: async (request: CallModelRequest): Promise<LLMResponse> => {
+        captured.push(itemTexts(request.items));
+        if (fail) {
+          throw new Error('model exploded');
+        }
+        return textOnlyResponse(`reply ${captured.length}`);
+      },
+    });
+
+    await harness.execute('good turn');
+    await harness.getAgentResponse();
+
+    fail = true;
+    await harness.execute('bad turn');
+    await expect(harness.getAgentResponse()).rejects.toThrow('model exploded');
+
+    fail = false;
+    await harness.execute('final turn');
+    await harness.getAgentResponse();
+
+    const last = captured[captured.length - 1];
+    // Turn 1's exchange survived the failed turn's rollback...
+    expect(last).toContain('good turn');
+    expect(last).toContain('reply 1');
+    // ...while turn 2's input was erased.
+    expect(last).not.toContain('bad turn');
+    expect(last).toContain('final turn');
+  });
+});

--- a/packages/core/test/runtime/step-ledger.test.ts
+++ b/packages/core/test/runtime/step-ledger.test.ts
@@ -546,6 +546,51 @@ describe('step ledger retention config', () => {
     expect(await ledgerKeys(storage, 'exec')).toHaveLength(3);
   });
 
+  it('a storage-outage burst of failed appends never evicts live entries (D3)', async () => {
+    const storage = createInMemoryStorage();
+    const store = createStepLedgerStore({
+      storage,
+    });
+    let failing = false;
+    const flaky: typeof store = {
+      ...store,
+      append: async (executionId, seq, entry) => {
+        if (failing) {
+          throw new Error('storage outage');
+        }
+        return store.append(executionId, seq, entry);
+      },
+    };
+    const ledger = new StepLedger({
+      executionId: 'exec',
+      store: flaky,
+      retention: {
+        maxEntries: 5,
+      },
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await ledger.record(entryOfBytes(`live-${i}`, 8));
+    }
+    failing = true;
+    for (let i = 0; i < 10; i++) {
+      await ledger.record(entryOfBytes(`lost-${i}`, 8));
+    }
+    failing = false;
+
+    expect(await ledgerKeys(storage, 'exec')).toHaveLength(5);
+    expect(ledger.stats.evicted).toBe(0);
+
+    await ledger.record(entryOfBytes('live-5', 8));
+    const retained = [
+      ...(await store.load('exec')).entries.keys(),
+    ];
+    expect(retained).toHaveLength(5);
+    expect(retained).not.toContain('live-0');
+    expect(retained).toContain('live-5');
+    expect(ledger.stats.evicted).toBe(1);
+  });
+
   it('gives concurrent records distinct keys', async () => {
     /* Fork legs record through the one shared ledger while in flight together. If the
      * sequence number were read after an await they would land on the same key and one

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -415,7 +415,9 @@ interface DetachedHandle<O> {
 
 - a FIFO `MessageQueue`,
 - a long-lived `EventBroadcaster` that relays SDK and framework events across all turns,
-- an `itemLog` snapshot that carries conversation history from turn to turn.
+- one live `ItemLogImpl` shared by every turn context in the session.
+
+The shared log eliminates per-turn copy-out/copy-back. A turn captures its starting length and truncates back to that watermark on failure or cancellation, so failed turns leave no partial input, model output, or tool results. History seeding validates the entire replacement before mutating the live log.
 
 Before the first turn runs, the harness walks the step tree to collect all tools from callModel steps, merges them with layer-provided tools, and deduplicates by name. This **unified tool set** is stored on the turn's execution context and sent with every LLM call for prompt cache efficiency. Individual steps restrict the model to a subset via the Open Responses `tool_choice: { type: "allowed_tools" }` parameter. `run(step, input, ctx)` does the same lazily: when an embedder drives a step directly on a bare `createContext()` context, `run` populates that context's unified tool set (the step's tools plus the harness tools) if it is not already set, so directly-driven steps — and any sub-agents they spawn — see the harness toolset. `run` also runs the configured context layers' `init()` hooks once per context (keyed by `ctx.id`) before executing, so a harness built with `contextLayers` + a storage adapter rehydrates prior layer state, recalls it, and persists updates on the bare `run()` path — the same guarantee the session/`execute()` path gives. The init is idempotent: nested or repeated `run()` calls and the session turn path never re-init (which would clobber accumulated in-layer state by re-hydrating from storage); a deliberate `disposeLayers(ctx)` clears the guard so a later `run()` re-hydrates.
 

--- a/specs/08-runtime.md
+++ b/specs/08-runtime.md
@@ -640,7 +640,7 @@ Snapshot content (Zod-validated by `CheckpointSnapshotSchema`):
 - `layers` — `Record<layerId, state>` captured via `layerStateStore.get(executionId, layerId)`.
 - `cwd` — `{ current, previous }`.
 - `askUser` — pending ask-user requests (populated when the code-agent's `AskUserService` integrates with the store).
-- `itemLog` — `{ items: Item[] }`, the full item log.
+- `itemLog` — either `{ items: Item[] }` for legacy inline snapshots, or `{ items: [], persistedCount: number }` when the transcript lives in append-only batches keyed by log owner (`execution:<ownerKey>:itemLog:<offset>`).
 - `capturedAt` — ISO-8601 timestamp.
 
 ### Restore Contract
@@ -648,7 +648,7 @@ Snapshot content (Zod-validated by `CheckpointSnapshotSchema`):
 `harness.restore(executionId)` reads the snapshot and rebuilds a `Context`:
 
 1. Replays layer state into `layerStateStore` under the same executionId so context projectors observe continuity.
-2. Re-parses `itemLog.items` via the harness's `ItemSchemaRegistry` (the same gate production traffic passes through).
+2. Re-parses `itemLog.items` via the harness's `ItemSchemaRegistry` (the same gate production traffic passes through). When `persistedCount` is present and the store supports batch loading, restore stitches the first contiguous durable prefix from the owner-keyed item batches and seeds the harness watermark from the recovered count.
 3. Seeds a new context with `threadId`, `resourceId`, and `cwdInit` from the snapshot.
 4. Returns a `Context` whose `.id` is overridden to the original `executionId` so downstream readers correlate across the restart.
 

--- a/specs/11-context-layer-system.md
+++ b/specs/11-context-layer-system.md
@@ -468,6 +468,10 @@ When `recall()` returns `tokenCount` less than allocated, the difference goes to
 
 The agent harness independently counts tokens. If layer-reported count diverges by >10%, the agent harness count is authoritative and a warning is emitted.
 
+## Warm Layer Hydration
+
+Session turns may carry initialized layer state forward without re-running `init`. Warm state is keyed by `(layer.id, resolveScopeKey(layer.scope, ctx))`, not by thread alone: resource-scoped state must cold-init when the resource changes, global state shares one bucket across threads, and thread state carries across turns. Execution-scoped layers always cold-init. Preview contexts are transient and never become a warm source. Each warm carry re-registers durable write-through targets for the new execution id.
+
 ## Recall Modes
 
 Each layer's `recallMode` controls whether its `recall()` blocks the model call:

--- a/specs/23-durable-execution.md
+++ b/specs/23-durable-execution.md
@@ -55,7 +55,8 @@ interface PendingAskUserSnapshot {
 }
 
 interface ItemLogSnapshot {
-  items: unknown[];                       // re-parsed via ItemSchemaRegistry on load
+  items: unknown[];                       // inline legacy shape, or [] when batched
+  persistedCount?: number;                // durable item count when batches are used
 }
 ```
 
@@ -69,7 +70,7 @@ Version history:
 
 `layers` is keyed by `layerId`; `restore()` re-inserts each entry into `harness.layerStateStore` under the original `executionId` so projections observe continuity. Layers that didn't publish state at snapshot time are absent from the record (not `null`).
 
-`itemLog.items` is serialised as `unknown[]` and re-parsed on load via `harness.itemSchemas.parseMany(...)` — the same gate production traffic passes through, so extension item shapes are validated identically.
+`itemLog.items` is serialised as `unknown[]` and re-parsed on load via `harness.itemSchemas.parseMany(...)` — the same gate production traffic passes through, so extension item shapes are validated identically. When the store supports item batches, the snapshot carries `persistedCount` and the transcript itself lives outside the snapshot as append-only batches under `execution:<ownerKey>:itemLog:<offset>`; restore stitches the first contiguous durable prefix from those batches.
 
 ## Checkpoint lifecycle
 
@@ -82,7 +83,7 @@ Version history:
 3. **Ask-user enqueue** — when a pending prompt is added to the ask-user queue. A restarted host can replay the modal to the TUI without losing state.
 4. **Post-`runAppendPipeline`** — after the append pipeline resolves. Layer state can mutate as items land, and the snapshot must follow that mutation.
 
-Any caller may additionally invoke `harness.checkpoint(ctx)` explicitly (e.g. after a long-running tool call settles). Snapshots are cheap: a few kilobytes per execution, one `StorageAdapter.set()` call.
+Any caller may additionally invoke `harness.checkpoint(ctx)` explicitly (e.g. after a long-running tool call settles). Snapshot writes stay O(layers + frontier): when batching is enabled only the delta item batch is appended, while the snapshot itself carries the durable item count. If a turn or seeded history rolls the shared session log back, the next checkpoint truncates orphaned durable batches before appending again, so restore cannot resurrect discarded transcript items.
 
 ### Idempotency
 
@@ -99,7 +100,7 @@ A failing `store.save` is logged via `console.warn` and swallowed. **A failing c
 1. Reads the snapshot via `checkpointStore.load(executionId)`. Returns `null` if no snapshot is recorded.
 2. Validates `schemaVersion` (throws `CHECKPOINT_SCHEMA_MISMATCH` on mismatch).
 3. Replays `layers` into `harness.layerStateStore` keyed by the original `executionId`, so context projectors and `ctx.context[layerId]` accessors observe continuity across the restart.
-4. Re-parses `itemLog.items` through `harness.itemSchemas` to recover typed `Item[]`.
+4. Re-parses `itemLog.items` through `harness.itemSchemas` to recover typed `Item[]`. When `persistedCount` is present and the store supports `loadItems`, restore loads the item batches through the same owner key capture used and clamps the harness watermark to the contiguous prefix actually recovered.
 5. Calls `harness.createContext({...opts, items, threadId, resourceId, cwdInit: snapshot.cwd?.current, context: opts?.context ?? harness._contextLayers})` to produce a fresh context seeded with the snapshot's item log, identity, and cwd.
 6. Overrides the returned context's `.id` to the original `executionId` so downstream adapter-correlation keeps working.
 7. Attaches the recovered step ledger (`23a-step-level-resume`) keyed to that same id.

--- a/specs/23a-step-level-resume.md
+++ b/specs/23a-step-level-resume.md
@@ -150,10 +150,10 @@ new AgentHarness({ /* … */ environment: { storage: { checkpointStore, stepLedg
    nothing an adapter could persist, so nothing is recorded.
 2. **Total entries.** Recording past `maxEntries` deletes the oldest entry, so resume is
    best-effort over a bounded **suffix** of the run: the tail replays, the head runs
-   again. The bound is on the sequence *window* (`nextSeq - oldestSeq`), which is what
-   makes eviction O(1) — an exact row count would need a `list()` per append, the very
-   cost sharding removed. A gap from a failed write makes the window a slight
-   over-estimate, so eviction fires marginally early, never late.
+   again. The bound is on the sequence *window* (`nextSeq - oldestSeq`) MINUS known
+   failed-append gaps, which keeps eviction O(1) without counting outage holes as live
+   entries. An exact row count would need a `list()` per append, the very cost sharding
+   removed.
 
 Both degradations reduce to the same thing: a step with no entry re-runs. That costs work
 and re-does whatever effects the step has (see "The side-effect boundary"), never a
@@ -162,9 +162,11 @@ counts what was recorded, dropped, and evicted — and the first drop of each ki
 
 Sequence numbers are reserved synchronously, before the append's `await`. Concurrent `inParallel`
 legs record through the one shared ledger, and a counter read after an await would let two
-legs write the same key, silently losing a sibling's entry. `load()` therefore reports
-`nextSeq` from storage rather than deriving it from the recovered entry count, which
-retention's gaps would place *inside* the live window.
+legs write the same key, silently losing a sibling's entry. Failed appends are remembered as
+explicit gaps until eviction's cursor passes them, so a clustered outage cannot evict real
+entries to satisfy a phantom count. `load()` therefore reports `nextSeq` from storage rather
+than deriving it from the recovered entry count, which retention's gaps would place *inside*
+the live window.
 
 ## Clearing a ledger
 
@@ -201,6 +203,7 @@ Hosts need it in two situations:
 - An oversized or unserialisable output is not recorded, and its step re-dispatches on resume while its neighbours still replay.
 - Concurrent records (inParallel legs through one shared ledger) land on distinct keys.
 - A resumed ledger never reuses a live sequence number, even when retention left a gap.
+- A burst of failed appends (reserved sequence numbers with no stored rows) never causes phantom eviction of live entries.
 - `harness.clearCheckpoint` removes the snapshot and every ledger shard.
 
 ## Sizing


### PR DESCRIPTION
## What

- persist checkpoint item logs as offset-keyed O(delta) batches
- stitch only contiguous batches and clamp persisted watermarks to available data
- truncate/rewrite batches after rollback or history reseed
- keep item-log persistence watermarks scoped to each harness
- preserve step-ledger continuity across storage outage gaps
- add an opt-in reproducible benchmark that reports raw measurements without multiplier claims

## Why

Full item logs in every checkpoint create quadratic write volume. Partial stores, failed turns, and reseeds also require explicit rollback semantics so stale batches cannot resurrect removed items.

This ports item 13 from `fork/port/openrouter-fixes` commits `fc89dbab` and `796f7ec2`, based on item-12 session-owned logs.

## Test plan

- [x] full core suite passes
- [x] checkpoint batch/stitch/rollback and ledger outage tests
- [x] core typecheck
- [x] root lint
- [x] opt-in benchmark reports raw measurements only
- [x] clean-context Pi review

## Dependencies and boundaries

Depends on [#79](https://github.com/mattapperson/noetic/pull/79). The current diff includes that prerequisite and must be rebased through main after #79 merges.

Known follow-up from review: durable batch ownership is keyed by thread id, matching the source port and current session identity contract. Multi-host consumers sharing a storage root must namespace their thread ids/storage; adding an explicit harness namespace is a separate public storage-format design.
