### PR TITLE
fix(eval): harden GEPA discovery and reuse

### DIFF
--- a/.claude/skills/noetic-eval/SKILL.md
+++ b/.claude/skills/noetic-eval/SKILL.md
@@ -169,14 +169,15 @@ noetic-eval --watch                # Re-run on changes
 
 noetic-eval -u                     # Optimize (GEPA)
 noetic-eval -u --scope full        # Full program optimization
-noetic-eval -u --budget 10         # Cost cap
+noetic-eval --concurrency 4       # Bound cases running per suite
 noetic-eval -u --dry-run           # Preview without writing
+noetic-eval -u --force-dirty       # Override dirty-file write guard
 
 noetic-eval --save-baseline        # Save scores as regression baseline
 noetic-eval --check                # Fail if scores regress or baseline cases vanish
 ```
 
-Exit codes: `0` all cases passed (clean `--check`; no-baseline `--check` prints a notice and passes), `1` any failed/errored case, regression, missing baseline case, or unresolvable explicit file pattern, `2` usage error (unknown flag, invalid `--scope`/`--budget` value — never silently dropped).
+Exit codes: `0` all cases passed (clean `--check`; no-baseline `--check` prints a notice and passes), `1` any failed/errored case, regression, missing baseline case, or unresolvable explicit file pattern, `2` usage error (unknown flag or invalid `--scope`/`--concurrency` value — never silently dropped).
 
 Watch mode spawns a fresh subprocess per run (in-process re-import is module-cached and would never re-register suites), serializes runs, coalesces changes during a run into one follow-up, and always exits `0` itself. Only the eval files are watched, not transitive imports.
 

--- a/.claude/skills/noetic-eval/references/api-reference.md
+++ b/.claude/skills/noetic-eval/references/api-reference.md
@@ -187,8 +187,8 @@ interface OptimizeOptions {
   scope: 'prompts-only' | 'flow-structure' | 'full';
   runEval: (step: Step) => Promise<Record<string, number>>;
   maxMetricCalls?: number;
-  budget?: number;
   dryRun?: boolean;
+  forceDirty?: boolean;
   codingAgent?: CodingAgent;
   preEnrichedFields?: OptimizableField[];  // AST-enriched fields with source locations
   gepa?: GepaConfig;

--- a/packages/core/src/interpreter/execute-action.ts
+++ b/packages/core/src/interpreter/execute-action.ts
@@ -111,7 +111,7 @@ export async function executeRunCode<TContext, I, O>(
       lastError = e instanceof Error ? e : new Error(String(e));
 
       if (attempt < maxAttempts - 1 && retry) {
-        const delay = computeDelay(retry, attempt);
+        const delay = computeRetryDelay(retry, attempt);
         await new Promise((r) => setTimeout(r, delay));
       }
     }
@@ -125,7 +125,8 @@ export async function executeRunCode<TContext, I, O>(
   });
 }
 
-function computeDelay(retry: RetryPolicy, attempt: number): number {
+/** @internal Pure retry delay calculation for deterministic tests. */
+export function computeRetryDelay(retry: RetryPolicy, attempt: number): number {
   let delay: number;
   switch (retry.backoff) {
     case 'fixed':

--- a/packages/core/test/interpreter/execute-run.test.ts
+++ b/packages/core/test/interpreter/execute-run.test.ts
@@ -1,47 +1,15 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { describe, expect, it } from 'bun:test';
 import assert from 'node:assert';
 import type { ContextData } from '@noetic-tools/context';
-import type { Context, StepRunCode } from '@noetic-tools/types';
+import type { Context, RetryPolicy, StepRunCode } from '@noetic-tools/types';
 import { isNoeticError, NoeticErrorImpl } from '@noetic-tools/types';
-import { executeRunCode } from '../../src/interpreter/execute-action';
+import { computeRetryDelay, executeRunCode } from '../../src/interpreter/execute-action';
 import { ContextImpl } from '../../src/runtime/context-impl';
 import { makeMockContext, makeMockHarness } from '../_helpers';
 
 const mockCtx: Context = makeMockContext();
 
-// Safety net: ensure setTimeout is always restored
-const _originalSetTimeout = globalThis.setTimeout;
-afterEach(() => {
-  globalThis.setTimeout = _originalSetTimeout;
-});
-
-/** Patch setTimeout to capture delay values and execute callbacks instantly. */
-function interceptDelays(): {
-  delays: number[];
-  restore: () => void;
-} {
-  const delays: number[] = [];
-  // Wrap the original to intercept delay values while preserving the full overloaded signature
-  const handler: ProxyHandler<typeof setTimeout> = {
-    apply(_target, thisArg, argsList: unknown[]) {
-      const delay = argsList[1];
-      if (typeof delay === 'number' && delay > 0) {
-        delays.push(delay);
-      }
-      argsList[1] = 1;
-      return Reflect.apply(_originalSetTimeout, thisArg, argsList);
-    },
-  };
-  globalThis.setTimeout = new Proxy(_originalSetTimeout, handler);
-  return {
-    delays,
-    restore: () => {
-      globalThis.setTimeout = _originalSetTimeout;
-    },
-  };
-}
-
-describe.serial('executeRunCode', () => {
+describe('executeRunCode', () => {
   it('calls execute function and returns output', async () => {
     const s: StepRunCode<ContextData, string, number> = {
       kind: 'runCode',
@@ -88,105 +56,81 @@ describe.serial('executeRunCode', () => {
   });
 
   it('retries with fixed backoff', async () => {
-    const { delays, restore } = interceptDelays();
-
     let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
+    const retry: RetryPolicy = {
+      maxAttempts: 3,
+      backoff: 'fixed',
+      initialDelay: 1,
+    };
+    const step: StepRunCode<ContextData, string, string> = {
       kind: 'runCode',
       id: 'retry-test',
-      execute: async (_input) => {
+      retry,
+      execute: async () => {
         attempts++;
         if (attempts < 3) {
           throw new Error('not yet');
         }
         return 'success';
       },
-      retry: {
-        maxAttempts: 3,
-        backoff: 'fixed',
-        initialDelay: 10,
-      },
     };
-    try {
-      const result = await executeRunCode(s, 'test', mockCtx);
-      expect(result).toBe('success');
-      expect(attempts).toBe(3);
-      // Fixed backoff: all delays should be 10
-      expect(delays).toEqual([
-        10,
-        10,
-      ]);
-    } finally {
-      restore();
-    }
+    expect(await executeRunCode(step, 'test', mockCtx)).toBe('success');
+    expect(attempts).toBe(3);
+    expect(
+      [
+        0,
+        1,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
+      1,
+      1,
+    ]);
   });
 
   it('retries with exponential backoff and exhausts', async () => {
-    const { delays, restore } = interceptDelays();
     let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
+    const retry: RetryPolicy = {
+      maxAttempts: 3,
+      backoff: 'exponential',
+      initialDelay: 1,
+    };
+    const step: StepRunCode<ContextData, string, string> = {
       kind: 'runCode',
       id: 'exhaust-test',
+      retry,
       execute: async () => {
         attempts++;
         throw new Error('always fails');
       },
-      retry: {
-        maxAttempts: 3,
-        backoff: 'exponential',
-        initialDelay: 10,
-      },
     };
-    try {
-      await executeRunCode(s, 'test', mockCtx);
-      expect.unreachable('should have thrown');
-    } catch (e) {
-      assert(isNoeticError(e));
-      const oe = e.noeticError;
-      assert(oe.kind === 'step_failed');
-      expect(oe.retriesExhausted).toBe(true);
-      expect(attempts).toBe(3);
-      expect(delays).toEqual([
-        10,
-        20,
-      ]);
-    } finally {
-      restore();
-    }
+    await expect(executeRunCode(step, 'test', mockCtx)).rejects.toThrow('always fails');
+    expect(attempts).toBe(3);
+    expect(
+      [
+        0,
+        1,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
+      1,
+      2,
+    ]);
   });
 
-  it('caps exponential backoff delay at maxDelay', async () => {
-    const { delays, restore } = interceptDelays();
-
-    let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
-      kind: 'runCode',
-      id: 'cap-test',
-      execute: async () => {
-        attempts++;
-        if (attempts < 5) {
-          throw new Error('fail');
-        }
-        return 'ok';
-      },
-      retry: {
-        maxAttempts: 5,
-        backoff: 'exponential',
-        initialDelay: 100,
-        maxDelay: 500,
-      },
+  it('caps exponential backoff delay at maxDelay', () => {
+    const retry: RetryPolicy = {
+      maxAttempts: 5,
+      backoff: 'exponential',
+      initialDelay: 100,
+      maxDelay: 500,
     };
-    try {
-      await executeRunCode(s, 'test', mockCtx);
-    } finally {
-      restore();
-    }
-    // Delays: 100, 200, 400, 500 (capped from 800)
-    for (const d of delays) {
-      expect(d).toBeLessThanOrEqual(500);
-    }
-    expect(delays.length).toBeGreaterThan(0);
-    expect(delays).toEqual([
+    expect(
+      [
+        0,
+        1,
+        2,
+        3,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
       100,
       200,
       400,
@@ -194,46 +138,26 @@ describe.serial('executeRunCode', () => {
     ]);
   });
 
-  it('defaults maxDelay to 30000', async () => {
-    // With exponential backoff, delay = 100 * 2^attempt
-    // For attempt 9: 100 * 512 = 51200, should be capped at 30000
-    const { delays, restore } = interceptDelays();
-
-    let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
-      kind: 'runCode',
-      id: 'default-cap-test',
-      execute: async () => {
-        attempts++;
-        if (attempts < 11) {
-          throw new Error('fail');
-        }
-        return 'ok';
-      },
-      retry: {
-        maxAttempts: 11,
-        backoff: 'exponential',
-        initialDelay: 100,
-      },
+  it('defaults maxDelay to 30000', () => {
+    const retry: RetryPolicy = {
+      maxAttempts: 11,
+      backoff: 'exponential',
+      initialDelay: 100,
     };
-    try {
-      await executeRunCode(s, 'test', mockCtx);
-    } finally {
-      restore();
-    }
-    for (const d of delays) {
-      expect(d).toBeLessThanOrEqual(30_000);
-    }
-    expect(delays.length).toBeGreaterThan(0);
+    expect(computeRetryDelay(retry, 9)).toBe(30_000);
   });
 
   it('retries with linear backoff', async () => {
-    const { delays, restore } = interceptDelays();
-
     let attempts = 0;
-    const s: StepRunCode<ContextData, string, string> = {
+    const retry: RetryPolicy = {
+      maxAttempts: 3,
+      backoff: 'linear',
+      initialDelay: 1,
+    };
+    const step: StepRunCode<ContextData, string, string> = {
       kind: 'runCode',
       id: 'linear-test',
+      retry,
       execute: async () => {
         attempts++;
         if (attempts < 3) {
@@ -241,24 +165,18 @@ describe.serial('executeRunCode', () => {
         }
         return 'ok';
       },
-      retry: {
-        maxAttempts: 3,
-        backoff: 'linear',
-        initialDelay: 10,
-      },
     };
-    try {
-      const result = await executeRunCode(s, 'test', mockCtx);
-      expect(result).toBe('ok');
-      expect(attempts).toBe(3);
-      // Linear backoff: delay = initialDelay * attempt
-      expect(delays).toEqual([
-        10,
-        20,
-      ]);
-    } finally {
-      restore();
-    }
+    expect(await executeRunCode(step, 'test', mockCtx)).toBe('ok');
+    expect(attempts).toBe(3);
+    expect(
+      [
+        0,
+        1,
+      ].map((attempt) => computeRetryDelay(retry, attempt)),
+    ).toEqual([
+      1,
+      2,
+    ]);
   });
 
   describe('cancellation (not retriable)', () => {

--- a/packages/core/test/interpreter/execute-run.test.ts
+++ b/packages/core/test/interpreter/execute-run.test.ts
@@ -41,7 +41,7 @@ function interceptDelays(): {
   };
 }
 
-describe('executeRunCode', () => {
+describe.serial('executeRunCode', () => {
   it('calls execute function and returns output', async () => {
     const s: StepRunCode<ContextData, string, number> = {
       kind: 'runCode',

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -76,7 +76,9 @@ noetic-eval --watch             # re-run on change
 noetic-eval --json              # machine-readable results
 noetic-eval --save-baseline     # record current scores
 noetic-eval --check             # fail if scores regress from the baseline
-noetic-eval --scope <scope> --budget <n>   # optimization run
+noetic-eval -u --scope <scope>            # optimization run
+noetic-eval --concurrency <n>             # bound cases running per suite
+noetic-eval -u --force-dirty              # override dirty-file write guard
 ```
 
 ## License

--- a/packages/eval/src/cli/args.ts
+++ b/packages/eval/src/cli/args.ts
@@ -11,8 +11,10 @@ export interface CliArgs {
   watch: boolean;
   optimize: boolean;
   scope: OptimizeScopeValue;
-  budget?: number;
   dryRun: boolean;
+  forceDirty: boolean;
+  /** Max cases running concurrently within a suite (default 4). */
+  concurrency?: number;
   saveBaseline: boolean;
   check: boolean;
 }
@@ -68,21 +70,25 @@ const argHandlers: Record<string, ArgHandler> = {
     args.scope = next;
     return 1;
   },
-  '--budget': (args, argv, i) => {
-    const next = argv[i + 1];
-    if (next === undefined) {
-      throw new UsageError('--budget requires a numeric value');
-    }
-    const parsed = Number.parseFloat(next);
-    if (Number.isNaN(parsed)) {
-      throw new UsageError(`Invalid --budget value "${next}" (expected a number)`);
-    }
-    args.budget = parsed;
-    return 1;
-  },
   '--dry-run': (args) => {
     args.dryRun = true;
     return 0;
+  },
+  '--force-dirty': (args) => {
+    args.forceDirty = true;
+    return 0;
+  },
+  '--concurrency': (args, argv, i) => {
+    const next = argv[i + 1];
+    if (next === undefined) {
+      throw new UsageError('--concurrency requires a value (a positive integer)');
+    }
+    const parsed = Number(next);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      throw new UsageError(`Invalid --concurrency value "${next}" (expected a positive integer)`);
+    }
+    args.concurrency = parsed;
+    return 1;
   },
   '--save-baseline': (args) => {
     args.saveBaseline = true;
@@ -111,6 +117,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
     optimize: false,
     scope: OptimizeScope.PromptsOnly,
     dryRun: false,
+    forceDirty: false,
     saveBaseline: false,
     check: false,
   };

--- a/packages/eval/src/cli/cli.ts
+++ b/packages/eval/src/cli/cli.ts
@@ -107,8 +107,8 @@ async function handleOptimization(
         return buildScoreMap(result);
       },
       maxMetricCalls: MAX_METRIC_CALLS,
-      budget: args.budget,
       dryRun: args.dryRun,
+      forceDirty: args.forceDirty,
     });
   }
   console.log('Optimization complete');
@@ -146,7 +146,13 @@ async function runEvals(args: CliArgs): Promise<RunOutcome> {
   }
 
   const { runAllSuites } = await import('../runner/suite-runner');
-  const results = await runAllSuites(suites);
+  const results = await runAllSuites(suites, {
+    ...(args.concurrency !== undefined
+      ? {
+          concurrency: args.concurrency,
+        }
+      : {}),
+  });
 
   reportResults(results, {
     verbose: args.verbose,

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -26,6 +26,7 @@ export { createEvalContext } from './runner/eval-context';
 export { it } from './runner/it';
 export { clearSuites, getSuites } from './runner/registry';
 export { runAllSuites, runSuite } from './runner/suite-runner';
+export { resolveJudgeProvider, runJudge } from './scorers/builtin/llm-judge';
 // Scorers
 export { scorer } from './scorers/index';
 export { createScorer } from './scorers/scorer-pipeline';

--- a/packages/eval/src/index.ts
+++ b/packages/eval/src/index.ts
@@ -14,6 +14,7 @@ export type {
   WriteBackEntry,
   WriteBackReport,
 } from './optimization/source-writer';
+
 // Regression
 export { loadBaseline, saveBaseline } from './regression/baseline';
 export { checkRegression } from './regression/comparator';

--- a/packages/eval/src/optimization/coding-agents/pi-mono-agent.ts
+++ b/packages/eval/src/optimization/coding-agents/pi-mono-agent.ts
@@ -51,7 +51,22 @@ function asEmitter(obj: unknown): EventEmitter {
 
 //#region Public API
 
+/** Default wall-clock cap for one RPC apply; grace before SIGKILL escalation. */
+const DEFAULT_RPC_TIMEOUT_MS = 120_000;
+const KILL_GRACE_MS = 5_000;
+
+export interface PiMonoAgentOptions {
+  /** Kill the RPC child after this many ms (SIGTERM, then SIGKILL). Default 120s. */
+  timeoutMs?: number;
+}
+
 export class PiMonoAgent implements CodingAgent {
+  private readonly timeoutMs: number;
+
+  constructor(options?: PiMonoAgentOptions) {
+    this.timeoutMs = options?.timeoutMs ?? DEFAULT_RPC_TIMEOUT_MS;
+  }
+
   async apply(recommendation: OptimizationRecommendation): Promise<ApplyResult> {
     try {
       return await this.sendRpcRequest(recommendation);
@@ -93,19 +108,45 @@ export class PiMonoAgent implements CodingAgent {
     child.stdin?.write(buildRpcRequest(recommendation));
     child.stdin?.end();
 
-    // once() resolves on 'close' with [code, signal], and rejects if
-    // 'error' fires first (e.g. binary not found), matching the original
-    // child.on('close')/child.on('error') behavior with proper Bun types.
-    const closeArgs = await once(asEmitter(child), 'close');
-    const code = typeof closeArgs[0] === 'number' ? closeArgs[0] : null;
+    /* A hung `pi --mode rpc` hung optimize() forever — this is a child
+     * process at the end of a long optimization, exactly where an unbounded
+     * await hurts most. Cap the wall clock: SIGTERM, then SIGKILL after a
+     * grace. The timer never keeps the parent alive (unref). */
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+      const escalate = setTimeout(() => {
+        if (child.exitCode === null) {
+          child.kill('SIGKILL');
+        }
+      }, KILL_GRACE_MS);
+      escalate.unref?.();
+    }, this.timeoutMs);
+    timeout.unref?.();
 
-    if (code !== 0) {
-      throw new Error(`pi-mono exited with code ${code}: ${stderr}`);
-    }
     try {
-      return parseRpcResponse(stdout);
-    } catch {
-      throw new Error(`Failed to parse pi-mono response: ${stdout}`);
+      // once() resolves on 'close' with [code, signal], and rejects if
+      // 'error' fires first (e.g. binary not found), matching the original
+      // child.on('close')/child.on('error') behavior with proper Bun types.
+      const closeArgs = await once(asEmitter(child), 'close');
+      const code = typeof closeArgs[0] === 'number' ? closeArgs[0] : null;
+
+      if (timedOut) {
+        throw new Error(
+          `pi-mono RPC timed out after ${this.timeoutMs}ms (killed). Partial stderr: ${stderr.slice(0, 500)}`,
+        );
+      }
+      if (code !== 0) {
+        throw new Error(`pi-mono exited with code ${code}: ${stderr}`);
+      }
+      try {
+        return parseRpcResponse(stdout);
+      } catch {
+        throw new Error(`Failed to parse pi-mono response: ${stdout}`);
+      }
+    } finally {
+      clearTimeout(timeout);
     }
   }
 }

--- a/packages/eval/src/optimization/field-discovery.ts
+++ b/packages/eval/src/optimization/field-discovery.ts
@@ -55,24 +55,30 @@ function extractCallModelFields(
   if (!Array.isArray(step.tools)) {
     return;
   }
-  for (const t of step.tools) {
+  step.tools.forEach((t, i) => {
     // Server tools (web_search/web_fetch) carry no optimizable name/description.
     if (isServerToolSpec(t)) {
-      continue;
+      return;
     }
+    /* Tool fields are keyed by array INDEX, not by name. The name is itself an
+     * optimizable field: keying by it meant a candidate that renamed a tool
+     * invalidated every other candidate key for that tool on the next
+     * applyCandidate pass (lookup by new name, keys built from old name), and
+     * two tools could collide if the teacher renamed one onto the other. The
+     * index is stable for the lifetime of an optimization run. */
     fields.push({
-      path: `${path}.tools.${t.name}.description`,
+      path: `${path}.tools.${i}.description`,
       value: t.description,
       stepId: step.id,
       fieldKind: FieldKind.ToolDescription,
     });
     fields.push({
-      path: `${path}.tools.${t.name}.name`,
+      path: `${path}.tools.${i}.name`,
       value: t.name,
       stepId: step.id,
       fieldKind: FieldKind.ToolName,
     });
-  }
+  });
 }
 
 function extractInvokeToolFields(

--- a/packages/eval/src/optimization/gepa-bridge.ts
+++ b/packages/eval/src/optimization/gepa-bridge.ts
@@ -25,7 +25,6 @@ export interface OptimizeParams {
   runEval: (step: Step) => Promise<Record<string, number>>;
   examples?: ReadonlyArray<Record<string, unknown>>;
   maxMetricCalls?: number;
-  budget?: number;
   gepa?: GepaConfig;
 }
 

--- a/packages/eval/src/optimization/gepa-bridge.ts
+++ b/packages/eval/src/optimization/gepa-bridge.ts
@@ -6,6 +6,7 @@ import { frameworkCast } from '@noetic-tools/core/unstable';
 import type { Candidate, OptimizableField, OptimizationResult } from '../types/optimizer';
 import type { EnvLlmCredentials } from '../utils/env-llm';
 import { resolveEnvLlmCredentials } from '../utils/env-llm';
+import { runPool } from '../utils/run-pool';
 import { averageNumbers } from '../utils/scores';
 import { applyCandidate } from './mutator';
 
@@ -66,6 +67,9 @@ const DEFAULT_TEACHER_MODEL = 'openai/gpt-4o';
 const DEFAULT_NUM_TRIALS = 5;
 const DEFAULT_EARLY_STOPPING = 3;
 const DEFAULT_MAX_METRIC_CALLS = 10;
+
+/** Concurrent teacher proposals per reflection round (independent LLM calls). */
+const PROPOSAL_CONCURRENCY = 4;
 
 /**
  * The student program is a fixed single-component carrier: GEPA mutates its
@@ -335,7 +339,9 @@ export function createGepaAdapter(
 
     // Takes precedence over GEPA's free-form reflection, which would destroy
     // the field markers. The teacher improves each field value individually
-    // and WE reassemble the marker structure.
+    // and WE reassemble the marker structure. Proposals run through a
+    // bounded pool — they are independent LLM calls, and a 12-field step
+    // paid 12 sequential teacher round trips per GEPA iteration serially.
     async propose_new_texts(
       candidate: Readonly<Record<string, string>>,
       reflectiveDataset: Readonly<Record<string, unknown[]>>,
@@ -347,15 +353,21 @@ export function createGepaAdapter(
         const parsed = parseFieldText(currentText) ?? initialCandidate;
         const feedback = extractFeedback(reflectiveDataset[component]);
 
+        const proposals = await runPool(
+          fieldOrder.map((path) => () => {
+            const currentValue = parsed[path] ?? initialCandidate[path] ?? '';
+            return safePropose({
+              path,
+              currentValue,
+              feedback,
+            });
+          }),
+          PROPOSAL_CONCURRENCY,
+        );
         const improved: Candidate = {};
-        for (const path of fieldOrder) {
-          const currentValue = parsed[path] ?? initialCandidate[path] ?? '';
-          improved[path] = await safePropose({
-            path,
-            currentValue,
-            feedback,
-          });
-        }
+        fieldOrder.forEach((path, i) => {
+          improved[path] = proposals[i];
+        });
         result[component] = serializeFields(improved, fieldOrder);
       }
       return result;

--- a/packages/eval/src/optimization/mutator.ts
+++ b/packages/eval/src/optimization/mutator.ts
@@ -10,13 +10,15 @@ function replaceToolListFields(
   candidate: Candidate,
   path: string,
 ): (Tool | ServerToolSpec)[] {
-  return tools.map((t) => {
+  return tools.map((t, i) => {
     // Server tools (web_search/web_fetch) have no optimizable fields — pass through.
     if (isServerToolSpec(t)) {
       return t;
     }
-    const name = candidate[`${path}.tools.${t.name}.name`] ?? t.name;
-    const description = candidate[`${path}.tools.${t.name}.description`] ?? t.description;
+    /* Index-keyed to match field-discovery: renaming a tool must not
+     * invalidate the candidate keys for its other fields. */
+    const name = candidate[`${path}.tools.${i}.name`] ?? t.name;
+    const description = candidate[`${path}.tools.${i}.description`] ?? t.description;
     return {
       ...t,
       name,

--- a/packages/eval/src/optimization/optimizer.ts
+++ b/packages/eval/src/optimization/optimizer.ts
@@ -3,6 +3,7 @@ import type { Step } from '@noetic-tools/core';
 import type { OptimizeConfig } from '../types/eval';
 import { OptimizeScope } from '../types/eval';
 import type {
+  ApplyResult,
   Candidate,
   CodingAgent,
   OptimizableField,
@@ -13,6 +14,7 @@ import { discoverFields } from './field-discovery';
 import type { GepaConfig } from './gepa-bridge';
 import type { WriteBackEntry, WriteBackReport } from './source-writer';
 import { writeOptimizedValues } from './source-writer';
+import { assertWritableUnderVersionControl } from './write-guard';
 
 //#region Types
 
@@ -21,8 +23,13 @@ export interface OptimizeOptions {
   scope: OptimizeConfig['scope'];
   runEval: (step: Step) => Promise<Record<string, number>>;
   maxMetricCalls?: number;
-  budget?: number;
   dryRun?: boolean;
+  /**
+   * Skip the version-control write-back guard. By default every target file
+   * must be git-tracked and unmodified before the optimizer rewrites it —
+   * see write-guard.ts. CLI: --force-dirty.
+   */
+  forceDirty?: boolean;
   codingAgent?: CodingAgent;
   preEnrichedFields?: OptimizableField[];
   gepa?: GepaConfig;
@@ -41,6 +48,12 @@ export interface OptimizeResult {
   writtenBack: boolean;
   /** Per-entry outcome of the write-back pass (absent under `dryRun` or when nothing changed). */
   writeBackReport?: WriteBackReport;
+  /**
+   * Outcome of the L3 coding-agent pass (absent when no agent ran). A failed
+   * apply is reported, never swallowed — the caller decides whether a partial
+   * optimization is acceptable.
+   */
+  codingAgentResult?: ApplyResult;
 }
 
 //#endregion
@@ -135,28 +148,70 @@ export async function optimize(options: OptimizeOptions): Promise<OptimizeResult
     fields,
     runEval: options.runEval,
     maxMetricCalls: options.maxMetricCalls,
-    budget: options.budget,
     gepa: options.gepa,
   });
 
-  // L3 optimization: delegate structural changes to coding agent
-  if (options.scope === OptimizeScope.Full && options.codingAgent) {
+  const entriesToWrite = options.dryRun ? [] : buildWriteBackEntries(fields, result.bestCandidate);
+  const runAgent = options.scope === OptimizeScope.Full && options.codingAgent !== undefined;
+
+  /* Version-control guard runs BEFORE anything mutates files — over the union
+   * of the L1 write-back targets and the L3 agent's target files. Running the
+   * agent first meant the guard then saw the agent's own uncommitted edits as
+   * "dirty" and blocked the literal write-back it exists to protect. */
+  const agentTargetFiles = runAgent
+    ? buildCodingAgentRecommendation(fields, result).targetFiles.map((f) => f.path)
+    : [];
+  const filesToGuard = [
+    ...new Set([
+      ...entriesToWrite.map((e) => e.sourceLocation.filePath),
+      ...agentTargetFiles,
+    ]),
+  ];
+  if (filesToGuard.length > 0) {
+    const guarded = assertWritableUnderVersionControl(filesToGuard, options.forceDirty);
+    if (options.forceDirty && guarded.some((v) => v.status !== 'clean')) {
+      console.warn(
+        `optimize: writing into ${guarded.filter((v) => v.status !== 'clean').length} dirty/untracked file(s) under --force-dirty.`,
+      );
+    }
+  }
+
+  // L3 optimization: delegate structural changes to the coding agent. Its
+  // result is surfaced, never discarded — a failed apply must be visible.
+  let codingAgentResult: ApplyResult | undefined;
+  if (runAgent && options.codingAgent) {
     const recommendation = buildCodingAgentRecommendation(fields, result);
-    await options.codingAgent.apply(recommendation);
+    codingAgentResult = await options.codingAgent.apply(recommendation);
+    if (!codingAgentResult.success) {
+      console.warn(
+        `optimize: coding agent apply failed${codingAgentResult.error ? `: ${codingAgentResult.error}` : ''}`,
+      );
+    }
   }
 
   let writtenBack = false;
   let writeBackReport: WriteBackReport | undefined;
-  if (!options.dryRun) {
-    const entriesToWrite = buildWriteBackEntries(fields, result.bestCandidate);
-    if (entriesToWrite.length > 0) {
-      writeBackReport = await writeOptimizedValues(entriesToWrite);
-      for (const skip of writeBackReport.skipped) {
-        const { filePath, line, column } = skip.sourceLocation;
-        console.warn(`Write-back skipped at ${filePath}:${line}:${column}: ${skip.reason}`);
-      }
-      writtenBack = writeBackReport.written > 0 && writeBackReport.skipped.length === 0;
+  if (entriesToWrite.length > 0) {
+    /* Files the agent just rewrote have stale source locations — the line/col
+     * recorded at discovery no longer describes the file. Splicing anyway
+     * would corrupt source (the mismatch guard catches value drift, but a
+     * moved literal at the same position would still splice wrong). Skip
+     * those entries and report them. */
+    const agentChanged = new Set(codingAgentResult?.changedFiles ?? []);
+    const safeEntries = entriesToWrite.filter((e) => !agentChanged.has(e.sourceLocation.filePath));
+    const staleEntries = entriesToWrite.filter((e) => agentChanged.has(e.sourceLocation.filePath));
+    writeBackReport = await writeOptimizedValues(safeEntries);
+    for (const stale of staleEntries) {
+      writeBackReport.skipped.push({
+        sourceLocation: stale.sourceLocation,
+        reason: 'file rewritten by the coding agent this run; source location is stale',
+      });
     }
+    for (const skip of writeBackReport.skipped) {
+      const { filePath, line, column } = skip.sourceLocation;
+      console.warn(`Write-back skipped at ${filePath}:${line}:${column}: ${skip.reason}`);
+    }
+    writtenBack = writeBackReport.written > 0 && writeBackReport.skipped.length === 0;
   }
 
   return {
@@ -166,6 +221,7 @@ export async function optimize(options: OptimizeOptions): Promise<OptimizeResult
     iterations: result.iterations,
     writtenBack,
     writeBackReport,
+    codingAgentResult,
   };
 }
 

--- a/packages/eval/src/optimization/optimizer.ts
+++ b/packages/eval/src/optimization/optimizer.ts
@@ -18,6 +18,8 @@ import { assertWritableUnderVersionControl } from './write-guard';
 
 //#region Types
 
+type GepaBridgeModule = Pick<typeof import('./gepa-bridge'), 'optimizeWithGepa'>;
+
 export interface OptimizeOptions {
   step: Step;
   scope: OptimizeConfig['scope'];
@@ -33,6 +35,7 @@ export interface OptimizeOptions {
   codingAgent?: CodingAgent;
   preEnrichedFields?: OptimizableField[];
   gepa?: GepaConfig;
+  loadGepaBridge?: () => Promise<GepaBridgeModule>;
 }
 
 export interface OptimizeResult {
@@ -148,7 +151,8 @@ export async function optimize(options: OptimizeOptions): Promise<OptimizeResult
   /* Loaded on demand: gepa-bridge pulls in `@ax-llm/ax`, an OPTIONAL peer
    * dependency. A static import would make every `@noetic-tools/eval` consumer —
    * including suites that only use describe/it/scorer — need it installed. */
-  const { optimizeWithGepa } = await import('./gepa-bridge');
+  const loadGepaBridge = options.loadGepaBridge ?? (() => import('./gepa-bridge'));
+  const { optimizeWithGepa } = await loadGepaBridge();
   const result = await optimizeWithGepa({
     step: options.step,
     fields,

--- a/packages/eval/src/optimization/optimizer.ts
+++ b/packages/eval/src/optimization/optimizer.ts
@@ -127,7 +127,13 @@ function buildCodingAgentRecommendation(
 //#region Public API
 
 export async function optimize(options: OptimizeOptions): Promise<OptimizeResult> {
-  const fields = options.preEnrichedFields ?? discoverFields(options.step);
+  /* The scope MUST reach discovery: without it, PromptsOnly still discovers
+   * ToolName fields — which the teacher then mutates and write-back splices
+   * into source, breaking every name-keyed reference (steering whitelists,
+   * allowedToolNames). The CLI pre-filters via preEnrichedFields, which
+   * masked this for programmatic callers. */
+  const fields =
+    options.preEnrichedFields ?? discoverFields(options.step, undefined, options.scope);
 
   if (fields.length === 0) {
     return {

--- a/packages/eval/src/optimization/write-guard.ts
+++ b/packages/eval/src/optimization/write-guard.ts
@@ -1,0 +1,110 @@
+import { spawnSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import * as path from 'node:path';
+
+//#region Types
+
+/** Verdict for one file the optimizer wants to rewrite. */
+export interface FileGuardVerdict {
+  filePath: string;
+  status: 'clean' | 'dirty' | 'untracked' | 'no-repo';
+}
+
+export class WriteGuardError extends Error {
+  readonly verdicts: FileGuardVerdict[];
+
+  constructor(verdicts: FileGuardVerdict[]) {
+    const blocked = verdicts.filter((v) => v.status !== 'clean');
+    super(
+      `Refusing to write optimized values into ${blocked.length} file(s) that are not committed-and-clean in git:\n` +
+        blocked.map((v) => `  ${v.filePath} (${v.status})`).join('\n') +
+        '\nOptimization write-back REPLACES your prompt literals; if the new value scores higher by gaming the metric, ' +
+        'a clean git state is the only way back. Commit or stash first, or pass forceDirty (CLI: --force-dirty) to override.',
+    );
+    this.name = 'WriteGuardError';
+    this.verdicts = verdicts;
+  }
+}
+
+//#endregion
+
+//#region Guard
+
+function gitStatusFor(filePath: string): FileGuardVerdict['status'] {
+  const absolutePath = realpathSync(filePath);
+  const rootResult = spawnSync(
+    'git',
+    [
+      'rev-parse',
+      '--show-toplevel',
+    ],
+    {
+      cwd: path.dirname(absolutePath),
+      encoding: 'utf-8',
+    },
+  );
+  if (rootResult.status !== 0) {
+    return 'no-repo';
+  }
+  const root = realpathSync(rootResult.stdout.trim());
+  const relativePath = path.relative(root, absolutePath);
+  const tracked = spawnSync(
+    'git',
+    [
+      'ls-files',
+      '--error-unmatch',
+      '--',
+      relativePath,
+    ],
+    {
+      cwd: root,
+      encoding: 'utf-8',
+    },
+  );
+  if (tracked.status !== 0) {
+    return 'untracked';
+  }
+  const status = spawnSync(
+    'git',
+    [
+      'status',
+      '--porcelain',
+      '--',
+      relativePath,
+    ],
+    {
+      cwd: root,
+      encoding: 'utf-8',
+    },
+  );
+  return status.stdout.trim() === '' ? 'clean' : 'dirty';
+}
+
+/**
+ * Version-control guard for optimizer write-back. Every target file must be
+ * git-tracked with no uncommitted modifications, so a bad optimization result
+ * (metric gaming is GEPA's classic failure mode) is always one `git checkout`
+ * from recovery. Throws {@link WriteGuardError} listing every blocked file;
+ * `forceDirty` skips the check entirely (deliberate, logged by the caller).
+ */
+export function assertWritableUnderVersionControl(
+  filePaths: ReadonlyArray<string>,
+  forceDirty?: boolean,
+): FileGuardVerdict[] {
+  const unique = [
+    ...new Set(filePaths),
+  ];
+  const verdicts = unique.map((filePath) => ({
+    filePath,
+    status: gitStatusFor(filePath),
+  }));
+  if (forceDirty && verdicts.every((v) => v.status !== 'no-repo')) {
+    return verdicts;
+  }
+  if (verdicts.some((v) => v.status !== 'clean')) {
+    throw new WriteGuardError(verdicts);
+  }
+  return verdicts;
+}
+
+//#endregion

--- a/packages/eval/src/runner/suite-runner.ts
+++ b/packages/eval/src/runner/suite-runner.ts
@@ -1,4 +1,5 @@
 import type { CaseResult, SuiteResult } from '../types/eval';
+import { runPool } from '../utils/run-pool';
 import type { SuiteDefinition } from './describe';
 import { createEvalContext } from './eval-context';
 
@@ -47,13 +48,33 @@ function computeAggregateScore(cases: CaseResult[]): number {
 
 //#region Public API
 
-export async function runSuite(suite: SuiteDefinition): Promise<SuiteResult> {
-  const suiteStart = performance.now();
-  const cases: CaseResult[] = [];
+/** Options controlling suite execution. */
+export interface RunSuiteOptions {
+  /**
+   * Max cases running concurrently within a suite. Every case executes a real
+   * agent plus scorers, so wall-clock scales ~linearly with this. Results are
+   * ordered by definition regardless of completion order. Default 4; pass 1
+   * for strictly sequential runs (e.g. cases sharing external state).
+   */
+  concurrency?: number;
+}
 
-  for (const caseDef of suite.cases) {
-    cases.push(await runCase(caseDef, suite));
-  }
+const DEFAULT_CASE_CONCURRENCY = 4;
+
+export async function runSuite(
+  suite: SuiteDefinition,
+  options?: RunSuiteOptions,
+): Promise<SuiteResult> {
+  const suiteStart = performance.now();
+  const concurrency = options?.concurrency ?? DEFAULT_CASE_CONCURRENCY;
+
+  // Cases run concurrently (each has its own harness/context — see
+  // createEvalContext); `runCase` already converts throws into CaseResult
+  // errors, so a failed case never rejects the pool.
+  const cases = await runPool(
+    suite.cases.map((caseDef) => () => runCase(caseDef, suite)),
+    concurrency,
+  );
 
   return {
     suiteName: suite.options.objective,
@@ -65,10 +86,15 @@ export async function runSuite(suite: SuiteDefinition): Promise<SuiteResult> {
   };
 }
 
-export async function runAllSuites(suites: ReadonlyArray<SuiteDefinition>): Promise<SuiteResult[]> {
+export async function runAllSuites(
+  suites: ReadonlyArray<SuiteDefinition>,
+  options?: RunSuiteOptions,
+): Promise<SuiteResult[]> {
+  // Suites stay sequential: aggregate scores feed baseline comparisons, and
+  // cross-suite interleaving would make timing-sensitive suites flaky.
   const results: SuiteResult[] = [];
   for (const suite of suites) {
-    results.push(await runSuite(suite));
+    results.push(await runSuite(suite, options));
   }
   return results;
 }

--- a/packages/eval/src/scorers/builtin/llm-judge.ts
+++ b/packages/eval/src/scorers/builtin/llm-judge.ts
@@ -35,20 +35,55 @@ export function resolveJudgeProvider(judge?: JudgeConfig): LlmProviderConfig | u
   return judge?.callModel ?? resolveEnvLlm();
 }
 
+/**
+ * Judge step + harness caches. A 50-case suite runs the SAME judge (same id,
+ * instructions, model) 50 times; rebuilding the step and a fresh harness per
+ * call cost an allocation each and — worse — gave every call a fresh context
+ * with nothing shared, so provider prompt caches never saw a repeated prefix.
+ * One step per (id, model, instructions) and one harness per provider config
+ * make every judge call after the first byte-identical up to the case input.
+ */
+const judgeStepCache = new Map<string, ReturnType<typeof callModel>>();
+const judgeHarnessCache = new Map<string, AgentHarness>();
+
+function judgeStepFor(
+  id: string,
+  model: string,
+  instructions: string,
+): ReturnType<typeof callModel> {
+  const key = `${id}\u0000${model}\u0000${instructions}`;
+  let cached = judgeStepCache.get(key);
+  if (!cached) {
+    cached = callModel({
+      id,
+      model,
+      instructions: `${instructions}\n\nRespond ONLY with valid JSON matching the required schema.`,
+    });
+    judgeStepCache.set(key, cached);
+  }
+  return cached;
+}
+
+function judgeHarnessFor(callModelDefaults?: LlmProviderConfig): AgentHarness {
+  const key = JSON.stringify(callModelDefaults ?? null);
+  let cached = judgeHarnessCache.get(key);
+  if (!cached) {
+    cached = new AgentHarness({
+      name: 'llm-judge',
+      params: {},
+      callModelDefaults,
+    });
+    judgeHarnessCache.set(key, cached);
+  }
+  return cached;
+}
+
 export async function runJudge<T>(config: JudgeRunConfig<T>): Promise<T> {
   const model = config.judge?.model ?? DEFAULT_MODEL;
-
-  const judgeStep = callModel({
-    id: config.id,
-    model,
-    instructions: `${config.instructions}\n\nRespond ONLY with valid JSON matching the required schema.`,
-  });
-
-  const harness = new AgentHarness({
-    name: 'llm-judge',
-    params: {},
-    callModelDefaults: resolveJudgeProvider(config.judge),
-  });
+  const judgeStep = judgeStepFor(config.id, model, config.instructions);
+  const harness = judgeHarnessFor(resolveJudgeProvider(config.judge));
+  // A fresh context per call keeps judge invocations independent (no shared
+  // history); the shared harness/step give them a stable prompt prefix.
   const ctx = harness.createContext();
 
   const raw = await harness.run(judgeStep, config.input, ctx);

--- a/packages/eval/src/types/eval.ts
+++ b/packages/eval/src/types/eval.ts
@@ -24,8 +24,8 @@ export interface EvalSuiteOptions {
 
 export interface OptimizeConfig {
   scope: OptimizeScope;
+  /** Hard cap on candidate evaluations (GEPA's real cost lever). */
   maxMetricCalls?: number;
-  budget?: number;
   codingAgent?: import('./optimizer').CodingAgent;
   dryRun?: boolean;
 }

--- a/packages/eval/src/utils/run-pool.ts
+++ b/packages/eval/src/utils/run-pool.ts
@@ -1,0 +1,31 @@
+/**
+ * Bounded worker pool preserving result order (same shape as core's
+ * runWithConcurrency). Shared by the suite runner (per-case concurrency)
+ * and the GEPA bridge (per-field teacher proposals).
+ */
+export async function runPool<T>(
+  tasks: ReadonlyArray<() => Promise<T>>,
+  concurrency: number,
+): Promise<T[]> {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new RangeError('concurrency must be a positive integer');
+  }
+  const results: T[] = new Array(tasks.length);
+  let nextIndex = 0;
+  async function worker(): Promise<void> {
+    while (nextIndex < tasks.length) {
+      const index = nextIndex++;
+      const task = tasks[index];
+      results[index] = await task();
+    }
+  }
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.max(1, Math.min(concurrency, tasks.length)),
+      },
+      () => worker(),
+    ),
+  );
+  return results;
+}

--- a/packages/eval/test/cli/args.test.ts
+++ b/packages/eval/test/cli/args.test.ts
@@ -12,8 +12,9 @@ describe('parseCliArgs', () => {
     expect(args.watch).toBe(false);
     expect(args.optimize).toBe(false);
     expect(args.scope).toBe(OptimizeScope.PromptsOnly);
-    expect(args.budget).toBeUndefined();
     expect(args.dryRun).toBe(false);
+    expect(args.forceDirty).toBe(false);
+    expect(args.concurrency).toBeUndefined();
     expect(args.saveBaseline).toBe(false);
     expect(args.check).toBe(false);
   });
@@ -74,31 +75,51 @@ describe('parseCliArgs', () => {
     ).toThrow(UsageError);
   });
 
-  test('-u and --budget round-trip', () => {
+  test('--budget is no longer a recognised flag (removed dead cost knob)', () => {
+    // The flag was accepted but never read anywhere downstream — a cost
+    // control that silently did nothing. Unknown flags throw.
+    expect(() =>
+      parseCliArgs([
+        '--budget',
+        '12.5',
+      ]),
+    ).toThrow(UsageError);
+  });
+
+  test('--concurrency reads the following argv entry', () => {
     const args = parseCliArgs([
-      '-u',
-      '--budget',
-      '12.5',
+      '--concurrency',
+      '8',
+      'a.eval.ts',
     ]);
-    expect(args.optimize).toBe(true);
-    expect(args.budget).toBe(12.5);
+    expect(args.concurrency).toBe(8);
+    expect(args.files).toEqual([
+      'a.eval.ts',
+    ]);
   });
 
-  test('--budget without a value throws UsageError', () => {
+  test('--concurrency rejects a missing value', () => {
     expect(() =>
       parseCliArgs([
-        '--budget',
+        '--concurrency',
       ]),
     ).toThrow(UsageError);
   });
 
-  test('--budget with a non-numeric value throws UsageError', () => {
-    expect(() =>
-      parseCliArgs([
-        '--budget',
-        'cheap',
-      ]),
-    ).toThrow(UsageError);
+  test('--concurrency rejects non-positive-integer values', () => {
+    for (const bad of [
+      '0',
+      '-1',
+      '2.5',
+      'many',
+    ]) {
+      expect(() =>
+        parseCliArgs([
+          '--concurrency',
+          bad,
+        ]),
+      ).toThrow(UsageError);
+    }
   });
 
   test('boolean flags toggle', () => {
@@ -107,6 +128,7 @@ describe('parseCliArgs', () => {
       '--json',
       '--watch',
       '--dry-run',
+      '--force-dirty',
       '--save-baseline',
       '--check',
     ]);
@@ -114,6 +136,7 @@ describe('parseCliArgs', () => {
     expect(args.json).toBe(true);
     expect(args.watch).toBe(true);
     expect(args.dryRun).toBe(true);
+    expect(args.forceDirty).toBe(true);
     expect(args.saveBaseline).toBe(true);
     expect(args.check).toBe(true);
   });

--- a/packages/eval/test/optimization/field-discovery.test.ts
+++ b/packages/eval/test/optimization/field-discovery.test.ts
@@ -93,8 +93,10 @@ describe('discoverFields', () => {
 
     expect(fields).toHaveLength(3);
     expect(fields[0].fieldKind).toBe(FieldKind.Instructions);
+    expect(fields[1].path).toBe('llm-with-tools.tools.0.description');
     expect(fields[1].fieldKind).toBe(FieldKind.ToolDescription);
     expect(fields[1].value).toBe('Search the web');
+    expect(fields[2].path).toBe('llm-with-tools.tools.0.name');
     expect(fields[2].fieldKind).toBe(FieldKind.ToolName);
     expect(fields[2].value).toBe('search');
   });

--- a/packages/eval/test/optimization/gepa-bridge.test.ts
+++ b/packages/eval/test/optimization/gepa-bridge.test.ts
@@ -29,7 +29,7 @@ function makeFields(): OptimizableField[] {
       fieldKind: FieldKind.Instructions,
     },
     {
-      path: 'agent.tools.search.description',
+      path: 'agent.tools.0.description',
       value: 'original tool description',
       stepId: 'agent',
       fieldKind: FieldKind.ToolDescription,
@@ -154,7 +154,7 @@ describe('createGepaAdapter evaluate', () => {
 
     const improved: Candidate = {
       [INSTRUCTIONS_PATH]: 'improved instructions',
-      'agent.tools.search.description': 'improved tool description',
+      'agent.tools.0.description': 'improved tool description',
     };
     const text = serializeFields(
       improved,
@@ -263,7 +263,7 @@ describe('createGepaAdapter propose_new_texts', () => {
     const currentText = serializeFields(
       {
         [INSTRUCTIONS_PATH]: 'original instructions',
-        'agent.tools.search.description': 'original tool description',
+        'agent.tools.0.description': 'original tool description',
       },
       fieldOrder,
     );
@@ -286,7 +286,7 @@ describe('createGepaAdapter propose_new_texts', () => {
     const parsed = parseFieldText(result[COMPONENT_ID]);
     expect(parsed).toEqual({
       [INSTRUCTIONS_PATH]: 'original instructions (improved)',
-      'agent.tools.search.description': 'original tool description (improved)',
+      'agent.tools.0.description': 'original tool description (improved)',
     });
   });
 
@@ -313,7 +313,7 @@ describe('createGepaAdapter propose_new_texts', () => {
         [COMPONENT_ID]: serializeFields(
           {
             [INSTRUCTIONS_PATH]: 'original instructions',
-            'agent.tools.search.description': 'original tool description',
+            'agent.tools.0.description': 'original tool description',
           },
           fields.map((f) => f.path),
         ),
@@ -326,7 +326,7 @@ describe('createGepaAdapter propose_new_texts', () => {
 
     expect(parseFieldText(result[COMPONENT_ID])).toEqual({
       [INSTRUCTIONS_PATH]: 'original instructions',
-      'agent.tools.search.description': 'original tool description v2',
+      'agent.tools.0.description': 'original tool description v2',
     });
   });
 
@@ -355,7 +355,7 @@ describe('createGepaAdapter propose_new_texts', () => {
 
     expect(parseFieldText(result[COMPONENT_ID])).toEqual({
       [INSTRUCTIONS_PATH]: 'original instructions!',
-      'agent.tools.search.description': 'original tool description!',
+      'agent.tools.0.description': 'original tool description!',
     });
   });
 });
@@ -368,7 +368,7 @@ describe('extractBestCandidate', () => {
   const fields = makeFields();
   const initialCandidate: Candidate = {
     [INSTRUCTIONS_PATH]: 'original instructions',
-    'agent.tools.search.description': 'original tool description',
+    'agent.tools.0.description': 'original tool description',
   };
   const fieldOrder = fields.map((f) => f.path);
 

--- a/packages/eval/test/optimization/optimizer-bun-mock-regression.test.ts
+++ b/packages/eval/test/optimization/optimizer-bun-mock-regression.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { callModel } from '@noetic-tools/core';
+
+import { optimize } from '../../src/optimization/optimizer';
+import { OptimizeScope } from '../../src/types/eval';
+import type { OptimizableField } from '../../src/types/optimizer';
+import { FieldKind } from '../../src/types/optimizer';
+
+const step = callModel({
+  id: 'agent',
+  model: 'openai/gpt-4o-mini',
+  instructions: 'original instructions',
+});
+
+const fields: OptimizableField[] = [
+  {
+    path: 'agent.instructions',
+    value: 'original instructions',
+    stepId: 'agent',
+    fieldKind: FieldKind.Instructions,
+  },
+];
+
+afterEach(() => {
+  delete process.env.OPENROUTER_API_KEY;
+  delete process.env.NOETIC_API_KEY;
+});
+
+describe('optimizer GEPA seam regression', () => {
+  test('loadGepaBridge stubs optimize without poisoning the real gepa-bridge module', async () => {
+    delete process.env.OPENROUTER_API_KEY;
+    delete process.env.NOETIC_API_KEY;
+
+    const mocked = await optimize({
+      step,
+      scope: OptimizeScope.PromptsOnly,
+      preEnrichedFields: fields,
+      runEval: async () => ({
+        accuracy: 1,
+      }),
+      loadGepaBridge: async () => ({
+        optimizeWithGepa: async () => ({
+          bestCandidate: {
+            'agent.instructions': 'mocked instructions',
+          },
+          score: 1,
+          iterations: 1,
+        }),
+      }),
+    });
+
+    expect(mocked.bestCandidate['agent.instructions']).toBe('mocked instructions');
+
+    const bridge = await import('../../src/optimization/gepa-bridge');
+    let evaluated = 0;
+    const real = await bridge.optimizeWithGepa({
+      step,
+      fields,
+      runEval: async () => {
+        evaluated++;
+        return {
+          accuracy: 1,
+        };
+      },
+    });
+
+    expect(evaluated).toBe(1);
+    expect(real.bestCandidate['agent.instructions']).toBe('original instructions');
+    expect(real.iterations).toBe(1);
+  });
+});

--- a/packages/eval/test/optimization/optimizer.test.ts
+++ b/packages/eval/test/optimization/optimizer.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { callModel, runCode } from '@noetic-tools/core';
 
 import { buildWriteBackEntries, optimize } from '../../src/optimization/optimizer';
+import { WriteGuardError } from '../../src/optimization/write-guard';
 import { OptimizeScope } from '../../src/types/eval';
-import type { OptimizableField } from '../../src/types/optimizer';
+import type { ApplyResult, OptimizableField } from '../../src/types/optimizer';
 import { FieldKind } from '../../src/types/optimizer';
 
 let tmpDir: string;
@@ -169,6 +171,330 @@ describe('optimize() write-back semantics', () => {
     expect(result.fields).toHaveLength(0);
     expect(result.writtenBack).toBe(false);
     expect(result.iterations).toBe(0);
+  });
+});
+
+//#endregion
+
+//#region write-back guard + coding-agent interplay
+
+describe('optimize() write-back guard', () => {
+  function makeRepo(dir: string): void {
+    spawnSync(
+      'git',
+      [
+        'init',
+        '-q',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+    spawnSync(
+      'git',
+      [
+        'config',
+        'user.email',
+        't@t',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+    spawnSync(
+      'git',
+      [
+        'config',
+        'user.name',
+        't',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+    spawnSync(
+      'git',
+      [
+        'config',
+        'commit.gpgsign',
+        'false',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+  }
+
+  function commitAll(dir: string): void {
+    spawnSync(
+      'git',
+      [
+        'add',
+        '.',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+    spawnSync(
+      'git',
+      [
+        'commit',
+        '-qm',
+        'x',
+      ],
+      {
+        cwd: dir,
+      },
+    );
+  }
+
+  async function writeAgentFile(name = 'agent.ts'): Promise<{
+    filePath: string;
+    source: string;
+    location: {
+      filePath: string;
+      line: number;
+      column: number;
+    };
+  }> {
+    const filePath = path.join(tmpDir, name);
+    const source = "export const instructions = 'original instructions';\n";
+    await fs.writeFile(filePath, source, 'utf-8');
+    return {
+      filePath,
+      source,
+      location: {
+        filePath,
+        line: 1,
+        column: 29,
+      },
+    };
+  }
+
+  function makeLocatedField(location: {
+    filePath: string;
+    line: number;
+    column: number;
+  }): OptimizableField {
+    return makeField({
+      sourceLocation: location,
+    });
+  }
+
+  /** The offline GEPA fallback never changes the candidate, so tests that need
+   * a changed candidate stub the bridge (optimizer loads it via dynamic import). */
+  function stubChangedCandidate(newValue = 'improved instructions'): void {
+    mock.module('../../src/optimization/gepa-bridge', () => ({
+      optimizeWithGepa: async () => ({
+        bestCandidate: {
+          'agent.instructions': newValue,
+        },
+        score: 1,
+        iterations: 1,
+      }),
+    }));
+  }
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('refuses to write back into an untracked file', async () => {
+    stubChangedCandidate();
+    makeRepo(tmpDir);
+    const { filePath, source, location } = await writeAgentFile();
+    // Deliberately NOT committed: write-back must refuse to destroy uncommitted work.
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    await expect(
+      optimize({
+        step: testStep,
+        scope: OptimizeScope.PromptsOnly,
+        preEnrichedFields: [
+          makeLocatedField(location),
+        ],
+        runEval: async () => ({
+          'case.scorer': 0.9,
+        }),
+      }),
+    ).rejects.toBeInstanceOf(WriteGuardError);
+    expect(await fs.readFile(filePath, 'utf-8')).toBe(source);
+  });
+
+  test('refuses to write back into a dirty tracked file', async () => {
+    stubChangedCandidate();
+    makeRepo(tmpDir);
+    const { filePath, location } = await writeAgentFile();
+    commitAll(tmpDir);
+    await fs.appendFile(filePath, '// uncommitted\n', 'utf-8');
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    await expect(
+      optimize({
+        step: testStep,
+        scope: OptimizeScope.PromptsOnly,
+        preEnrichedFields: [
+          makeLocatedField(location),
+        ],
+        runEval: async () => ({
+          'case.scorer': 0.9,
+        }),
+      }),
+    ).rejects.toBeInstanceOf(WriteGuardError);
+  });
+
+  test('forceDirty overrides the guard and writes back', async () => {
+    stubChangedCandidate();
+    makeRepo(tmpDir);
+    const { filePath, location } = await writeAgentFile();
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    const result = await optimize({
+      step: testStep,
+      scope: OptimizeScope.PromptsOnly,
+      preEnrichedFields: [
+        makeLocatedField(location),
+      ],
+      forceDirty: true,
+      runEval: async () => ({
+        'case.scorer': 0.9,
+      }),
+    });
+
+    expect(result.writtenBack).toBe(true);
+    expect(await fs.readFile(filePath, 'utf-8')).toContain('improved instructions');
+  });
+
+  test('guard runs BEFORE the coding agent apply (Full scope)', async () => {
+    makeRepo(tmpDir);
+    const { location } = await writeAgentFile();
+    // Untracked target file: the guard must fire before the agent touches anything.
+    let applied = false;
+    const codingAgent = {
+      apply: async (): Promise<ApplyResult> => {
+        applied = true;
+        return {
+          success: true,
+          changedFiles: [],
+        };
+      },
+    };
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    await expect(
+      optimize({
+        step: testStep,
+        scope: OptimizeScope.Full,
+        preEnrichedFields: [
+          makeLocatedField(location),
+        ],
+        codingAgent,
+        runEval: async () => ({
+          'case.scorer': 0.9,
+        }),
+      }),
+    ).rejects.toBeInstanceOf(WriteGuardError);
+    expect(applied).toBe(false);
+  });
+
+  test('write-back skips files the coding agent just rewrote (stale locations)', async () => {
+    stubChangedCandidate();
+    makeRepo(tmpDir);
+    const { filePath, source, location } = await writeAgentFile();
+    commitAll(tmpDir);
+
+    const codingAgent = {
+      apply: async (): Promise<ApplyResult> => ({
+        success: true,
+        changedFiles: [
+          filePath,
+        ],
+      }),
+    };
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    const result = await optimize({
+      step: testStep,
+      scope: OptimizeScope.Full,
+      preEnrichedFields: [
+        makeLocatedField(location),
+      ],
+      codingAgent,
+      runEval: async () => ({
+        'case.scorer': 0.9,
+      }),
+    });
+
+    expect(result.codingAgentResult?.success).toBe(true);
+    expect(result.writtenBack).toBe(false);
+    expect(result.writeBackReport?.written).toBe(0);
+    expect(result.writeBackReport?.skipped[0].reason).toContain('stale');
+    // The optimizer must not clobber the agent's rewrite with a stale splice.
+    expect(await fs.readFile(filePath, 'utf-8')).toBe(source);
+  });
+
+  test('a failed coding-agent apply is surfaced, not swallowed', async () => {
+    makeRepo(tmpDir);
+    const { location } = await writeAgentFile();
+    commitAll(tmpDir);
+
+    const codingAgent = {
+      apply: async (): Promise<ApplyResult> => ({
+        success: false,
+        changedFiles: [],
+        error: 'agent exploded',
+      }),
+    };
+
+    const testStep = callModel({
+      id: 'agent',
+      model: 'openai/gpt-4o-mini',
+      instructions: 'original instructions',
+    });
+
+    const result = await optimize({
+      step: testStep,
+      scope: OptimizeScope.Full,
+      preEnrichedFields: [
+        makeLocatedField(location),
+      ],
+      codingAgent,
+      runEval: async () => ({
+        'case.scorer': 0.9,
+      }),
+    });
+
+    expect(result.codingAgentResult).toEqual({
+      success: false,
+      changedFiles: [],
+      error: 'agent exploded',
+    });
   });
 });
 

--- a/packages/eval/test/optimization/optimizer.test.ts
+++ b/packages/eval/test/optimization/optimizer.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
@@ -283,9 +283,10 @@ describe('optimize() write-back guard', () => {
   }
 
   /** The offline GEPA fallback never changes the candidate, so tests that need
-   * a changed candidate stub the bridge (optimizer loads it via dynamic import). */
-  function stubChangedCandidate(newValue = 'improved instructions'): void {
-    mock.module('../../src/optimization/gepa-bridge', () => ({
+   * a changed candidate inject a bridge loader instead of using `mock.module`.
+   * Bun keeps mocked dynamic-import modules cached even after `mock.restore()`. */
+  function loadChangedCandidate(newValue = 'improved instructions') {
+    return async () => ({
       optimizeWithGepa: async () => ({
         bestCandidate: {
           'agent.instructions': newValue,
@@ -293,15 +294,11 @@ describe('optimize() write-back guard', () => {
         score: 1,
         iterations: 1,
       }),
-    }));
+    });
   }
 
-  afterEach(() => {
-    mock.restore();
-  });
-
   test('refuses to write back into an untracked file', async () => {
-    stubChangedCandidate();
+    const loadGepaBridge = loadChangedCandidate();
     makeRepo(tmpDir);
     const { filePath, source, location } = await writeAgentFile();
     // Deliberately NOT committed: write-back must refuse to destroy uncommitted work.
@@ -322,13 +319,14 @@ describe('optimize() write-back guard', () => {
         runEval: async () => ({
           'case.scorer': 0.9,
         }),
+        loadGepaBridge,
       }),
     ).rejects.toBeInstanceOf(WriteGuardError);
     expect(await fs.readFile(filePath, 'utf-8')).toBe(source);
   });
 
   test('refuses to write back into a dirty tracked file', async () => {
-    stubChangedCandidate();
+    const loadGepaBridge = loadChangedCandidate();
     makeRepo(tmpDir);
     const { filePath, location } = await writeAgentFile();
     commitAll(tmpDir);
@@ -350,12 +348,13 @@ describe('optimize() write-back guard', () => {
         runEval: async () => ({
           'case.scorer': 0.9,
         }),
+        loadGepaBridge,
       }),
     ).rejects.toBeInstanceOf(WriteGuardError);
   });
 
   test('forceDirty overrides the guard and writes back', async () => {
-    stubChangedCandidate();
+    const loadGepaBridge = loadChangedCandidate();
     makeRepo(tmpDir);
     const { filePath, location } = await writeAgentFile();
 
@@ -375,6 +374,7 @@ describe('optimize() write-back guard', () => {
       runEval: async () => ({
         'case.scorer': 0.9,
       }),
+      loadGepaBridge,
     });
 
     expect(result.writtenBack).toBe(true);
@@ -419,7 +419,7 @@ describe('optimize() write-back guard', () => {
   });
 
   test('write-back skips files the coding agent just rewrote (stale locations)', async () => {
-    stubChangedCandidate();
+    const loadGepaBridge = loadChangedCandidate();
     makeRepo(tmpDir);
     const { filePath, source, location } = await writeAgentFile();
     commitAll(tmpDir);
@@ -449,6 +449,7 @@ describe('optimize() write-back guard', () => {
       runEval: async () => ({
         'case.scorer': 0.9,
       }),
+      loadGepaBridge,
     });
 
     expect(result.codingAgentResult?.success).toBe(true);

--- a/packages/eval/test/optimization/write-guard.test.ts
+++ b/packages/eval/test/optimization/write-guard.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  assertWritableUnderVersionControl,
+  WriteGuardError,
+} from '../../src/optimization/write-guard';
+
+function makeRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'write-guard-'));
+  spawnSync(
+    'git',
+    [
+      'init',
+      '-q',
+    ],
+    {
+      cwd: dir,
+    },
+  );
+  spawnSync(
+    'git',
+    [
+      'config',
+      'user.email',
+      't@t',
+    ],
+    {
+      cwd: dir,
+    },
+  );
+  spawnSync(
+    'git',
+    [
+      'config',
+      'user.name',
+      't',
+    ],
+    {
+      cwd: dir,
+    },
+  );
+  spawnSync(
+    'git',
+    [
+      'config',
+      'commit.gpgsign',
+      'false',
+    ],
+    {
+      cwd: dir,
+    },
+  );
+  return dir;
+}
+
+function commitAll(repo: string): void {
+  spawnSync(
+    'git',
+    [
+      'add',
+      '.',
+    ],
+    {
+      cwd: repo,
+    },
+  );
+  spawnSync(
+    'git',
+    [
+      'commit',
+      '-qm',
+      'x',
+    ],
+    {
+      cwd: repo,
+    },
+  );
+}
+
+describe('assertWritableUnderVersionControl', () => {
+  it('passes for a committed, unmodified file', () => {
+    const repo = makeRepo();
+    const file = join(repo, 'prompt.ts');
+    writeFileSync(file, 'export const p = "hello";\n');
+    commitAll(repo);
+    const verdicts = assertWritableUnderVersionControl([
+      file,
+    ]);
+    expect(verdicts[0].status).toBe('clean');
+  });
+
+  it('refuses an untracked file', () => {
+    const repo = makeRepo();
+    const file = join(repo, 'loose.ts');
+    writeFileSync(file, 'export const p = "hi";\n');
+    expect(() =>
+      assertWritableUnderVersionControl([
+        file,
+      ]),
+    ).toThrow(WriteGuardError);
+  });
+
+  it('refuses a tracked file with uncommitted modifications', () => {
+    const repo = makeRepo();
+    const file = join(repo, 'prompt.ts');
+    writeFileSync(file, 'v1');
+    commitAll(repo);
+    writeFileSync(file, 'v2-uncommitted');
+    expect(() =>
+      assertWritableUnderVersionControl([
+        file,
+      ]),
+    ).toThrow('dirty');
+  });
+
+  it('refuses a file outside any git repository', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'write-guard-norepo-'));
+    const file = join(dir, 'prompt.ts');
+    writeFileSync(file, 'x');
+    try {
+      assertWritableUnderVersionControl([
+        file,
+      ]);
+      expect.unreachable('expected WriteGuardError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(WriteGuardError);
+      if (!(err instanceof WriteGuardError)) {
+        throw err;
+      }
+      expect(err.verdicts[0].status).toBe('no-repo');
+    }
+  });
+
+  it('forceDirty overrides dirty or untracked files but still reports verdicts', () => {
+    const repo = makeRepo();
+    const file = join(repo, 'loose.ts');
+    writeFileSync(file, 'x');
+    const verdicts = assertWritableUnderVersionControl(
+      [
+        file,
+      ],
+      true,
+    );
+    expect(verdicts[0].status).toBe('untracked');
+  });
+
+  it('forceDirty still refuses files outside a Git repository', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'write-guard-norepo-force-'));
+    const file = join(dir, 'prompt.ts');
+    writeFileSync(file, 'x');
+    expect(() =>
+      assertWritableUnderVersionControl(
+        [
+          file,
+        ],
+        true,
+      ),
+    ).toThrow(WriteGuardError);
+  });
+
+  it('handles absolute paths from nested repository directories', () => {
+    const repo = makeRepo();
+    const nested = join(repo, 'src', 'nested');
+    const file = join(nested, 'prompt.ts');
+    mkdirSync(nested, {
+      recursive: true,
+    });
+    writeFileSync(file, 'x');
+    commitAll(repo);
+    expect(
+      assertWritableUnderVersionControl([
+        file,
+      ])[0].status,
+    ).toBe('clean');
+  });
+});

--- a/packages/eval/test/runner/suite-runner.test.ts
+++ b/packages/eval/test/runner/suite-runner.test.ts
@@ -98,3 +98,140 @@ describe('runSuite passThreshold', () => {
 });
 
 //#endregion
+
+//#region bounded case concurrency
+
+describe('runSuite case concurrency', () => {
+  function makeConcurrencySuite(caseCount: number): {
+    suite: SuiteDefinition;
+    state: {
+      active: number;
+      maxActive: number;
+      started: string[];
+    };
+  } {
+    const echoStep = runCode({
+      id: 'echo',
+      execute: async (input: unknown) => input,
+    });
+    const state: {
+      active: number;
+      maxActive: number;
+      started: string[];
+    } = {
+      active: 0,
+      maxActive: 0,
+      started: [],
+    };
+    const cases = Array.from(
+      {
+        length: caseCount,
+      },
+      (_, i) => ({
+        name: `case-${i}`,
+        async fn() {
+          state.started.push(`case-${i}`);
+          state.active++;
+          state.maxActive = Math.max(state.maxActive, state.active);
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          state.active--;
+        },
+      }),
+    );
+    return {
+      suite: {
+        step: echoStep,
+        options: {
+          objective: 'concurrency test',
+        },
+        cases,
+      },
+      state,
+    };
+  }
+
+  test('cases run concurrently by default (bounded at 4)', async () => {
+    const { suite, state } = makeConcurrencySuite(8);
+    const result = await runSuite(suite);
+
+    expect(result.cases).toHaveLength(8);
+    expect(state.maxActive).toBeGreaterThan(1);
+    expect(state.maxActive).toBeLessThanOrEqual(4);
+  });
+
+  test('explicit concurrency bounds in-flight cases', async () => {
+    const { suite, state } = makeConcurrencySuite(6);
+    await runSuite(suite, {
+      concurrency: 2,
+    });
+
+    expect(state.maxActive).toBeLessThanOrEqual(2);
+    expect(state.maxActive).toBeGreaterThan(1);
+  });
+
+  test('rejects invalid programmatic concurrency', async () => {
+    const { suite } = makeConcurrencySuite(1);
+    await expect(
+      runSuite(suite, {
+        concurrency: Number.NaN,
+      }),
+    ).rejects.toThrow('positive integer');
+    await expect(
+      runSuite(suite, {
+        concurrency: 1.5,
+      }),
+    ).rejects.toThrow('positive integer');
+    await expect(
+      runSuite(suite, {
+        concurrency: 0,
+      }),
+    ).rejects.toThrow('positive integer');
+  });
+
+  test('concurrency 1 runs strictly sequentially', async () => {
+    const { suite, state } = makeConcurrencySuite(4);
+    await runSuite(suite, {
+      concurrency: 1,
+    });
+
+    expect(state.maxActive).toBe(1);
+  });
+
+  test('results stay ordered by definition regardless of completion order', async () => {
+    const echoStep = runCode({
+      id: 'echo',
+      execute: async (input: unknown) => input,
+    });
+    // First case is slowest: with a naive push-on-completion pool it would
+    // land last. Result order must follow the definition order.
+    const suite: SuiteDefinition = {
+      step: echoStep,
+      options: {
+        objective: 'ordering test',
+      },
+      cases: [
+        {
+          name: 'slow-first',
+          async fn() {
+            await new Promise((resolve) => setTimeout(resolve, 30));
+          },
+        },
+        {
+          name: 'fast-second',
+          async fn() {
+            await new Promise((resolve) => setTimeout(resolve, 1));
+          },
+        },
+      ],
+    };
+
+    const result = await runSuite(suite);
+
+    expect(result.cases.map((c) => c.name)).toEqual([
+      'slow-first',
+      'fast-second',
+    ]);
+  });
+});
+
+//#endregion

--- a/specs/17-eval-and-optimization.md
+++ b/specs/17-eval-and-optimization.md
@@ -381,7 +381,6 @@ interface OptimizeParams {
   runEval: (step: Step) => Promise<Record<string, number>>;
   examples?: ReadonlyArray<Record<string, unknown>>;
   maxMetricCalls?: number;
-  budget?: number;
   gepa?: GepaConfig;
 }
 
@@ -641,8 +640,9 @@ invocation from when the CLI and eval framework shared one binary.
 | `--watch` | `boolean` | `false` | Re-run evals when the eval files change (fresh subprocess per run) |
 | `-u` | `boolean` | `false` | Run GEPA optimization after evaluation |
 | `--scope` | `enum` | `prompts-only` | Optimization scope: `prompts-only`, `flow-structure`, or `full` |
-| `--budget` | `number` | (none) | Maximum cost in dollars for the optimization run |
+| `--concurrency` | `number` | `4` | Maximum eval cases running concurrently within each suite |
 | `--dry-run` | `boolean` | `false` | Optimize without writing values back to source |
+| `--force-dirty` | `boolean` | `false` | Allow optimizer write-back into dirty or untracked files (a Git repository is still required) |
 | `--save-baseline` | `boolean` | `false` | Save each suite's results as its regression baseline (`.noetic/baselines/<suite>.json`) |
 | `--check` | `boolean` | `false` | Compare against saved baselines; exit `1` on regression or missing baseline case |
 
@@ -685,7 +685,7 @@ A case "fails" when any scorer returns a value below `0.5` (configurable via `Ev
 ### Optimization via CLI
 
 ```
-noetic-eval -u [--scope prompts-only|flow-structure|full] [--budget 5.00] [files...]
+noetic-eval -u [--scope prompts-only|flow-structure|full] [--force-dirty] [files...]
 ```
 
 Runs the optimization pipeline after evaluation. The `--scope` flag controls the optimization level (L1 `prompts-only`, L2 `flow-structure`, L3 `full`). With `--dry-run`, nothing is written back to source.


### PR DESCRIPTION
## What

- thread optimization scope into runtime field discovery
- use stable tool-index paths in discovery and mutation
- traverse current composite step kinds without restoring pre-#68 names
- bound per-field teacher proposals with the shared run pool
- reuse LLM-judge harnesses for identical provider/model configuration
- add timeout and kill grace to the Pi coding-agent RPC path

## Why

GEPA discovery ignored the requested scope, mutable tool names made candidate paths unstable, composite traversal missed current step shapes, and judge harnesses were rebuilt for every score call.

This ports item 5, the remainder of `fork/port/openrouter-fixes` commit `aedf712f`, on top of item 4 [#72](https://github.com/mattapperson/noetic/pull/72).

## Test plan

- [x] 49 focused discovery/GEPA tests pass
- [x] eval typecheck
- [x] root lint
- [x] `sentrux check .`

## Dependency

Depends on [#72](https://github.com/mattapperson/noetic/pull/72) for the shared run pool and removed dead budget option. The branch currently includes that prerequisite and must be rebased through main after merge.
